### PR TITLE
Add support for CONDSTORE and QRESYNC

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/FetchProfile.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/FetchProfile.java
@@ -25,10 +25,6 @@ public class FetchProfile extends ArrayList<FetchProfile.Item> {
      */
     public enum Item {
         /**
-         * Download the modification sequence of the message (for CONDSTORE-enabled IMAP accounts only).
-         */
-        MODSEQ,
-        /**
          * Download the flags of the message.
          */
         FLAGS,

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/K9MailLib.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/K9MailLib.java
@@ -3,7 +3,6 @@ package com.fsck.k9.mail;
 
 public class K9MailLib {
     private static DebugStatus debugStatus = new DefaultDebugStatus();
-    private static ImapExtensionStatus imapExtensionStatus = new DefaultImapExtensionStatus();
 
     private K9MailLib() {
     }
@@ -43,14 +42,6 @@ public class K9MailLib {
         return debugStatus.debugSensitive();
     }
 
-    public static boolean shouldUseCondstore() {
-        return imapExtensionStatus.useCondstore();
-    }
-
-    public static boolean shouldUseQresync() {
-        return imapExtensionStatus.useQresync();
-    }
-
     public static void setDebugSensitive(boolean b) {
         if (debugStatus instanceof WritableDebugStatus) {
             ((WritableDebugStatus) debugStatus).setSensitive(b);
@@ -63,28 +54,10 @@ public class K9MailLib {
         }
     }
 
-    public static void setUseCondstore(boolean useCondstore) {
-        if (imapExtensionStatus instanceof WritableImapExtensionStatus) {
-            ((WritableImapExtensionStatus) imapExtensionStatus).setUseCondstore(useCondstore);
-        }
-    }
-
-    public static void setUseQresync(boolean useQresync) {
-        if (imapExtensionStatus instanceof WritableImapExtensionStatus) {
-            ((WritableImapExtensionStatus) imapExtensionStatus).setUseQresync(useQresync);
-        }
-    }
-
     public interface DebugStatus {
         boolean enabled();
 
         boolean debugSensitive();
-    }
-
-    public interface ImapExtensionStatus {
-        boolean useCondstore();
-
-        boolean useQresync();
     }
 
     public static void setDebugStatus(DebugStatus status) {
@@ -94,23 +67,10 @@ public class K9MailLib {
         debugStatus = status;
     }
 
-    public static void setImapExtensionStatus(ImapExtensionStatus status) {
-        if (status == null) {
-            throw new IllegalArgumentException("status cannot be null");
-        }
-        imapExtensionStatus = status;
-    }
-
     private interface WritableDebugStatus extends DebugStatus {
         void setEnabled(boolean enabled);
 
         void setSensitive(boolean sensitive);
-    }
-
-    private interface WritableImapExtensionStatus extends ImapExtensionStatus {
-        void setUseCondstore(boolean useCondstore);
-
-        void setUseQresync(boolean useQresync);
     }
 
     private static class DefaultDebugStatus implements WritableDebugStatus {
@@ -135,31 +95,6 @@ public class K9MailLib {
         @Override
         public void setSensitive(boolean sensitive) {
             this.sensitive = sensitive;
-        }
-    }
-
-    private static class DefaultImapExtensionStatus implements WritableImapExtensionStatus {
-        private boolean useCondstore = true;
-        private boolean useQresync = true;
-
-        @Override
-        public boolean useCondstore() {
-            return useCondstore;
-        }
-
-        @Override
-        public boolean useQresync() {
-            return useQresync;
-        }
-
-        @Override
-        public void setUseCondstore(boolean useCondstore) {
-            this.useCondstore = useCondstore;
-        }
-
-        @Override
-        public void setUseQresync(boolean useQresync) {
-            this.useQresync = useQresync;
         }
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/K9MailLib.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/K9MailLib.java
@@ -3,6 +3,7 @@ package com.fsck.k9.mail;
 
 public class K9MailLib {
     private static DebugStatus debugStatus = new DefaultDebugStatus();
+    private static ImapExtensionStatus imapExtensionStatus = new DefaultImapExtensionStatus();
 
     private K9MailLib() {
     }
@@ -42,6 +43,14 @@ public class K9MailLib {
         return debugStatus.debugSensitive();
     }
 
+    public static boolean shouldUseCondstore() {
+        return imapExtensionStatus.useCondstore();
+    }
+
+    public static boolean shouldUseQresync() {
+        return imapExtensionStatus.useQresync();
+    }
+
     public static void setDebugSensitive(boolean b) {
         if (debugStatus instanceof WritableDebugStatus) {
             ((WritableDebugStatus) debugStatus).setSensitive(b);
@@ -54,10 +63,28 @@ public class K9MailLib {
         }
     }
 
+    public static void setUseCondstore(boolean useCondstore) {
+        if (imapExtensionStatus instanceof WritableImapExtensionStatus) {
+            ((WritableImapExtensionStatus) imapExtensionStatus).setUseCondstore(useCondstore);
+        }
+    }
+
+    public static void setUseQresync(boolean useQresync) {
+        if (imapExtensionStatus instanceof WritableImapExtensionStatus) {
+            ((WritableImapExtensionStatus) imapExtensionStatus).setUseQresync(useQresync);
+        }
+    }
+
     public interface DebugStatus {
         boolean enabled();
 
         boolean debugSensitive();
+    }
+
+    public interface ImapExtensionStatus {
+        boolean useCondstore();
+
+        boolean useQresync();
     }
 
     public static void setDebugStatus(DebugStatus status) {
@@ -67,10 +94,23 @@ public class K9MailLib {
         debugStatus = status;
     }
 
+    public static void setImapExtensionStatus(ImapExtensionStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("status cannot be null");
+        }
+        imapExtensionStatus = status;
+    }
+
     private interface WritableDebugStatus extends DebugStatus {
         void setEnabled(boolean enabled);
 
         void setSensitive(boolean sensitive);
+    }
+
+    private interface WritableImapExtensionStatus extends ImapExtensionStatus {
+        void setUseCondstore(boolean useCondstore);
+
+        void setUseQresync(boolean useQresync);
     }
 
     private static class DefaultDebugStatus implements WritableDebugStatus {
@@ -95,6 +135,31 @@ public class K9MailLib {
         @Override
         public void setSensitive(boolean sensitive) {
             this.sensitive = sensitive;
+        }
+    }
+
+    private static class DefaultImapExtensionStatus implements WritableImapExtensionStatus {
+        private boolean useCondstore = true;
+        private boolean useQresync = true;
+
+        @Override
+        public boolean useCondstore() {
+            return useCondstore;
+        }
+
+        @Override
+        public boolean useQresync() {
+            return useQresync;
+        }
+
+        @Override
+        public void setUseCondstore(boolean useCondstore) {
+            this.useCondstore = useCondstore;
+        }
+
+        @Override
+        public void setUseQresync(boolean useQresync) {
+            this.useQresync = useQresync;
         }
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -3,7 +3,6 @@ package com.fsck.k9.mail.store.imap;
 
 class Capabilities {
     public static final String IDLE = "IDLE";
-    public static final String ENABLE = "ENABLE";
     public static final String CONDSTORE = "CONDSTORE";
     public static final String QRESYNC = "QRESYNC";
     public static final String SASL_IR = "SASL-IR";

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -14,6 +14,7 @@ public class Commands {
     public static final String LOGIN = "LOGIN";
     public static final String LIST = "LIST";
     public static final String NOOP = "NOOP";
+    public static final String ENABLE = "ENABLE";
     public static final String UID_SEARCH = "UID SEARCH";
     public static final String UID_STORE = "UID STORE";
     public static final String UID_FETCH = "UID FETCH";

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConfig.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConfig.java
@@ -1,0 +1,41 @@
+package com.fsck.k9.mail.store.imap;
+
+public class ImapConfig {
+    private static ExtensionStatus extensionStatus = new DefaultImapExtensionStatus();
+
+    static boolean shouldUseCondstore() {
+        return extensionStatus.useCondstore();
+    }
+
+    static boolean shouldUseQresync() {
+        return extensionStatus.useQresync();
+    }
+
+    public interface ExtensionStatus {
+        boolean useCondstore();
+
+        boolean useQresync();
+    }
+
+    public static void setExtensionStatus(ExtensionStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("status cannot be null");
+        }
+        extensionStatus = status;
+    }
+
+    private static class DefaultImapExtensionStatus implements ExtensionStatus {
+        private boolean useCondstore = true;
+        private boolean useQresync = true;
+
+        @Override
+        public boolean useCondstore() {
+            return useCondstore;
+        }
+
+        @Override
+        public boolean useQresync() {
+            return useQresync;
+        }
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -604,7 +604,7 @@ public class ImapConnection {
     }
 
     void enableQresync() throws IOException, MessagingException {
-        if (!qresyncEnabled && hasCapability(Capabilities.QRESYNC) && K9MailLib.shouldUseQresync()) {
+        if (!qresyncEnabled && hasCapability(Capabilities.QRESYNC) && ImapConfig.shouldUseQresync()) {
             executeSimpleCommand(String.format("%s %s %s", Commands.ENABLE, Capabilities.CONDSTORE,
                     Capabilities.QRESYNC));
             qresyncEnabled = true;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -604,9 +604,8 @@ public class ImapConnection {
     }
 
     void enableQresync() throws IOException, MessagingException {
-        if (!qresyncEnabled && hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC)
-                && K9MailLib.shouldUseQresync()) {
-            executeSimpleCommand(String.format("%s %s %s", Capabilities.ENABLE, Capabilities.CONDSTORE,
+        if (!qresyncEnabled && hasCapability(Capabilities.QRESYNC) && K9MailLib.shouldUseQresync()) {
+            executeSimpleCommand(String.format("%s %s %s", Commands.ENABLE, Capabilities.CONDSTORE,
                     Capabilities.QRESYNC));
             qresyncEnabled = true;
         }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -603,7 +603,7 @@ public class ImapConnection {
     }
 
     private void enableQresyncIfAvailable() throws IOException, MessagingException {
-        if (hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC)) {
+        if (hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC) && K9MailLib.shouldUseQresync()) {
             executeSimpleCommand(String.format("%s %s %s", Capabilities.ENABLE, Capabilities.CONDSTORE,
                     Capabilities.QRESYNC));
         }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -687,7 +687,8 @@ public class ImapConnection {
         return isListResponse && hierarchyDelimiterValid;
     }
 
-    boolean hasCapability(String capability) {
+    boolean hasCapability(String capability) throws IOException, MessagingException {
+        requestCapabilitiesIfNecessary();
         return capabilities.contains(capability.toUpperCase(Locale.US));
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -77,6 +77,7 @@ public class ImapConnection {
     private Exception stacktraceForClose;
     private boolean open = false;
     private boolean retryXoauth2WithNewToken = true;
+    private boolean qresyncEnabled = false;
 
 
     public ImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
@@ -130,7 +131,7 @@ public class ImapConnection {
             extractOrRequestCapabilities(responses);
 
             enableCompressionIfRequested();
-            enableQresyncIfAvailable();
+            enableQresync();
 
             retrievePathPrefixIfNecessary();
             retrievePathDelimiterIfNecessary();
@@ -602,10 +603,12 @@ public class ImapConnection {
         }
     }
 
-    private void enableQresyncIfAvailable() throws IOException, MessagingException {
-        if (hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC) && K9MailLib.shouldUseQresync()) {
+    void enableQresync() throws IOException, MessagingException {
+        if (!qresyncEnabled && hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC)
+                && K9MailLib.shouldUseQresync()) {
             executeSimpleCommand(String.format("%s %s %s", Capabilities.ENABLE, Capabilities.CONDSTORE,
                     Capabilities.QRESYNC));
+            qresyncEnabled = true;
         }
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -130,7 +130,7 @@ public class ImapConnection {
             extractOrRequestCapabilities(responses);
 
             enableCompressionIfRequested();
-            enableExtensionsIfAvailable();
+            enableQresyncIfAvailable();
 
             retrievePathPrefixIfNecessary();
             retrievePathDelimiterIfNecessary();
@@ -602,14 +602,10 @@ public class ImapConnection {
         }
     }
 
-    private void enableExtensionsIfAvailable() throws IOException, MessagingException {
-        if (hasCapability(Capabilities.ENABLE)) {
-            if (hasCapability(Capabilities.CONDSTORE)) {
-                executeSimpleCommand(String.format("%s %s", Capabilities.ENABLE, Capabilities.CONDSTORE));
-            }
-            if (hasCapability(Capabilities.QRESYNC)) {
-                executeSimpleCommand(String.format("%s %s", Capabilities.ENABLE, Capabilities.QRESYNC));
-            }
+    private void enableQresyncIfAvailable() throws IOException, MessagingException {
+        if (hasCapability(Capabilities.ENABLE) && hasCapability(Capabilities.QRESYNC)) {
+            executeSimpleCommand(String.format("%s %s %s", Capabilities.ENABLE, Capabilities.CONDSTORE,
+                    Capabilities.QRESYNC));
         }
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -182,6 +182,10 @@ public class ImapFolder extends Folder<ImapMessage> {
             if (response.hasOpenMode()) {
                 this.mode = response.getOpenMode();
             }
+            if (response == null) {
+                // This shouldn't happen
+                return null;
+            }
             exists = true;
             uidValidity = response.getUidValidity();
             highestModSeq = response.getHighestModSeq();
@@ -434,7 +438,7 @@ public class ImapFolder extends Folder<ImapMessage> {
         return !(highestModSeq == INVALID_HIGHEST_MOD_SEQ);
     }
 
-    public boolean supportsQresync() throws IOException, MessagingException {
+    boolean supportsQresync() throws IOException, MessagingException {
         return supportsModSeq() && connection.isQresyncCapable();
     }
 
@@ -1355,7 +1359,7 @@ public class ImapFolder extends Folder<ImapMessage> {
         return getName().hashCode();
     }
 
-    private ImapStore getStore() {
+    ImapStore getStore() {
         return store;
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -126,12 +126,12 @@ public class ImapFolder extends Folder<ImapMessage> {
         }
     }
 
-    public QresyncResponse openUsingQresync(int mode, long cachedUidValidity, long cachedHighestModSeq)
+    public QresyncResponse open(int mode, long cachedUidValidity, long cachedHighestModSeq)
         throws MessagingException {
-        return openUsingQresync(mode, cachedUidValidity, cachedHighestModSeq, 0);
+        return open(mode, cachedUidValidity, cachedHighestModSeq, 0);
     }
 
-    public QresyncResponse openUsingQresync(int mode, long cachedUidValidity, long cachedHighestModSeq,
+    public QresyncResponse open(int mode, long cachedUidValidity, long cachedHighestModSeq,
             long smallestUid) throws MessagingException {
         SelectOrExamineResponse response = internalOpen(mode, cachedUidValidity, cachedHighestModSeq, smallestUid, false);
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -202,27 +202,6 @@ public class ImapFolder extends Folder<ImapMessage> {
         }
     }
 
-    void updateHighestModSeq(List<ImapMessage> changedMessages) throws IOException, MessagingException {
-        if (!supportsModSeq()) {
-            return;
-        }
-
-        FetchProfile fp = new FetchProfile();
-        fp.add(FetchProfile.Item.MODSEQ);
-        fetch(changedMessages, fp, null);
-
-        long newHighestModSeq = 0;
-        for (ImapMessage message : changedMessages) {
-            long modSeq = message.getModSeq();
-            if (modSeq > newHighestModSeq) {
-                newHighestModSeq = modSeq;
-            }
-        }
-        if (newHighestModSeq != 0) {
-            highestModSeq = newHighestModSeq;
-        }
-    }
-
     @Override
     public boolean isOpen() {
         return connection != null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -121,7 +121,7 @@ public class ImapFolder extends Folder<ImapMessage> {
 
     @Override
     public void open(int mode) throws MessagingException {
-        internalOpen(mode, INVALID_UID_VALIDITY, INVALID_HIGHEST_MOD_SEQ, true);
+        internalOpen(mode, INVALID_UID_VALIDITY, INVALID_HIGHEST_MOD_SEQ);
 
         if (messageCount == -1) {
             throw new MessagingException("Did not find message count during open");
@@ -130,7 +130,7 @@ public class ImapFolder extends Folder<ImapMessage> {
 
     public QresyncParamResponse open(int mode, long cachedUidValidity, long cachedHighestModSeq)
             throws MessagingException {
-        SelectOrExamineResponse response = internalOpen(mode, cachedUidValidity, cachedHighestModSeq, false);
+        SelectOrExamineResponse response = internalOpen(mode, cachedUidValidity, cachedHighestModSeq);
 
         if (messageCount == -1) {
             throw new MessagingException("Did not find message count during open");
@@ -138,9 +138,9 @@ public class ImapFolder extends Folder<ImapMessage> {
         return response.getQresyncParamResponse();
     }
 
-    SelectOrExamineResponse internalOpen(int mode, long cachedUidValidity, long cachedHighestModSeq,
-            boolean reuseConnection) throws MessagingException {
-        if (reuseConnection && isOpen() && this.mode == mode) {
+    SelectOrExamineResponse internalOpen(int mode, long cachedUidValidity, long cachedHighestModSeq)
+            throws MessagingException {
+        if (isOpen() && this.mode == mode) {
             // Make sure the connection is valid. If it's not we'll close it down and continue
             // on to get a new one.
             try {
@@ -163,6 +163,7 @@ public class ImapFolder extends Folder<ImapMessage> {
             String escapedFolderName = ImapUtility.encodeString(encodedFolderName);
             SelectOrExamineCommand command;
             if (connection.isQresyncCapable() && K9MailLib.shouldUseQresync()) {
+                connection.enableQresync();
                 command = SelectOrExamineCommand.createWithQresyncParameter(mode, escapedFolderName, cachedUidValidity,
                         cachedHighestModSeq);
             } else if (connection.isCondstoreCapable() && K9MailLib.shouldUseCondstore()) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -128,7 +128,7 @@ public class ImapFolder extends Folder<ImapMessage> {
         }
     }
 
-    public QresyncParamResponse open(int mode, long cachedUidValidity, long cachedHighestModSeq)
+    public QresyncParamResponse openUsingQresyncParam(int mode, long cachedUidValidity, long cachedHighestModSeq)
             throws MessagingException {
         SelectOrExamineResponse response = internalOpen(mode, cachedUidValidity, cachedHighestModSeq);
 
@@ -439,8 +439,8 @@ public class ImapFolder extends Folder<ImapMessage> {
         return !(highestModSeq == INVALID_HIGHEST_MOD_SEQ);
     }
 
-    boolean supportsQresync() throws IOException, MessagingException {
-        return supportsModSeq() && connection.isQresyncCapable();
+    boolean doesConnectionSupportQresync() throws IOException, MessagingException {
+        return connection.isQresyncCapable();
     }
 
     public long getUidValidity() {
@@ -527,6 +527,9 @@ public class ImapFolder extends Folder<ImapMessage> {
 
     public void fetchChangedMessageFlagsUsingCondstore(List<ImapMessage> messages, long modseq,
             MessageRetrievalListener<ImapMessage> listener) throws MessagingException {
+        if (messages == null || messages.isEmpty()) {
+            return;
+        }
         checkOpen();
 
         List<Long> uids = new ArrayList<>(messages.size());
@@ -753,7 +756,7 @@ public class ImapFolder extends Folder<ImapMessage> {
                 }
 
                 if (listener != null) {
-                    listener.messageStarted(uid, messageNumber++, messageMap.size());
+                    listener.messageStarted(uid, messageNumber, messageMap.size());
                 }
 
                 ImapMessage imapMessage = (ImapMessage) message;
@@ -775,6 +778,7 @@ public class ImapFolder extends Folder<ImapMessage> {
                 if (listener != null) {
                     listener.messageFinished(imapMessage, messageNumber, messageMap.size());
                 }
+                messageNumber++;
             } else {
                 handleUntaggedResponse(response);
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -162,10 +162,10 @@ public class ImapFolder extends Folder<ImapMessage> {
             String encodedFolderName = folderNameCodec.encode(getPrefixedName());
             String escapedFolderName = ImapUtility.encodeString(encodedFolderName);
             SelectOrExamineCommand command;
-            if (connection.isQresyncCapable()) {
+            if (connection.isQresyncCapable() && K9MailLib.shouldUseQresync()) {
                 command = SelectOrExamineCommand.createWithQresyncParameter(mode, escapedFolderName, cachedUidValidity,
                         cachedHighestModSeq);
-            } else if (connection.isCondstoreCapable()) {
+            } else if (connection.isCondstoreCapable() && K9MailLib.shouldUseCondstore()) {
                 command = SelectOrExamineCommand.createWithCondstoreParameter(mode, escapedFolderName);
             } else {
                 command = SelectOrExamineCommand.create(mode, escapedFolderName);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -42,8 +42,6 @@ import com.fsck.k9.mail.store.imap.selectedstate.response.UidCopyResponse;
 import com.fsck.k9.mail.store.imap.selectedstate.response.UidSearchResponse;
 import timber.log.Timber;
 
-import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
-
 
 public class ImapFolder extends Folder<ImapMessage> {
     private static final ThreadLocal<SimpleDateFormat> RFC3501_DATE = new ThreadLocal<SimpleDateFormat>() {
@@ -730,7 +728,7 @@ public class ImapFolder extends Folder<ImapMessage> {
 
             response = command.readResponse(connection);
 
-            if (response.getTag() == null && equalsIgnoreCase(response.get(1), "FETCH")) {
+            if (response.getTag() == null && ImapResponseParser.equalsIgnoreCase(response.get(1), "FETCH")) {
                 ImapList fetchList = (ImapList) response.getKeyedValue("FETCH");
                 String uid = fetchList.getKeyedString("UID");
                 long msgSeq = response.getLong(0);
@@ -805,7 +803,7 @@ public class ImapFolder extends Folder<ImapMessage> {
             do {
                 response = command.readResponse(connection);
 
-                if (response.getTag() == null && equalsIgnoreCase(response.get(1), "FETCH")) {
+                if (response.getTag() == null && ImapResponseParser.equalsIgnoreCase(response.get(1), "FETCH")) {
                     ImapList fetchList = (ImapList) response.getKeyedValue("FETCH");
                     String uid = fetchList.getKeyedString("UID");
 
@@ -918,7 +916,7 @@ public class ImapFolder extends Folder<ImapMessage> {
     }
 
     protected void handlePossibleUidNext(ImapResponse response) {
-        if (equalsIgnoreCase(response.get(0), "OK") && response.size() > 1) {
+        if (ImapResponseParser.equalsIgnoreCase(response.get(0), "OK") && response.size() > 1) {
             Object bracketedObj = response.get(1);
             if (bracketedObj instanceof ImapList) {
                 ImapList bracketed = (ImapList) bracketedObj;
@@ -944,7 +942,7 @@ public class ImapFolder extends Folder<ImapMessage> {
      */
     protected void handleUntaggedResponse(ImapResponse response) {
         if (response.getTag() == null && response.size() > 1) {
-            if (equalsIgnoreCase(response.get(1), "EXISTS")) {
+            if (ImapResponseParser.equalsIgnoreCase(response.get(1), "EXISTS")) {
                 messageCount = response.getNumber(0);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Got untagged EXISTS with value %d for %s", messageCount, getLogId());
@@ -953,14 +951,14 @@ public class ImapFolder extends Folder<ImapMessage> {
 
             handlePossibleUidNext(response);
 
-            if (equalsIgnoreCase(response.get(1), "EXPUNGE") && messageCount > 0) {
+            if (ImapResponseParser.equalsIgnoreCase(response.get(1), "EXPUNGE") && messageCount > 0) {
                 messageCount--;
                 if (K9MailLib.isDebug()) {
                     Timber.d("Got untagged EXPUNGE with messageCount %d for %s", messageCount, getLogId());
                 }
             }
 
-            if (equalsIgnoreCase(response.get(0), "VANISHED") && messageCount > 0) {
+            if (ImapResponseParser.equalsIgnoreCase(response.get(0), "VANISHED") && messageCount > 0) {
                 List<String> vanishedUids = ImapUtility.extractVanishedUids(Collections.singletonList(response));
                 messageCount -= vanishedUids.size();
                 if (K9MailLib.isDebug()) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -160,11 +160,11 @@ public class ImapFolder extends Folder<ImapMessage> {
             String encodedFolderName = folderNameCodec.encode(getPrefixedName());
             String escapedFolderName = ImapUtility.encodeString(encodedFolderName);
             SelectOrExamineCommand command;
-            if (connection.isQresyncCapable() && K9MailLib.shouldUseQresync()) {
+            if (connection.isQresyncCapable() && ImapConfig.shouldUseQresync()) {
                 connection.enableQresync();
                 command = SelectOrExamineCommand.createWithQresyncParameter(mode, escapedFolderName, cachedUidValidity,
                         cachedHighestModSeq);
-            } else if (connection.isCondstoreCapable() && K9MailLib.shouldUseCondstore()) {
+            } else if (connection.isCondstoreCapable() && ImapConfig.shouldUseCondstore()) {
                 command = SelectOrExamineCommand.createWithCondstoreParameter(mode, escapedFolderName);
             } else {
                 command = SelectOrExamineCommand.create(mode, escapedFolderName);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -525,14 +525,17 @@ public class ImapFolder extends Folder<ImapMessage> {
         return getMessages(start, end, earliestDate, false, listener);
     }
 
-    public void fetchChangedMessageFlagsUsingCondstore(List<Long> uids, long modseq,
+    public void fetchChangedMessageFlagsUsingCondstore(List<ImapMessage> messages, long modseq,
             MessageRetrievalListener<ImapMessage> listener) throws MessagingException {
         checkOpen();
 
+        List<Long> uids = new ArrayList<>(messages.size());
         HashMap<String, Message> messageMap = new HashMap<>();
-        for (Long uid : uids) {
-            ImapMessage imapMessage = new ImapMessage(String.valueOf(uid), this);
-            messageMap.put(String.valueOf(uid), imapMessage);
+
+        for (ImapMessage message : messages) {
+            Long uid = Long.parseLong(message.getUid());
+            uids.add(uid);
+            messageMap.put(String.valueOf(uid), message);
         }
 
         FetchProfile fp = new FetchProfile();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -325,7 +325,7 @@ class ImapFolderPusher extends ImapFolder {
 
         private boolean openConnectionIfNecessary() throws MessagingException {
             ImapConnection oldConnection = connection;
-            internalOpen(OPEN_MODE_RO, INVALID_UID_VALIDITY, INVALID_HIGHEST_MOD_SEQ, true);
+            internalOpen(OPEN_MODE_RO, INVALID_UID_VALIDITY, INVALID_HIGHEST_MOD_SEQ);
 
             ImapConnection conn = connection;
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -325,7 +325,7 @@ class ImapFolderPusher extends ImapFolder {
 
         private boolean openConnectionIfNecessary() throws MessagingException {
             ImapConnection oldConnection = connection;
-            internalOpen(OPEN_MODE_RO, 0, 0, null, true);
+            internalOpen(OPEN_MODE_RO, INVALID_UID_VALIDITY, INVALID_HIGHEST_MOD_SEQ, true);
 
             ImapConnection conn = connection;
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -100,9 +100,7 @@ class ImapFolderPusher extends ImapFolder {
     @Override
     protected void handleUntaggedResponse(ImapResponse response) {
         if (response.getTag() == null && response.size() > 1) {
-            Object responseType = response.get(1);
-            if (equalsIgnoreCase(responseType, "FETCH") || equalsIgnoreCase(responseType, "EXPUNGE") ||
-                    equalsIgnoreCase(responseType, "EXISTS")) {
+            if (isUntaggedResponseSupported(response)) {
 
                 if (K9MailLib.isDebug()) {
                     Timber.d("Storing response %s for later processing", response);
@@ -115,6 +113,11 @@ class ImapFolderPusher extends ImapFolder {
 
             handlePossibleUidNext(response);
         }
+    }
+
+    private boolean isUntaggedResponseSupported(ImapResponse response) {
+        return (equalsIgnoreCase(response.get(1), "EXISTS") || equalsIgnoreCase(response.get(1), "EXPUNGE") ||
+                equalsIgnoreCase(response.get(1), "FETCH") || equalsIgnoreCase(response.get(0), "VANISHED"));
     }
 
     private void superHandleUntaggedResponse(ImapResponse response) {
@@ -375,10 +378,7 @@ class ImapFolderPusher extends ImapFolder {
             } else {
                 if (response.getTag() == null) {
                     if (response.size() > 1) {
-                        Object responseType = response.get(1);
-                        if (equalsIgnoreCase(responseType, "EXISTS") || equalsIgnoreCase(responseType, "EXPUNGE") ||
-                                equalsIgnoreCase(responseType, "FETCH")) {
-
+                        if (isUntaggedResponseSupported(response)) {
                             wakeLock.acquire(PUSH_WAKE_LOCK_TIMEOUT);
 
                             if (K9MailLib.isDebug()) {
@@ -521,6 +521,12 @@ class ImapFolderPusher extends ImapFolder {
                         List<Long> msgSeqs = new ArrayList<Long>(msgSeqUidMap.keySet());
                         Collections.sort(msgSeqs);  // Have to do comparisons in order because of msgSeq reductions
 
+                        //TODO: Add a fix for this case in CONDSTORE and regular IMAP folders.
+                        if (msgSeqs.isEmpty()) {
+                            Timber.e("Received untagged EXPUNGE response for folder %s, but msgSeqUidMap is empty",
+                                    getName());
+                        }
+
                         for (long msgSeqNum : msgSeqs) {
                             if (K9MailLib.isDebug()) {
                                 Timber.v("Comparing EXPUNGEd msgSeq %d to %d", msgSeq, msgSeqNum);
@@ -545,6 +551,22 @@ class ImapFolderPusher extends ImapFolder {
                                 msgSeqUidMap.remove(msgSeqNum);
                                 msgSeqUidMap.put(msgSeqNum - 1, uid);
                             }
+                        }
+                    }
+
+                    if (equalsIgnoreCase(response.get(0), "VANISHED")) {
+                        List<String> vanishedUids = ImapUtility.extractVanishedUids(Collections.singletonList(response));
+                        messageCountDelta -= vanishedUids.size();
+
+                        if (K9MailLib.isDebug()) {
+                            Timber.d("Got untagged VANISHED for UIDs %s for %s", vanishedUids, getLogId());
+                        }
+
+                        for (String uid : vanishedUids) {
+                            if (K9MailLib.isDebug()) {
+                                Timber.d("Scheduling removal of UID %s", uid);
+                            }
+                            removeMsgUids.add(uid);
                         }
                     }
                 } catch (Exception e) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
@@ -11,8 +11,6 @@ import com.fsck.k9.mail.internet.MimeMessage;
 
 public class ImapMessage extends MimeMessage {
 
-    private long modSeq;
-
     public ImapMessage(String uid, Folder folder) {
         this.mUid = uid;
         this.mFolder = folder;
@@ -37,11 +35,4 @@ public class ImapMessage extends MimeMessage {
         getFolder().delete(Collections.singletonList(this), trashFolderName);
     }
 
-    long getModSeq() {
-        return modSeq;
-    }
-
-    void setModSeq(long modSeq) {
-        this.modSeq = modSeq;
-    }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
@@ -10,7 +10,6 @@ import com.fsck.k9.mail.internet.MimeMessage;
 
 
 public class ImapMessage extends MimeMessage {
-
     public ImapMessage(String uid, Folder folder) {
         this.mUid = uid;
         this.mFolder = folder;
@@ -34,5 +33,4 @@ public class ImapMessage extends MimeMessage {
     public void delete(String trashFolderName) throws MessagingException {
         getFolder().delete(Collections.singletonList(this), trashFolderName);
     }
-
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -136,6 +136,10 @@ public class ImapStore extends RemoteStore {
         return combinedPrefix;
     }
 
+    public static boolean isStoreUriImap(String storeUri) {
+        return storeUri.startsWith("imap");
+    }
+
     @Override
     public List<ImapFolder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         ImapConnection connection = getConnection();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.MessagingException;
 import timber.log.Timber;
 
 
@@ -192,5 +193,29 @@ public class ImapUtility {
             sb.append(token);
         }
         return sb.toString();
+    }
+
+
+    public static void setMessageFlags(ImapList fetchList, ImapMessage message, ImapStore store)
+            throws MessagingException {
+        ImapList flags = fetchList.getKeyedList("FLAGS");
+        if (flags != null) {
+            for (int i = 0, count = flags.size(); i < count; i++) {
+                String flag = flags.getString(i);
+                if (flag.equalsIgnoreCase("\\Deleted")) {
+                    message.setFlagInternal(Flag.DELETED, true);
+                } else if (flag.equalsIgnoreCase("\\Answered")) {
+                    message.setFlagInternal(Flag.ANSWERED, true);
+                } else if (flag.equalsIgnoreCase("\\Seen")) {
+                    message.setFlagInternal(Flag.SEEN, true);
+                } else if (flag.equalsIgnoreCase("\\Flagged")) {
+                    message.setFlagInternal(Flag.FLAGGED, true);
+                } else if (flag.equalsIgnoreCase("$Forwarded")) {
+                    message.setFlagInternal(Flag.FORWARDED, true);
+                    /* a message contains FORWARDED FLAG -> so we can also create them */
+                    store.getPermanentFlagsIndex().add(Flag.FORWARDED);
+                }
+            }
+        }
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -26,6 +26,8 @@ import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
 import timber.log.Timber;
 
+import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
+
 
 /**
  * Utility methods for use with IMAP.
@@ -196,8 +198,7 @@ public class ImapUtility {
     }
 
 
-    public static void setMessageFlags(ImapList fetchList, ImapMessage message, ImapStore store)
-            throws MessagingException {
+    static void setMessageFlags(ImapList fetchList, ImapMessage message, ImapStore store) throws MessagingException {
         ImapList flags = fetchList.getKeyedList("FLAGS");
         if (flags != null) {
             for (int i = 0, count = flags.size(); i < count; i++) {
@@ -217,5 +218,23 @@ public class ImapUtility {
                 }
             }
         }
+    }
+
+    static Long extractHighestModSeq(ImapResponse imapResponse) {
+        for (Object token : imapResponse) {
+            if (token instanceof ImapList) {
+                ImapList list = (ImapList) token;
+                if (list.size() < 2 || !(equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)
+                        || equalsIgnoreCase(list.get(1), Responses.NOMODSEQ)) ||
+                        !list.isString(1)) {
+                    continue;
+                }
+
+                if (equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)) {
+                    return Long.parseLong(list.getString(1));
+                }
+            }
+        }
+        return null;
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -237,4 +237,15 @@ public class ImapUtility {
         }
         return null;
     }
+
+    static List<String> extractVanishedUids(List<ImapResponse> imapResponses) {
+        List<String> uids = new ArrayList<>();
+        for (ImapResponse imapResponse : imapResponses) {
+            if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(0), "VANISHED")
+                    && imapResponse.isString(1)) {
+                uids = ImapUtility.getImapSequenceValues(imapResponse.getString(1));
+            }
+        }
+        return uids;
+    }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -240,9 +240,14 @@ public class ImapUtility {
         List<String> uids = new ArrayList<>();
         for (ImapResponse imapResponse : imapResponses) {
             if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(0), "VANISHED")) {
+
+                //For VANISHED responses. ex : * VANISHED 505,507,510,625
                 if (imapResponse.isString(1)) {
                     uids = ImapUtility.getImapSequenceValues(imapResponse.getString(1));
-                } else if (imapResponse.isList(1) && imapResponse.getList(1).getString(0).equals("EARLIER")
+                }
+
+                //For VANISHED (EARLIER) responses. ex : * VANISHED (EARLIER) 300:310,405,411
+                if (imapResponse.isList(1) && imapResponse.getList(1).getString(0).equals("EARLIER")
                         && imapResponse.isString(2)) {
                     uids = ImapUtility.getImapSequenceValues(imapResponse.getString(2));
                 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -26,8 +26,6 @@ import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
 import timber.log.Timber;
 
-import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
-
 
 /**
  * Utility methods for use with IMAP.
@@ -224,13 +222,13 @@ public class ImapUtility {
         for (Object token : imapResponse) {
             if (token instanceof ImapList) {
                 ImapList list = (ImapList) token;
-                if (list.size() < 2 || !(equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)
-                        || equalsIgnoreCase(list.get(0), Responses.NOMODSEQ)) ||
+                if (list.size() < 2 || !(ImapResponseParser.equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)
+                        || ImapResponseParser.equalsIgnoreCase(list.get(0), Responses.NOMODSEQ)) ||
                         !list.isString(1)) {
                     continue;
                 }
 
-                if (equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)) {
+                if (ImapResponseParser.equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)) {
                     return Long.parseLong(list.getString(1));
                 }
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -239,9 +239,13 @@ public class ImapUtility {
     static List<String> extractVanishedUids(List<ImapResponse> imapResponses) {
         List<String> uids = new ArrayList<>();
         for (ImapResponse imapResponse : imapResponses) {
-            if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(0), "VANISHED")
-                    && imapResponse.isString(1)) {
-                uids = ImapUtility.getImapSequenceValues(imapResponse.getString(1));
+            if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(0), "VANISHED")) {
+                if (imapResponse.isString(1)) {
+                    uids = ImapUtility.getImapSequenceValues(imapResponse.getString(1));
+                } else if (imapResponse.isList(1) && imapResponse.getList(1).getString(0).equals("EARLIER")
+                        && imapResponse.isString(2)) {
+                    uids = ImapUtility.getImapSequenceValues(imapResponse.getString(2));
+                }
             }
         }
         return uids;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapUtility.java
@@ -225,7 +225,7 @@ public class ImapUtility {
             if (token instanceof ImapList) {
                 ImapList list = (ImapList) token;
                 if (list.size() < 2 || !(equalsIgnoreCase(list.get(0), Responses.HIGHESTMODSEQ)
-                        || equalsIgnoreCase(list.get(1), Responses.NOMODSEQ)) ||
+                        || equalsIgnoreCase(list.get(0), Responses.NOMODSEQ)) ||
                         !list.isString(1)) {
                     continue;
                 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/PermanentFlagsResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/PermanentFlagsResponse.java
@@ -22,6 +22,10 @@ class PermanentFlagsResponse {
     }
 
     public static PermanentFlagsResponse parse(ImapResponse response) {
+        if (response.isTagged() || !equalsIgnoreCase(response.get(0), Responses.OK) || !response.isList(1)) {
+            return null;
+        }
+
         ImapList responseTextList = response.getList(1);
         if (responseTextList.size() < 2 || !equalsIgnoreCase(responseTextList.get(0), Responses.PERMANENTFLAGS) ||
                 !responseTextList.isList(1)) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/QresyncParamResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/QresyncParamResponse.java
@@ -18,7 +18,7 @@ public class QresyncParamResponse {
         parse(imapResponses, folder);
     }
 
-    public static QresyncParamResponse newInstance(List<ImapResponse> imapResponses, ImapFolder folder)
+    static QresyncParamResponse fromSelectOrExamineResponse(List<ImapResponse> imapResponses, ImapFolder folder)
             throws MessagingException {
         return new QresyncParamResponse(imapResponses, folder);
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/QresyncResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/QresyncResponse.java
@@ -1,0 +1,54 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fsck.k9.mail.MessagingException;
+
+
+public class QresyncResponse {
+
+    private List<String> expungedUids;
+    private List<ImapMessage> modifiedMessages;
+
+    private QresyncResponse() {
+        expungedUids = new ArrayList<>();
+        modifiedMessages = new ArrayList<>();
+    }
+
+    public static QresyncResponse parse(List<ImapResponse> imapResponses, ImapFolder folder) throws MessagingException {
+        QresyncResponse qresyncResponse = new QresyncResponse();
+        for (ImapResponse imapResponse : imapResponses) {
+            handleExpungedUids(imapResponse, qresyncResponse);
+            handleModifiedMessages(imapResponse, qresyncResponse, folder);
+        }
+        return qresyncResponse;
+    }
+
+    private static void handleExpungedUids(ImapResponse imapResponse, QresyncResponse qresyncResponse) {
+        if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(0), "VANISHED") &&
+                imapResponse.isString(2)) {
+            qresyncResponse.expungedUids.addAll(ImapUtility.getImapSequenceValues(imapResponse.getString(2)));
+        }
+    }
+
+    private static void handleModifiedMessages(ImapResponse imapResponse, QresyncResponse qresyncResponse,
+            ImapFolder folder) throws MessagingException {
+        if (imapResponse.getTag() == null && ImapResponseParser.equalsIgnoreCase(imapResponse.get(1), "FETCH")) {
+            ImapList fetchList = (ImapList) imapResponse.getKeyedValue("FETCH");
+            String uid = fetchList.getKeyedString("UID");
+            ImapMessage message = new ImapMessage(uid, folder);
+            ImapUtility.setMessageFlags(fetchList, message, folder.store);
+            qresyncResponse.modifiedMessages.add(message);
+        }
+    }
+
+    public List<String> getExpungedUids() {
+        return expungedUids;
+    }
+
+    public List<ImapMessage> getModifiedMessages() {
+        return modifiedMessages;
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.mail.store.imap;
 
 
+import com.fsck.k9.mail.K9MailLib;
+
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 
 
@@ -40,9 +42,9 @@ class SelectOrExamineCommand {
         StringBuilder builder = new StringBuilder();
         String openCommand = mode == OPEN_MODE_RW ? "SELECT" : "EXAMINE";
         builder.append(String.format("%s %s", openCommand, escapedFolderName));
-        if (useQresync()) {
+        if (useQresync() && K9MailLib.shouldUseQresync()) {
             builder.append(String.format(" (%s (%s %s))", Capabilities.QRESYNC, cachedUidValidity, cachedHighestModSeq));
-        } else if (useCondstore) {
+        } else if (useCondstore && K9MailLib.shouldUseCondstore()) {
             builder.append(String.format(" (%s)", Capabilities.CONDSTORE));
         }
         return builder.toString();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
@@ -5,42 +5,35 @@ import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 
 
 class SelectOrExamineCommand {
-
     private static final long INVALID_UIDVALIDITY = -1L;
     private static final long INVALID_HIGHESTMODSEQ = -1L;
-    private static final long INVALID_SMALLEST_UID = -1L;
 
     private int mode;
     private String escapedFolderName;
     private boolean useCondstore;
     private long cachedUidValidity;
     private long cachedHighestModSeq;
-    private long smallestUid;
 
-    static SelectOrExamineCommand createNormal(int mode, String escapedFolderName) {
-        return new SelectOrExamineCommand(mode, escapedFolderName, false, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ,
-                INVALID_SMALLEST_UID);
+    static SelectOrExamineCommand create(int mode, String escapedFolderName) {
+        return new SelectOrExamineCommand(mode, escapedFolderName, false, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ);
     }
 
     static SelectOrExamineCommand createWithCondstoreParameter(int mode, String escapedFolderName) {
-        return new SelectOrExamineCommand(mode, escapedFolderName, true, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ,
-                INVALID_SMALLEST_UID);
+        return new SelectOrExamineCommand(mode, escapedFolderName, true, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ);
     }
 
-    static SelectOrExamineCommand createWithQresyncParameter(int mode, String escapedFolderName,
-            long cachedUidValidity, long cachedHighestModSeq, long smallestUid) {
-        return new SelectOrExamineCommand(mode, escapedFolderName, false, cachedUidValidity, cachedHighestModSeq,
-                smallestUid);
+    static SelectOrExamineCommand createWithQresyncParameter(int mode, String escapedFolderName, long cachedUidValidity,
+            long cachedHighestModSeq) {
+        return new SelectOrExamineCommand(mode, escapedFolderName, true, cachedUidValidity, cachedHighestModSeq);
     }
 
     private SelectOrExamineCommand(int mode, String escapedFolderName, boolean useCondstore, long cachedUidValidity,
-            long cachedHighestModSeq, long smallestUid) {
+            long cachedHighestModSeq) {
         this.mode = mode;
         this.escapedFolderName = escapedFolderName;
         this.useCondstore = useCondstore;
         this.cachedUidValidity = cachedUidValidity;
         this.cachedHighestModSeq = cachedHighestModSeq;
-        this.smallestUid = smallestUid;
     }
 
     String createCommandString() {
@@ -48,9 +41,7 @@ class SelectOrExamineCommand {
         String openCommand = mode == OPEN_MODE_RW ? "SELECT" : "EXAMINE";
         builder.append(String.format("%s %s", openCommand, escapedFolderName));
         if (useQresync()) {
-            String uidsParam = smallestUid == 0 ? "" : String.format(" %s:*", String.valueOf(smallestUid));
-            builder.append(String.format(" (%s (%s %s%s))", Capabilities.QRESYNC, cachedUidValidity,
-                    cachedHighestModSeq, uidsParam));
+            builder.append(String.format(" (%s (%s %s))", Capabilities.QRESYNC, cachedUidValidity, cachedHighestModSeq));
         } else if (useCondstore) {
             builder.append(String.format(" (%s)", Capabilities.CONDSTORE));
         }
@@ -58,6 +49,6 @@ class SelectOrExamineCommand {
     }
 
     private boolean useQresync() {
-        return cachedUidValidity != INVALID_UIDVALIDITY && cachedHighestModSeq != INVALID_HIGHESTMODSEQ;
+        return cachedUidValidity > 0 && cachedHighestModSeq > 0;
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
@@ -42,9 +42,9 @@ class SelectOrExamineCommand {
         StringBuilder builder = new StringBuilder();
         String openCommand = mode == OPEN_MODE_RW ? "SELECT" : "EXAMINE";
         builder.append(String.format("%s %s", openCommand, escapedFolderName));
-        if (useQresync() && K9MailLib.shouldUseQresync()) {
+        if (useQresync() && ImapConfig.shouldUseQresync()) {
             builder.append(String.format(" (%s (%s %s))", Capabilities.QRESYNC, cachedUidValidity, cachedHighestModSeq));
-        } else if (useCondstore && K9MailLib.shouldUseCondstore()) {
+        } else if (useCondstore && ImapConfig.shouldUseCondstore()) {
             builder.append(String.format(" (%s)", Capabilities.CONDSTORE));
         }
         return builder.toString();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommand.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.mail.store.imap;
 
 
-import java.util.List;
-
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 
 
@@ -10,39 +8,39 @@ class SelectOrExamineCommand {
 
     private static final long INVALID_UIDVALIDITY = -1L;
     private static final long INVALID_HIGHESTMODSEQ = -1L;
-    private static final List<Long> INVALID_UIDS = null;
+    private static final long INVALID_SMALLEST_UID = -1L;
 
     private int mode;
     private String escapedFolderName;
     private boolean useCondstore;
     private long cachedUidValidity;
     private long cachedHighestModSeq;
-    private List<Long> cachedUids;
+    private long smallestUid;
 
     static SelectOrExamineCommand createNormal(int mode, String escapedFolderName) {
         return new SelectOrExamineCommand(mode, escapedFolderName, false, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ,
-                INVALID_UIDS);
+                INVALID_SMALLEST_UID);
     }
 
     static SelectOrExamineCommand createWithCondstoreParameter(int mode, String escapedFolderName) {
         return new SelectOrExamineCommand(mode, escapedFolderName, true, INVALID_UIDVALIDITY, INVALID_HIGHESTMODSEQ,
-                INVALID_UIDS);
+                INVALID_SMALLEST_UID);
     }
 
     static SelectOrExamineCommand createWithQresyncParameter(int mode, String escapedFolderName,
-            long cachedUidValidity, long cachedHighestModSeq, List<Long> cachedUids) {
+            long cachedUidValidity, long cachedHighestModSeq, long smallestUid) {
         return new SelectOrExamineCommand(mode, escapedFolderName, false, cachedUidValidity, cachedHighestModSeq,
-                cachedUids);
+                smallestUid);
     }
 
     private SelectOrExamineCommand(int mode, String escapedFolderName, boolean useCondstore, long cachedUidValidity,
-            long cachedHighestModSeq, List<Long> cachedUids) {
+            long cachedHighestModSeq, long smallestUid) {
         this.mode = mode;
         this.escapedFolderName = escapedFolderName;
         this.useCondstore = useCondstore;
         this.cachedUidValidity = cachedUidValidity;
         this.cachedHighestModSeq = cachedHighestModSeq;
-        this.cachedUids = cachedUids;
+        this.smallestUid = smallestUid;
     }
 
     String createCommandString() {
@@ -50,7 +48,7 @@ class SelectOrExamineCommand {
         String openCommand = mode == OPEN_MODE_RW ? "SELECT" : "EXAMINE";
         builder.append(String.format("%s %s", openCommand, escapedFolderName));
         if (useQresync()) {
-            String uidsParam = cachedUids.isEmpty() ? "" : " " + ImapUtility.join(",", cachedUids);
+            String uidsParam = smallestUid == 0 ? "" : String.format(" %s:*", String.valueOf(smallestUid));
             builder.append(String.format(" (%s (%s %s%s))", Capabilities.QRESYNC, cachedUidValidity,
                     cachedHighestModSeq, uidsParam));
         } else if (useCondstore) {
@@ -60,7 +58,6 @@ class SelectOrExamineCommand {
     }
 
     private boolean useQresync() {
-        return cachedUidValidity != INVALID_UIDVALIDITY && cachedHighestModSeq != INVALID_HIGHESTMODSEQ
-                && cachedUids != INVALID_UIDS;
+        return cachedUidValidity != INVALID_UIDVALIDITY && cachedHighestModSeq != INVALID_HIGHESTMODSEQ;
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -45,7 +45,7 @@ class SelectOrExamineResponse {
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
         if (folder.supportsQresync()) {
-            this.qresyncParamResponse = QresyncParamResponse.newInstance(imapResponses, folder);
+            this.qresyncParamResponse = QresyncParamResponse.fromSelectOrExamineResponse(imapResponses, folder);
         } else {
             this.qresyncParamResponse = null;
         }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -54,15 +54,9 @@ class SelectOrExamineResponse {
 
     private static void handleHighestModSeq(ImapResponse imapResponse, SelectOrExamineResponse selectOrExamineResponse)
             throws IOException, MessagingException {
-        ImapList responseTextList = imapResponse.getList(1);
-        if (responseTextList.size() < 2 || !(equalsIgnoreCase(responseTextList.get(0), Responses.HIGHESTMODSEQ)
-                || equalsIgnoreCase(responseTextList.get(1), Responses.NOMODSEQ)) ||
-                !responseTextList.isString(1)) {
-            return;
-        }
-
-        if (equalsIgnoreCase(responseTextList.get(0), Responses.HIGHESTMODSEQ)) {
-            selectOrExamineResponse.highestModSeq = Long.parseLong(responseTextList.getString(1));
+        Long highestModSeq = ImapUtility.extractHighestModSeq(imapResponse);
+        if (highestModSeq != null) {
+            selectOrExamineResponse.highestModSeq = highestModSeq;
         }
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -17,13 +17,14 @@ class SelectOrExamineResponse {
     private long uidValidity;
     private long highestModSeq = -1L;
     private boolean canCreateKeywords;
+    private QresyncResponse qresyncResponse;
     private Boolean readWriteMode;
 
     private SelectOrExamineResponse() {
     }
 
-    public static SelectOrExamineResponse parse(List<ImapResponse> imapResponses, Set<Flag> permanentFlags)
-            throws IOException, MessagingException {
+    public static SelectOrExamineResponse parse(List<ImapResponse> imapResponses, ImapFolder folder) throws IOException,
+            MessagingException {
         SelectOrExamineResponse selectOrExamineResponse = new SelectOrExamineResponse();
         for (ImapResponse imapResponse : imapResponses) {
             if (imapResponse.isTagged() || !equalsIgnoreCase(imapResponse.get(0), Responses.OK)
@@ -32,9 +33,10 @@ class SelectOrExamineResponse {
             }
             handleUidValidity(imapResponse, selectOrExamineResponse);
             handleHighestModSeq(imapResponse, selectOrExamineResponse);
-            handlePermanentFlags(imapResponse, selectOrExamineResponse, permanentFlags);
+            handlePermanentFlags(imapResponse, selectOrExamineResponse, folder.store.getPermanentFlagsIndex());
         }
         selectOrExamineResponse.readWriteMode = isModeReadWrite(ImapUtility.getLastResponse(imapResponses));
+        selectOrExamineResponse.qresyncResponse = QresyncResponse.parse(imapResponses, folder);
         return selectOrExamineResponse;
     }
 
@@ -105,6 +107,10 @@ class SelectOrExamineResponse {
 
     boolean canCreateKeywords() {
         return canCreateKeywords;
+    }
+
+    QresyncResponse getQresyncResponse() {
+        return qresyncResponse;
     }
 
     boolean hasOpenMode() {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -15,8 +15,10 @@ import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
 
 class SelectOrExamineResponse {
 
+    private static final long INVALID_HIGHEST_MOD_SEQ = -1L;
+
     private long uidValidity;
-    private long highestModSeq = -1L;
+    private long highestModSeq = INVALID_HIGHEST_MOD_SEQ;
     private boolean canCreateKeywords;
     private QresyncParamResponse qresyncParamResponse;
     private Boolean readWriteMode;
@@ -45,7 +47,8 @@ class SelectOrExamineResponse {
             parsePermanentFlags(imapResponse, folder.getStore().getPermanentFlagsIndex());
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
-        if (folder.supportsQresync() && K9MailLib.shouldUseQresync()) {
+        if (folder.doesConnectionSupportQresync() && highestModSeq != INVALID_HIGHEST_MOD_SEQ
+                && K9MailLib.shouldUseQresync()) {
             this.qresyncParamResponse = QresyncParamResponse.fromSelectOrExamineResponse(imapResponses, folder);
         } else {
             this.qresyncParamResponse = null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -48,7 +48,7 @@ class SelectOrExamineResponse {
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
         if (folder.doesConnectionSupportQresync() && highestModSeq != INVALID_HIGHEST_MOD_SEQ
-                && K9MailLib.shouldUseQresync()) {
+                && ImapConfig.shouldUseQresync()) {
             this.qresyncParamResponse = QresyncParamResponse.fromSelectOrExamineResponse(imapResponses, folder);
         } else {
             this.qresyncParamResponse = null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -27,6 +27,9 @@ class SelectOrExamineResponse {
 
     public static SelectOrExamineResponse newInstance(List<ImapResponse> imapResponses, ImapFolder folder) throws
             IOException, MessagingException {
+        if (!isResponseValid(imapResponses)) {
+            return null;
+        }
         return new SelectOrExamineResponse(imapResponses, folder);
     }
 
@@ -38,7 +41,7 @@ class SelectOrExamineResponse {
             }
             parseUidValidity(imapResponse);
             parseHighestModSeq(imapResponse);
-            parsePermanentFlags(imapResponse, folder.store.getPermanentFlagsIndex());
+            parsePermanentFlags(imapResponse, folder.getStore().getPermanentFlagsIndex());
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
         if (folder.supportsQresync()) {
@@ -74,10 +77,6 @@ class SelectOrExamineResponse {
     }
 
     private static Boolean isModeReadWriteIfAvailable(ImapResponse imapResponse) {
-        if (!imapResponse.isTagged() || !equalsIgnoreCase(imapResponse.get(0), Responses.OK)) {
-            return null;
-        }
-
         if (!imapResponse.isList(1)) {
             return null;
         }
@@ -95,6 +94,14 @@ class SelectOrExamineResponse {
         }
 
         return null;
+    }
+
+    private static boolean isResponseValid(List<ImapResponse> imapResponses) {
+        ImapResponse lastResponse = ImapUtility.getLastResponse(imapResponses);
+        if (!lastResponse.isTagged() || !equalsIgnoreCase(lastResponse.get(0), Responses.OK)) {
+            return false;
+        }
+        return true;
     }
 
     long getUidValidity() {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.MessagingException;
 
 import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
@@ -44,7 +45,7 @@ class SelectOrExamineResponse {
             parsePermanentFlags(imapResponse, folder.getStore().getPermanentFlagsIndex());
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
-        if (folder.supportsQresync()) {
+        if (folder.supportsQresync() && K9MailLib.shouldUseQresync()) {
             this.qresyncParamResponse = QresyncParamResponse.fromSelectOrExamineResponse(imapResponses, folder);
         } else {
             this.qresyncParamResponse = null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -44,7 +44,7 @@ class SelectOrExamineResponse {
             }
             parseUidValidity(imapResponse);
             parseHighestModSeq(imapResponse);
-            parsePermanentFlags(imapResponse, folder.getStore().getPermanentFlagsIndex());
+            parsePermanentFlags(imapResponse, folder.getPermanentFlags());
         }
         this.readWriteMode = isModeReadWriteIfAvailable(ImapUtility.getLastResponse(imapResponses));
         if (folder.doesConnectionSupportQresync() && highestModSeq != INVALID_HIGHEST_MOD_SEQ

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -36,7 +36,11 @@ class SelectOrExamineResponse {
             handlePermanentFlags(imapResponse, selectOrExamineResponse, folder.store.getPermanentFlagsIndex());
         }
         selectOrExamineResponse.readWriteMode = isModeReadWrite(ImapUtility.getLastResponse(imapResponses));
-        selectOrExamineResponse.qresyncResponse = QresyncResponse.parse(imapResponses, folder);
+        if (folder.supportsQresync()) {
+            selectOrExamineResponse.qresyncResponse = QresyncResponse.parse(imapResponses, folder);
+        } else {
+            selectOrExamineResponse.qresyncResponse = null;
+        }
         return selectOrExamineResponse;
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
@@ -25,6 +25,7 @@ import com.fsck.k9.mail.store.imap.ImapUtility;
 public class UidFetchCommand extends SelectedStateCommand {
     private int maximumAutoDownloadMessageSize;
     private FetchProfile fetchProfile;
+    private Long changedSince;
     private HashMap<String, Message> messageMap;
     private Part part;
     private BodyFactory bodyFactory;
@@ -37,6 +38,9 @@ public class UidFetchCommand extends SelectedStateCommand {
         StringBuilder builder = new StringBuilder(Commands.UID_FETCH).append(" ");
         builder.append(createCombinedIdString());
         addDataItems(builder);
+        if (changedSince != null) {
+            builder.append(String.format("(CHANGEDSINCE %s) ", String.valueOf(changedSince)));
+        }
         return builder.toString().trim();
     }
 
@@ -96,7 +100,7 @@ public class UidFetchCommand extends SelectedStateCommand {
             }
 
             String spaceSeparatedFetchFields = ImapUtility.join(" ", fetchFields);
-            builder.append("(").append(spaceSeparatedFetchFields).append(")");
+            builder.append("(").append(spaceSeparatedFetchFields).append(") ");
         } else if (part != null) {
             String partId = part.getServerExtra();
 
@@ -107,7 +111,7 @@ public class UidFetchCommand extends SelectedStateCommand {
                 fetch = String.format("BODY.PEEK[%s]", partId);
             }
 
-            builder.append("(UID ").append(fetch).append(")");
+            builder.append("(UID ").append(fetch).append(") ");
         }
     }
 
@@ -115,6 +119,7 @@ public class UidFetchCommand extends SelectedStateCommand {
     Builder newBuilder() {
         return new Builder()
                 .maximumAutoDownloadMessageSize(maximumAutoDownloadMessageSize)
+                .changedSince(changedSince)
                 .messageParams(fetchProfile, messageMap)
                 .partParams(part, bodyFactory);
     }
@@ -123,6 +128,13 @@ public class UidFetchCommand extends SelectedStateCommand {
 
         public Builder maximumAutoDownloadMessageSize(int maximumAutoDownloadMessageSize) {
             command.maximumAutoDownloadMessageSize = maximumAutoDownloadMessageSize;
+            return builder;
+        }
+
+        public Builder changedSince(Long changedSince) {
+            if (changedSince != null) {
+                command.changedSince = changedSince;
+            }
             return builder;
         }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
@@ -2,9 +2,9 @@ package com.fsck.k9.mail.store.imap.selectedstate.command;
 
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 
 import com.fsck.k9.mail.BodyFactory;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
@@ -68,10 +68,6 @@ public class UidFetchCommand extends SelectedStateCommand {
             Set<String> fetchFields = new LinkedHashSet<>();
             fetchFields.add("UID");
 
-            if (fetchProfile.contains(FetchProfile.Item.MODSEQ)) {
-                fetchFields.add("MODSEQ");
-            }
-
             if (fetchProfile.contains(FetchProfile.Item.FLAGS)) {
                 fetchFields.add("FLAGS");
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommand.java
@@ -2,9 +2,9 @@ package com.fsck.k9.mail.store.imap.selectedstate.command;
 
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import com.fsck.k9.mail.BodyFactory;
@@ -26,7 +26,7 @@ public class UidFetchCommand extends FolderSelectedStateCommand {
     private int maximumAutoDownloadMessageSize;
     private FetchProfile fetchProfile;
     private Long changedSince;
-    private HashMap<String, Message> messageMap;
+    private Map<String, Message> messageMap;
     private Part part;
     private BodyFactory bodyFactory;
 
@@ -134,7 +134,7 @@ public class UidFetchCommand extends FolderSelectedStateCommand {
             return builder;
         }
 
-        public Builder messageParams(FetchProfile fetchProfile, HashMap<String, Message> messageMap) {
+        public Builder messageParams(FetchProfile fetchProfile, Map<String, Message> messageMap) {
             command.fetchProfile = fetchProfile;
             command.messageMap = messageMap;
             return builder;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidSearchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidSearchCommand.java
@@ -27,7 +27,6 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
     private Date since;
     private Set<Flag> requiredFlags;
     private Set<Flag> forbiddenFlags;
-    private Long modSeq;
     private MessageRetrievalListener<ImapMessage> listener;
 
     private UidSearchCommand() {
@@ -45,7 +44,6 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
         addSince(builder);
         addFlags(builder, requiredFlags, false);
         addFlags(builder, forbiddenFlags, true);
-        addModSeq(builder);
         return builder.toString().trim();
     }
 
@@ -125,12 +123,6 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
         }
     }
 
-    private void addModSeq(StringBuilder builder) {
-        if (modSeq != null) {
-            builder.append("MODSEQ ").append(modSeq).append(" ");
-        }
-    }
-
     @Override
     Builder newBuilder() {
         return new Builder()
@@ -141,7 +133,6 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
                 .since(since)
                 .requiredFlags(requiredFlags)
                 .forbiddenFlags(forbiddenFlags)
-                .modSeq(modSeq)
                 .listener(listener);
     }
 
@@ -179,11 +170,6 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
 
         public Builder forbiddenFlags(Set<Flag> forbiddenFlags) {
             command.forbiddenFlags = forbiddenFlags;
-            return builder;
-        }
-
-        public Builder modSeq(long modSeq) {
-            command.modSeq = modSeq;
             return builder;
         }
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -770,7 +770,7 @@ public class ImapConnectionTest {
     public void open_withIoExceptionDuringListCommand_shouldThrow() throws Exception {
         settings.setAuthType(AuthType.PLAIN);
         MockImapServer server = new MockImapServer();
-        simplePreAuthAndLoginDialog(server, "");
+        simplePreAuthAndLoginDialog(server, "IMAP4 IMAP4REV1");
         server.expect("3 LIST \"\" \"\"");
         server.output("* Now what?");
         ImapConnection imapConnection = startServerAndCreateImapConnection(server);
@@ -789,7 +789,7 @@ public class ImapConnectionTest {
     public void open_withNegativeResponseToListCommand() throws Exception {
         settings.setAuthType(AuthType.PLAIN);
         MockImapServer server = new MockImapServer();
-        simplePreAuthAndLoginDialog(server, "");
+        simplePreAuthAndLoginDialog(server, "IMAP4 IMAP4REV1");
         server.expect("3 LIST \"\" \"\"");
         server.output("3 NO");
         ImapConnection imapConnection = startServerAndCreateImapConnection(server);
@@ -916,7 +916,7 @@ public class ImapConnectionTest {
     }
 
     private ImapConnection simpleOpen(MockImapServer server) throws Exception {
-        return simpleOpenWithCapabilities(server, "");
+        return simpleOpenWithCapabilities(server, "IMAP4 IMAP4REV1");
     }
 
     private ImapConnection simpleOpenWithCapabilities(MockImapServer server, String postAuthCapabilities)

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -801,6 +801,29 @@ public class ImapConnectionTest {
     }
 
     @Test
+    public void open_withQresyncCapability_shouldEnableQresync() throws Exception {
+        MockImapServer server = new MockImapServer();
+        simpleOpenWithQresyncEnabled(server);
+        ImapConnection imapConnection = startServerAndCreateImapConnection(server);
+
+        imapConnection.open();
+
+        server.verifyConnectionStillOpen();
+        server.verifyInteractionCompleted();
+    }
+
+    @Test
+    public void open_withoutQresyncCapability_shouldNotEnableQresync() throws Exception {
+        MockImapServer server = new MockImapServer();
+        ImapConnection imapConnection = simpleOpen(server);
+
+        imapConnection.open();
+
+        server.verifyConnectionStillOpen();
+        server.verifyInteractionCompleted();
+    }
+
+    @Test
     public void isConnected_withoutPreviousOpen_shouldReturnFalse() throws Exception {
         ImapConnection imapConnection = createImapConnection(
                 settings, socketFactory, connectivityManager, oAuth2TokenProvider);
@@ -882,6 +905,56 @@ public class ImapConnectionTest {
     }
 
     @Test
+    public void isCondstoreCapable_withoutCondstoreCapability() throws Exception {
+        MockImapServer server = new MockImapServer();
+        ImapConnection imapConnection = simpleOpen(server);
+
+        boolean result = imapConnection.isCondstoreCapable();
+
+        assertFalse(result);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void isCondstoreCapable_withCondstoreCapability() throws Exception {
+        MockImapServer server = new MockImapServer();
+        ImapConnection imapConnection = simpleOpenWithCapabilities(server, "CONDSTORE");
+
+        boolean result = imapConnection.isCondstoreCapable();
+
+        assertTrue(result);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void isQresyncCapable_withoutQresyncCapability() throws Exception {
+        MockImapServer server = new MockImapServer();
+        ImapConnection imapConnection = simpleOpen(server);
+
+        boolean result = imapConnection.isQresyncCapable();
+
+        assertFalse(result);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void isQresyncCapable_withQresyncCapability() throws Exception {
+        MockImapServer server = new MockImapServer();
+        simpleOpenWithQresyncEnabled(server);
+        ImapConnection imapConnection = startServerAndCreateImapConnection(server);
+        imapConnection.open();
+
+        boolean result = imapConnection.isQresyncCapable();
+
+        assertTrue(result);
+
+        server.shutdown();
+    }
+
+    @Test
     public void sendContinuation() throws Exception {
         settings.setAuthType(AuthType.PLAIN);
         MockImapServer server = new MockImapServer();
@@ -901,6 +974,18 @@ public class ImapConnectionTest {
         server.verifyInteractionCompleted();
     }
 
+    @Test
+    public void enableQresync_withQresyncAlreadyEnabled_shouldNotSendEnableCommand() throws Exception {
+        MockImapServer server = new MockImapServer();
+        simpleOpenWithQresyncEnabled(server);
+        ImapConnection imapConnection = startServerAndCreateImapConnection(server);
+        imapConnection.open();
+
+        imapConnection.enableQresync();
+
+        server.verifyConnectionStillOpen();
+        server.verifyInteractionCompleted();
+    }
 
     private ImapConnection createImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
             ConnectivityManager connectivityManager, OAuth2TokenProvider oAuth2TokenProvider) {
@@ -973,6 +1058,14 @@ public class ImapConnectionTest {
 
         server.expect("2 LOGIN \"" + USERNAME + "\" \"" + PASSWORD + "\"");
         server.output("2 OK [CAPABILITY " + postAuthCapabilities + "] LOGIN completed");
+    }
+
+    private void simpleOpenWithQresyncEnabled(MockImapServer server) {
+        simplePreAuthAndLoginDialog(server, "CONDSTORE QRESYNC ENABLE");
+        server.expect("3 ENABLE CONDSTORE QRESYNC");
+        server.output("* ENABLED CONDSTORE QRESYNC");
+        server.output("3 OK command completed");
+        simplePostAuthenticationDialog(server, 4);
     }
 
     private OAuth2TokenProvider createOAuth2TokenProvider() throws AuthenticationFailedException {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -462,7 +462,7 @@ public class ImapFolderTest {
     public void getUnreadMessageCount_connectionThrowsIOException_shouldThrowMessagingException() throws Exception {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RW);
-        when(imapConnection.executeSimpleCommand("UID SEARCH 1:* NOT SEEN NOT DELETED")).thenThrow(new IOException());
+        when(imapConnection.executeSimpleCommand("UID SEARCH 1:* NOT DELETED NOT SEEN")).thenThrow(new IOException());
         folder.open(OPEN_MODE_RW);
 
         try {
@@ -478,7 +478,7 @@ public class ImapFolderTest {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RW);
         List<ImapResponse> imapResponses = singletonList(createImapResponse("* SEARCH 1 2 3"));
-        when(imapConnection.executeSimpleCommand("UID SEARCH 1:* NOT SEEN NOT DELETED")).thenReturn(imapResponses);
+        when(imapConnection.executeSimpleCommand("UID SEARCH 1:* NOT DELETED NOT SEEN")).thenReturn(imapResponses);
         folder.open(OPEN_MODE_RW);
 
         int unreadMessageCount = folder.getUnreadMessageCount();
@@ -1234,6 +1234,8 @@ public class ImapFolderTest {
         } else {
             when(imapConnection.executeSimpleCommand("EXAMINE \"Folder\"")).thenReturn(imapResponses);
         }
+        when(imapConnection.executeSimpleCommand("NOOP")).thenReturn(
+                createImapResponse(Collections.singletonList("3 OK")));
     }
 
     private void assertCheckOpenErrorMessage(String folderName, MessagingException e) {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
@@ -5,15 +5,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 
-import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.filter.PeekableInputStream;
-
-import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
-import static java.util.Arrays.asList;
 
 
 public class ImapResponseHelper {
@@ -49,50 +42,5 @@ public class ImapResponseHelper {
             ids.add(i);
         }
         return ids;
-    }
-
-    static List<ImapResponse> createFolderOpenedResponse(int openMode, Long uidValidity, Long highestModSeq,
-            List<String> vanishedUids, Map<String, Set<Flag>> fetchResponses) throws IOException {
-        List<ImapResponse> openResponses = new ArrayList<>(asList(
-                createImapResponse("* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk $MDNSent)"),
-                createImapResponse("* OK [PERMANENTFLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk " +
-                        "$MDNSent \\*)] Flags permitted."),
-                createImapResponse("* 23 EXISTS"),
-                createImapResponse("* 0 RECENT"),
-                createImapResponse(String.format(Locale.US, "* OK [UIDVALIDITY %d] UIDs valid", uidValidity)),
-                createImapResponse("* OK [UIDNEXT 57576] Predicted next UID")
-        ));
-
-        String highestModSeqResponse;
-        if (highestModSeq == null) {
-            highestModSeqResponse = "* OK [NOMODSEQ] Sorry, this mailbox format doesn't support modsequences";
-        } else {
-            highestModSeqResponse = String.format(Locale.US,
-                    "* OK [HIGHESTMODSEQ %d] Highest mailbox mod-sequence", highestModSeq);
-        }
-        openResponses.add(createImapResponse(highestModSeqResponse));
-
-        if (vanishedUids != null || fetchResponses != null) {
-            if (vanishedUids != null) {
-                String vanishedUidsString = ImapUtility.join(",", vanishedUids);
-                openResponses.add(createImapResponse(String.format("* VANISHED (EARLIER) %s", vanishedUidsString)));
-            }
-
-            if (highestModSeq != null && fetchResponses != null) {
-                int seqNum = 30;
-                for (Map.Entry<String, Set<Flag>> fetchResponse : fetchResponses.entrySet()) {
-                    String fetchResponseString = String.format(Locale.US, "* %d FETCH (UID %s FLAGS (%s) MODSEQ (%d))",
-                            ++seqNum, fetchResponse.getKey(), ImapUtility.combineFlags(fetchResponse.getValue(), false),
-                            highestModSeq--);
-                    openResponses.add(createImapResponse(fetchResponseString));
-                }
-            }
-        }
-
-        ImapResponse finishedResponse = (openMode == OPEN_MODE_RW) ?
-                createImapResponse("2 OK [READ-WRITE] Select completed.") :
-                createImapResponse("2 OK [READ-ONLY] Examine completed.");
-        openResponses.add(finishedResponse);
-        return openResponses;
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
@@ -5,8 +5,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
+import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.filter.PeekableInputStream;
+
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
+import static java.util.Arrays.asList;
 
 
 public class ImapResponseHelper {
@@ -42,5 +49,50 @@ public class ImapResponseHelper {
             ids.add(i);
         }
         return ids;
+    }
+
+    static List<ImapResponse> createFolderOpenedResponse(int openMode, Long uidValidity, Long highestModSeq,
+            List<String> vanishedUids, Map<String, Set<Flag>> fetchResponses) throws IOException {
+        List<ImapResponse> openResponses = new ArrayList<>(asList(
+                createImapResponse("* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk $MDNSent)"),
+                createImapResponse("* OK [PERMANENTFLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk " +
+                        "$MDNSent \\*)] Flags permitted."),
+                createImapResponse("* 23 EXISTS"),
+                createImapResponse("* 0 RECENT"),
+                createImapResponse(String.format(Locale.US, "* OK [UIDVALIDITY %d] UIDs valid", uidValidity)),
+                createImapResponse("* OK [UIDNEXT 57576] Predicted next UID")
+        ));
+
+        String highestModSeqResponse;
+        if (highestModSeq == null) {
+            highestModSeqResponse = "* OK [NOMODSEQ] Sorry, this mailbox format doesn't support modsequences";
+        } else {
+            highestModSeqResponse = String.format(Locale.US,
+                    "* OK [HIGHESTMODSEQ %d] Highest mailbox mod-sequence", highestModSeq);
+        }
+        openResponses.add(createImapResponse(highestModSeqResponse));
+
+        if (vanishedUids != null || fetchResponses != null) {
+            if (vanishedUids != null) {
+                String vanishedUidsString = ImapUtility.join(",", vanishedUids);
+                openResponses.add(createImapResponse(String.format("* VANISHED (EARLIER) %s", vanishedUidsString)));
+            }
+
+            if (highestModSeq != null && fetchResponses != null) {
+                int seqNum = 30;
+                for (Map.Entry<String, Set<Flag>> fetchResponse : fetchResponses.entrySet()) {
+                    String fetchResponseString = String.format(Locale.US, "* %d FETCH (UID %s FLAGS (%s) MODSEQ (%d))",
+                            ++seqNum, fetchResponse.getKey(), ImapUtility.combineFlags(fetchResponse.getValue(), false),
+                            highestModSeq--);
+                    openResponses.add(createImapResponse(fetchResponseString));
+                }
+            }
+        }
+
+        ImapResponse finishedResponse = (openMode == OPEN_MODE_RW) ?
+                createImapResponse("2 OK [READ-WRITE] Select completed.") :
+                createImapResponse("2 OK [READ-ONLY] Examine completed.");
+        openResponses.add(finishedResponse);
+        return openResponses;
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapUtilityTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapUtilityTest.java
@@ -17,14 +17,27 @@
 
 package com.fsck.k9.mail.store.imap;
 
-import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-
+import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(K9LibRobolectricTestRunner.class)
@@ -145,5 +158,66 @@ public class ImapUtilityTest  {
         expected = new String[0];
         actual = ImapUtility.getImapRangeValues("1:*");
         assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void setMessageFlags() throws Exception {
+        ImapList fetchList = createImapResponse("(UID 4 MODSEQ (65402) FLAGS (\\Seen $Forwarded))");
+        ImapMessage message = mock(ImapMessage.class);
+        ImapStore store = mock(ImapStore.class);
+        Set<Flag> permanentFlagsIndex = new HashSet<>(0);
+        when(store.getPermanentFlagsIndex()).thenReturn(permanentFlagsIndex);
+
+        ImapUtility.setMessageFlags(fetchList, message, store);
+
+        verify(message).setFlagInternal(Flag.SEEN, true);
+        verify(message).setFlagInternal(Flag.FORWARDED, true);
+        assertEquals(permanentFlagsIndex, Collections.singleton(Flag.FORWARDED));
+    }
+
+    @Test
+    public void extractHighestModSeq_withHighestModSeqResponse_shouldReturnRespectiveValue() throws Exception {
+        ImapResponse response = createImapResponse("* OK [HIGHESTMODSEQ 715194045007]");
+
+        Long highestModSeq = ImapUtility.extractHighestModSeq(response);
+
+        assertNotNull(highestModSeq);
+        assertEquals(highestModSeq.longValue(), 715194045007L);
+    }
+
+    @Test
+    public void extractHighestModSeq_withNoModSeqResponse_shouldReturnNull() throws Exception {
+        ImapResponse response = createImapResponse("* OK [NOMODSEQ] Sorry, this mailbox doesn't support modsequences");
+
+        Long highestModSeq = ImapUtility.extractHighestModSeq(response);
+
+        assertNull(highestModSeq);
+    }
+
+    @Test
+    public void extractHighestModSeq_withoutModSeqResponse_shouldReturnNull() throws Exception {
+        ImapResponse response = createImapResponse("* OK [UIDNEXT 4392] Predicted next UID");
+
+        Long highestModSeq = ImapUtility.extractHighestModSeq(response);
+
+        assertNull(highestModSeq);
+    }
+
+    @Test
+    public void extractVanishedUids_withVanishedResponse_shouldReturnRespectiveValues() throws Exception {
+        List<ImapResponse> response = singletonList(createImapResponse("* VANISHED 505,507,510,625"));
+
+        List<String> expungedUids = ImapUtility.extractVanishedUids(response);
+
+        assertEquals(expungedUids, asList("505", "507", "510", "625"));
+    }
+
+    @Test
+    public void extractVanishedUids_withVanishedEarlierResponse_shouldReturnRespectiveValues() throws Exception {
+        List<ImapResponse> response = singletonList(createImapResponse("* VANISHED (EARLIER) 505,507,510,625"));
+
+        List<String> expungedUids = ImapUtility.extractVanishedUids(response);
+
+        assertEquals(expungedUids, asList("505", "507", "510", "625"));
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/QresyncParamResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/QresyncParamResponseTest.java
@@ -1,0 +1,38 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fsck.k9.mail.Flag;
+import org.junit.Test;
+
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+
+public class QresyncParamResponseTest {
+
+    @Test
+    public void fromSelectOrExamineResponse_shouldParseResponseCorrectly() throws Exception {
+        List<String> expungedUids = asList("3", "4");
+        Map<String, Set<Flag>> modifiedMessages = singletonMap("15", singleton(Flag.SEEN));
+        List<ImapResponse> selectOrExamineResponse = ImapResponseHelper.createFolderOpenedResponse(OPEN_MODE_RW, 1L, 2L,
+                expungedUids, modifiedMessages);
+
+        QresyncParamResponse response = QresyncParamResponse.fromSelectOrExamineResponse(selectOrExamineResponse,
+                mock(ImapFolder.class));
+
+        assertNotNull(response);
+        assertEquals(response.getExpungedUids(), expungedUids);
+        ImapMessage modifiedMessage = response.getModifiedMessages().get(0);
+        assertEquals(modifiedMessage.getUid(), "15");
+        assertEquals(modifiedMessage.getFlags(), singleton(Flag.SEEN));
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/QresyncParamResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/QresyncParamResponseTest.java
@@ -2,16 +2,10 @@ package com.fsck.k9.mail.store.imap;
 
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import com.fsck.k9.mail.Flag;
 import org.junit.Test;
 
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -21,18 +15,16 @@ public class QresyncParamResponseTest {
 
     @Test
     public void fromSelectOrExamineResponse_shouldParseResponseCorrectly() throws Exception {
-        List<String> expungedUids = asList("3", "4");
-        Map<String, Set<Flag>> modifiedMessages = singletonMap("15", singleton(Flag.SEEN));
-        List<ImapResponse> selectOrExamineResponse = ImapResponseHelper.createFolderOpenedResponse(OPEN_MODE_RW, 1L, 2L,
-                expungedUids, modifiedMessages);
+        SelectOrExamineResponseDataFixture dataFixture = SelectOrExamineResponseDataFixture.getDefaultInstance();
+        List<ImapResponse> selectOrExamineResponse = dataFixture.createForQresyncParam(OPEN_MODE_RW, false);
 
         QresyncParamResponse response = QresyncParamResponse.fromSelectOrExamineResponse(selectOrExamineResponse,
                 mock(ImapFolder.class));
 
         assertNotNull(response);
-        assertEquals(response.getExpungedUids(), expungedUids);
+        assertEquals(response.getExpungedUids(), SelectOrExamineResponseDataFixture.TEST_EXPUNGED_UIDS);
         ImapMessage modifiedMessage = response.getModifiedMessages().get(0);
-        assertEquals(modifiedMessage.getUid(), "15");
-        assertEquals(modifiedMessage.getFlags(), singleton(Flag.SEEN));
+        assertEquals(modifiedMessage.getUid(), SelectOrExamineResponseDataFixture.TEST_MODIFIED_MESSAGE_UID);
+        assertEquals(modifiedMessage.getFlags(), SelectOrExamineResponseDataFixture.TEST_MODIFIED_MESSAGE_FLAGS);
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommandTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineCommandTest.java
@@ -1,0 +1,49 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import org.junit.Test;
+
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RO;
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
+import static org.junit.Assert.assertEquals;
+
+
+public class SelectOrExamineCommandTest {
+
+    @Test
+    public void createCommandString_withReadWriteMode_shouldReturnRespectiveString() throws Exception {
+        SelectOrExamineCommand command = SelectOrExamineCommand.create(OPEN_MODE_RW, "\"Folder\"");
+
+        String commandString = command.createCommandString();
+
+        assertEquals(commandString, "SELECT \"Folder\"");
+    }
+
+    @Test
+    public void createCommandString_withReadOnlyMode_shouldReturnRespectiveString() throws Exception {
+        SelectOrExamineCommand command = SelectOrExamineCommand.create(OPEN_MODE_RO, "\"Folder\"");
+
+        String commandString = command.createCommandString();
+
+        assertEquals(commandString, "EXAMINE \"Folder\"");
+    }
+
+    @Test
+    public void createCommandString_withOpenUsingCondstoreParam_shouldReturnRespectiveString() throws Exception {
+        SelectOrExamineCommand command = SelectOrExamineCommand.createWithCondstoreParameter(OPEN_MODE_RW, "\"Folder\"");
+
+        String commandString = command.createCommandString();
+
+        assertEquals(commandString, "SELECT \"Folder\" (CONDSTORE)");
+    }
+
+    @Test
+    public void createCommandString_withOpenUsingQresyncParam_shouldReturnRespectiveString() throws Exception {
+        SelectOrExamineCommand command = SelectOrExamineCommand.createWithQresyncParameter(OPEN_MODE_RW, "\"Folder\"",
+                123456L, 123456789L);
+
+        String commandString = command.createCommandString();
+
+        assertEquals(commandString, "SELECT \"Folder\" (QRESYNC (123456 123456789))");
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseDataFixture.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseDataFixture.java
@@ -1,0 +1,121 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.fsck.k9.mail.Flag;
+
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
+import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+
+
+class SelectOrExamineResponseDataFixture {
+
+    static final int TEST_MESSAGE_COUNT = 23;
+    static final long TEST_CURRENT_UID_VALIDITY = 1234567L;
+    static final long TEST_CURRENT_HIGHEST_MOD_SEQ = 10045679000L;
+    static final List<String> TEST_EXPUNGED_UIDS = asList("10056", "10078");
+    static final String TEST_MODIFIED_MESSAGE_UID = "10099";
+    static final Set<Flag> TEST_MODIFIED_MESSAGE_FLAGS = new HashSet<>(asList(Flag.SEEN, Flag.FLAGGED));
+    static final Map<String, Set<Flag>> TEST_MODIFIED_MESSAGE_DATA = singletonMap(TEST_MODIFIED_MESSAGE_UID,
+            TEST_MODIFIED_MESSAGE_FLAGS);
+
+    private int messageCount = TEST_MESSAGE_COUNT;
+    private Long currentUidValidity = TEST_CURRENT_UID_VALIDITY;
+    private Long currentHighestModSeq = TEST_CURRENT_HIGHEST_MOD_SEQ;
+    private List<String> expungedUids = TEST_EXPUNGED_UIDS;
+    private Map<String, Set<Flag>> modifiedMessageData = TEST_MODIFIED_MESSAGE_DATA;
+
+    static SelectOrExamineResponseDataFixture getDefaultInstance() {
+        return new SelectOrExamineResponseDataFixture();
+    }
+
+    private SelectOrExamineResponseDataFixture() {
+    }
+
+    List<ImapResponse> create(int openMode) throws IOException {
+        currentHighestModSeq = null;
+        expungedUids = null;
+        modifiedMessageData = null;
+        return createWithMode(openMode);
+    }
+
+    List<ImapResponse> createForCondstoreParam(int openMode, boolean noModSeq) throws IOException {
+        if (noModSeq) {
+            currentHighestModSeq = null;
+        }
+        expungedUids = null;
+        modifiedMessageData = null;
+        return createWithMode(openMode);
+    }
+
+    List<ImapResponse> createForQresyncParam(int openMode, boolean noModSeq) throws IOException {
+        if (noModSeq) {
+            currentHighestModSeq = null;
+        }
+        return createWithMode(openMode);
+    }
+
+    List<ImapResponse> createWithTaggedResponse(String lastLine) throws IOException {
+        List<ImapResponse> response = createUntaggedOpenResponse();
+        response.add(createImapResponse(lastLine));
+        return response;
+    }
+
+    private List<ImapResponse> createWithMode(int openMode) throws IOException {
+        List<ImapResponse> response = createUntaggedOpenResponse();
+        ImapResponse finishedResponse = (openMode == OPEN_MODE_RW) ?
+                createImapResponse("2 OK [READ-WRITE] Select completed.") :
+                createImapResponse("2 OK [READ-ONLY] Examine completed.");
+        response.add(finishedResponse);
+        return response;
+    }
+
+    private List<ImapResponse> createUntaggedOpenResponse() throws IOException {
+        List<ImapResponse> openResponse = new ArrayList<>(asList(
+                createImapResponse("* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk $MDNSent)"),
+                createImapResponse("* OK [PERMANENTFLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk " +
+                        "$MDNSent \\*)] Flags permitted."),
+                createImapResponse(String.format(Locale.US, "* %d EXISTS", messageCount)),
+                createImapResponse("* 0 RECENT"),
+                createImapResponse(String.format(Locale.US, "* OK [UIDVALIDITY %d] UIDs valid", currentUidValidity)),
+                createImapResponse("* OK [UIDNEXT 57576] Predicted next UID")
+        ));
+
+        String highestModSeqResponse;
+        if (currentHighestModSeq == null) {
+            highestModSeqResponse = "* OK [NOMODSEQ] Sorry, this mailbox format doesn't support modsequences";
+        } else {
+            highestModSeqResponse = String.format(Locale.US,
+                    "* OK [HIGHESTMODSEQ %d] Highest mailbox mod-sequence", currentHighestModSeq);
+        }
+        openResponse.add(createImapResponse(highestModSeqResponse));
+
+        if (expungedUids != null || modifiedMessageData != null) {
+            if (expungedUids != null) {
+                String vanishedUidsString = ImapUtility.join(",", expungedUids);
+                openResponse.add(createImapResponse(String.format("* VANISHED (EARLIER) %s", vanishedUidsString)));
+            }
+
+            if (currentHighestModSeq != null && modifiedMessageData != null) {
+                int seqNum = 30;
+                for (Map.Entry<String, Set<Flag>> modifiedMessage : modifiedMessageData.entrySet()) {
+                    String fetchResponseString = String.format(Locale.US, "* %d FETCH (UID %s FLAGS (%s) MODSEQ (%d))",
+                            ++seqNum, modifiedMessage.getKey(),
+                            ImapUtility.combineFlags(modifiedMessage.getValue(), false), currentHighestModSeq--);
+                    openResponse.add(createImapResponse(fetchResponseString));
+                }
+            }
+        }
+
+        return openResponse;
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
@@ -28,10 +28,8 @@ public class SelectOrExamineResponseTest {
 
     @Before
     public void setup() throws Exception {
-        ImapStore store = mock(ImapStore.class);
-        when(store.getPermanentFlagsIndex()).thenReturn(TEST_PERMANENT_FLAGS);
         folder = mock(ImapFolder.class);
-        when(folder.getStore()).thenReturn(store);
+        when(folder.getPermanentFlags()).thenReturn(TEST_PERMANENT_FLAGS);
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
@@ -1,23 +1,67 @@
 package com.fsck.k9.mail.store.imap;
 
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fsck.k9.mail.Flag;
+import org.junit.Before;
 import org.junit.Test;
 
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RO;
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class SelectOrExamineResponseTest {
-    @Test
-    public void parse_withSelectResponse_shouldReturnOpenModeReadWrite() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK [READ-WRITE] Select completed.");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+    private static final long TEST_UIDVALIDITY = 1125022061L;
+    private static final long TEST_HIGHESTMODSEQ = 345678912L;
+    private static final Set<Flag> TEST_PERMANENT_FLAGS = new HashSet<>(0);
+
+    private ImapFolder folder;
+
+    @Before
+    public void setup() throws Exception {
+        ImapStore store = mock(ImapStore.class);
+        when(store.getPermanentFlagsIndex()).thenReturn(TEST_PERMANENT_FLAGS);
+        folder = mock(ImapFolder.class);
+        when(folder.getStore()).thenReturn(store);
+        when(folder.supportsQresync()).thenReturn(true);
+    }
+
+    @Test
+    public void newInstance_withSelectResponse_shouldParseAllFieldsCorrectly() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("1 OK [READ-WRITE] mailbox selected");
+
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
+
+        assertNotNull(result);
+        assertEquals(result.getUidValidity(), TEST_UIDVALIDITY);
+        assertEquals(result.getHighestModSeq(), TEST_HIGHESTMODSEQ);
+        assertEquals(TEST_PERMANENT_FLAGS.size(), 4);
+        assertEquals(result.canCreateKeywords(), true);
+        assertNotNull(result.getQresyncParamResponse());
+        assertEquals(result.getQresyncParamResponse().getExpungedUids().size(), 6);
+        assertEquals(result.getQresyncParamResponse().getModifiedMessages().size(), 2);
+        assertEquals(true, result.hasOpenMode());
+        assertEquals(OPEN_MODE_RW, result.getOpenMode());
+    }
+
+    @Test
+    public void newInstance_withSelectResponse_shouldReturnOpenModeReadWrite() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK [READ-WRITE] Select completed.");
+
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNotNull(result);
         assertEquals(true, result.hasOpenMode());
@@ -25,10 +69,10 @@ public class SelectOrExamineResponseTest {
     }
 
     @Test
-    public void parse_withExamineResponse_shouldReturnOpenModeReadOnly() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK [READ-ONLY] Examine completed.");
+    public void newInstance_withExamineResponse_shouldReturnOpenModeReadOnly() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK [READ-ONLY] Examine completed.");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNotNull(result);
         assertEquals(true, result.hasOpenMode());
@@ -36,10 +80,10 @@ public class SelectOrExamineResponseTest {
     }
 
     @Test
-    public void parse_withoutResponseCode_shouldReturnHasOpenModeFalse() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK Select completed.");
+    public void newInstance_withoutResponseCode_shouldReturnHasOpenModeFalse() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK Select completed.");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNotNull(result);
         assertEquals(false, result.hasOpenMode());
@@ -47,10 +91,11 @@ public class SelectOrExamineResponseTest {
 
     @Test
     public void getOpenMode_withoutResponseCode_shouldThrow() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK Select completed.");
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
-        assertNotNull(result);
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK Select completed.");
 
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
+
+        assertNotNull(result);
         try {
             result.getOpenMode();
             fail("Expected exception");
@@ -59,40 +104,57 @@ public class SelectOrExamineResponseTest {
     }
 
     @Test
-    public void parse_withInvalidResponseText_shouldReturnHasOpenModeFalse() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK [()] Examine completed.");
+    public void newInstance_withInvalidResponseText_shouldReturnHasOpenModeFalse() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK [()] Examine completed.");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
-
-        assertNotNull(result);
-        assertEquals(false, result.hasOpenMode());
-    }
-
-    @Test
-    public void parse_withUnknownResponseText_shouldReturnHasOpenModeFalse() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x OK [FUNKY] Examine completed.");
-
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNotNull(result);
         assertEquals(false, result.hasOpenMode());
     }
 
     @Test
-    public void parse_withUntaggedResponse_shouldReturnNull() throws Exception {
-        ImapResponse imapResponse = createImapResponse("* OK [READ-WRITE] Select completed.");
+    public void newInstance_withUnknownResponseText_shouldReturnHasOpenModeFalse() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x OK [FUNKY] Examine completed.");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
+
+        assertNotNull(result);
+        assertEquals(false, result.hasOpenMode());
+    }
+
+    @Test
+    public void newInstance_withUntaggedResponse_shouldReturnNull() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("* OK [READ-WRITE] Select completed.");
+
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNull(result);
     }
 
     @Test
-    public void parse_withoutOkResponse_shouldReturnNull() throws Exception {
-        ImapResponse imapResponse = createImapResponse("x BYE");
+    public void newInstance_withoutOkResponse_shouldReturnNull() throws Exception {
+        List<ImapResponse> imapResponses = createMockImapResponses("x BYE");
 
-        SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
+        SelectOrExamineResponse result = SelectOrExamineResponse.newInstance(imapResponses, folder);
 
         assertNull(result);
+    }
+
+    private static List<ImapResponse> createMockImapResponses(String lastLine) throws IOException {
+        return asList(
+                createImapResponse("* 23 EXISTS"),
+                createImapResponse("* 0 RECENT"),
+                createImapResponse("* OK [UIDVALIDITY " + TEST_UIDVALIDITY + "] UIDs valid"),
+                createImapResponse("* OK [UIDNEXT 57576] Predicted next UID"),
+                createImapResponse("* OK [HIGHESTMODSEQ " + TEST_HIGHESTMODSEQ + "] Highest mailbox mod-sequence"),
+                createImapResponse("* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk $MDNSent)"),
+                createImapResponse("* OK [PERMANENTFLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft NonJunk " +
+                        "$MDNSent \\*)] Flags permitted."),
+                createImapResponse("* VANISHED (EARLIER) 41,200,230:233"),
+                createImapResponse("* 49 FETCH (UID 117 FLAGS (\\Seen \\Answered) MODSEQ (90060115194045001))"),
+                createImapResponse("* 50 FETCH (UID 119 FLAGS (\\Draft $MDNSent) MODSEQ (90060115194045308))"),
+                createImapResponse(lastLine)
+        );
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
@@ -36,7 +36,7 @@ public class SelectOrExamineResponseTest {
         when(store.getPermanentFlagsIndex()).thenReturn(TEST_PERMANENT_FLAGS);
         folder = mock(ImapFolder.class);
         when(folder.getStore()).thenReturn(store);
-        when(folder.supportsQresync()).thenReturn(true);
+        when(folder.doesConnectionSupportQresync()).thenReturn(true);
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommandTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommandTest.java
@@ -2,6 +2,7 @@ package com.fsck.k9.mail.store.imap.selectedstate.command;
 
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.FetchProfile.Item;
@@ -106,8 +107,8 @@ public class UidFetchCommandTest {
         return new UidFetchCommand.Builder()
                 .maximumAutoDownloadMessageSize(maximumAutoDownloadMessageSize)
                 .idSet(Collections.singletonList(uid))
-                .messageParams(fetchProfile, Collections.singletonMap(String.valueOf(uid),
-                        (Message) createImapMessage(String.valueOf(uid))))
+                .messageParams(fetchProfile, new HashMap<>(Collections.singletonMap(String.valueOf(uid),
+                        (Message) createImapMessage(String.valueOf(uid)))))
                 .build();
     }
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommandTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidFetchCommandTest.java
@@ -2,7 +2,6 @@ package com.fsck.k9.mail.store.imap.selectedstate.command;
 
 
 import java.util.Collections;
-import java.util.HashMap;
 
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.FetchProfile.Item;
@@ -107,8 +106,8 @@ public class UidFetchCommandTest {
         return new UidFetchCommand.Builder()
                 .maximumAutoDownloadMessageSize(maximumAutoDownloadMessageSize)
                 .idSet(Collections.singletonList(uid))
-                .messageParams(fetchProfile, new HashMap<>(Collections.singletonMap(String.valueOf(uid),
-                        (Message) createImapMessage(String.valueOf(uid)))))
+                .messageParams(fetchProfile, Collections.singletonMap(String.valueOf(uid),
+                        (Message) createImapMessage(String.valueOf(uid))))
                 .build();
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -164,6 +164,8 @@ public class K9 extends Application {
      */
     private static SharedPreferences sDatabaseVersionCache;
 
+    private static boolean useCondstore = true;
+    private static boolean useQresync = true;
     private static boolean mAnimations = true;
 
     private static boolean mConfirmDelete = false;
@@ -443,6 +445,8 @@ public class K9 extends Application {
         editor.putBoolean("enableDebugLogging", K9.DEBUG);
         editor.putBoolean("enableSensitiveLogging", K9.DEBUG_SENSITIVE);
         editor.putString("backgroundOperations", K9.backgroundOps.name());
+        editor.putBoolean("useCondstore", useCondstore);
+        editor.putBoolean("useQresync", useQresync);
         editor.putBoolean("animations", mAnimations);
         editor.putBoolean("gesturesEnabled", mGesturesEnabled);
         editor.putBoolean("useVolumeKeysForNavigation", mUseVolumeKeysForNavigation);
@@ -532,6 +536,19 @@ public class K9 extends Application {
 
             @Override public boolean debugSensitive() {
                 return DEBUG_SENSITIVE;
+            }
+        });
+
+        K9MailLib.setImapExtensionStatus(new K9MailLib.ImapExtensionStatus() {
+
+            @Override
+            public boolean useCondstore() {
+                return useCondstore;
+            }
+
+            @Override
+            public boolean useQresync() {
+                return useQresync;
             }
         });
 
@@ -675,6 +692,8 @@ public class K9 extends Application {
         Storage storage = prefs.getStorage();
         setDebug(storage.getBoolean("enableDebugLogging", BuildConfig.DEVELOPER_MODE));
         DEBUG_SENSITIVE = storage.getBoolean("enableSensitiveLogging", false);
+        useCondstore = storage.getBoolean("useCondstore", true);
+        useQresync = storage.getBoolean("useQresync", true);
         mAnimations = storage.getBoolean("animations", true);
         mGesturesEnabled = storage.getBoolean("gesturesEnabled", false);
         mUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false);
@@ -1033,6 +1052,22 @@ public class K9 extends Application {
 
     public static void setStartIntegratedInbox(boolean startIntegratedInbox) {
         mStartIntegratedInbox = startIntegratedInbox;
+    }
+
+    public static boolean shouldUseCondstore() {
+        return useCondstore;
+    }
+
+    public static void setUseCondstore(boolean useCondstore) {
+        K9.useCondstore = useCondstore;
+    }
+
+    public static boolean shouldUseQresync() {
+        return useQresync;
+    }
+
+    public static void setUseQresync(boolean useQresync) {
+        K9.useQresync = useQresync;
     }
 
     public static boolean showAnimations() {

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -37,6 +37,7 @@ import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.ssl.LocalKeyStore;
+import com.fsck.k9.mail.store.imap.ImapConfig;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
@@ -539,7 +540,7 @@ public class K9 extends Application {
             }
         });
 
-        K9MailLib.setImapExtensionStatus(new K9MailLib.ImapExtensionStatus() {
+        ImapConfig.setExtensionStatus(new ImapConfig.ExtensionStatus() {
 
             @Override
             public boolean useCondstore() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -229,7 +229,7 @@ public class FolderList extends K9ListActivity {
                 wakeLock.release();
             }
         };
-        MessagingController.getInstance(getApplication()).synchronizeMailbox(mAccount, folder.name, listener, null);
+        MessagingController.getInstance(getApplication()).synchronizeMailbox(mAccount, folder.name, listener);
         sendMail(mAccount);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -501,7 +501,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             }
             MessagingController.getInstance(getApplication()).listFoldersSynchronous(account, true, null);
             MessagingController.getInstance(getApplication())
-                    .synchronizeMailbox(account, account.getInboxFolderName(), null, null);
+                    .synchronizeMailbox(account, account.getInboxFolderName(), null);
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceScreen;
 import android.text.TextUtils;
@@ -94,6 +95,8 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_BACKGROUND_OPS = "background_ops";
     private static final String PREFERENCE_DEBUG_LOGGING = "debug_logging";
     private static final String PREFERENCE_SENSITIVE_LOGGING = "sensitive_logging";
+    private static final String PREFERENCE_DO_NOT_USE_CONDSTORE = "condstore_extension";
+    private static final String PREFERENCE_DO_NOT_USE_QRESYNC = "qresync_extension";
 
     private static final String PREFERENCE_ATTACHMENT_DEF_PATH = "attachment_default_path";
     private static final String PREFERENCE_BACKGROUND_AS_UNREAD_INDICATOR = "messagelist_background_as_unread_indicator";
@@ -143,6 +146,8 @@ public class Prefs extends K9PreferenceActivity {
     private ListPreference mBackgroundOps;
     private CheckBoxPreference mDebugLogging;
     private CheckBoxPreference mSensitiveLogging;
+    private CheckBoxPreference doNotUseCondstore;
+    private CheckBoxPreference doNotUseQresync;
     private CheckBoxPreference mHideUserAgent;
     private CheckBoxPreference mHideTimeZone;
     private CheckBoxPreference mWrapFolderNames;
@@ -354,11 +359,33 @@ public class Prefs extends K9PreferenceActivity {
 
         mDebugLogging = (CheckBoxPreference)findPreference(PREFERENCE_DEBUG_LOGGING);
         mSensitiveLogging = (CheckBoxPreference)findPreference(PREFERENCE_SENSITIVE_LOGGING);
+        doNotUseCondstore = (CheckBoxPreference) findPreference(PREFERENCE_DO_NOT_USE_CONDSTORE);
+        doNotUseQresync = (CheckBoxPreference) findPreference(PREFERENCE_DO_NOT_USE_QRESYNC);
         mHideUserAgent = (CheckBoxPreference)findPreference(PREFERENCE_HIDE_USERAGENT);
         mHideTimeZone = (CheckBoxPreference)findPreference(PREFERENCE_HIDE_TIMEZONE);
 
         mDebugLogging.setChecked(K9.isDebug());
         mSensitiveLogging.setChecked(K9.DEBUG_SENSITIVE);
+        doNotUseCondstore.setChecked(!K9.shouldUseCondstore());
+        doNotUseCondstore.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (newValue instanceof Boolean && (Boolean) newValue) {
+                    doNotUseQresync.setChecked(true);
+                }
+                return true;
+            }
+        });
+        doNotUseQresync.setChecked(!K9.shouldUseQresync());
+        doNotUseQresync.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (newValue instanceof Boolean && !(Boolean) newValue) {
+                    doNotUseCondstore.setChecked(false);
+                }
+                return true;
+            }
+        });
         mHideUserAgent.setChecked(K9.hideUserAgent());
         mHideTimeZone.setChecked(K9.hideTimeZone());
 
@@ -534,6 +561,8 @@ public class Prefs extends K9PreferenceActivity {
         }
         K9.setDebug(mDebugLogging.isChecked());
         K9.DEBUG_SENSITIVE = mSensitiveLogging.isChecked();
+        K9.setUseCondstore(!doNotUseCondstore.isChecked());
+        K9.setUseQresync(!doNotUseQresync.isChecked());
         K9.setHideUserAgent(mHideUserAgent.isChecked());
         K9.setHideTimeZone(mHideTimeZone.isChecked());
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
@@ -31,20 +31,22 @@ class FlagSyncHelper {
     private final MessagingController controller;
     private final Contacts contacts;
     private final NotificationController notificationController;
+    private final SyncHelper syncHelper;
 
-    public static FlagSyncHelper newInstance(Context context, MessagingController controller) {
+    public static FlagSyncHelper newInstance(Context context, MessagingController controller, SyncHelper syncHelper) {
         Context appContext = context.getApplicationContext();
         Contacts contacts = Contacts.getInstance(context);
         NotificationController notificationController = NotificationController.newInstance(appContext);
-        return new FlagSyncHelper(appContext, controller, contacts, notificationController);
+        return new FlagSyncHelper(appContext, controller, contacts, notificationController, syncHelper);
     }
 
     private FlagSyncHelper(Context context, MessagingController controller, Contacts contacts,
-            NotificationController notificationController) {
+            NotificationController notificationController, SyncHelper syncHelper) {
         this.context = context;
         this.controller = controller;
         this.contacts = contacts;
         this.notificationController = notificationController;
+        this.syncHelper = syncHelper;
     }
 
     void refreshLocalMessageFlags(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
@@ -85,12 +87,12 @@ class FlagSyncHelper {
         boolean messageChanged = syncFlags(localMessage, remoteMessage);
         if (messageChanged) {
             boolean shouldBeNotifiedOf = false;
-            if (localMessage.isSet(Flag.DELETED) || SyncUtils.isMessageSuppressed(localMessage, context)) {
+            if (localMessage.isSet(Flag.DELETED) || syncHelper.isMessageSuppressed(localMessage, context)) {
                 for (MessagingListener l : controller.getListeners()) {
                     l.synchronizeMailboxRemovedMessage(account, folderName, localMessage);
                 }
             } else {
-                if (SyncUtils.shouldNotifyForMessage(account, localFolder, localMessage, contacts)) {
+                if (syncHelper.shouldNotifyForMessage(account, localFolder, localMessage, contacts)) {
                     shouldBeNotifiedOf = true;
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
@@ -1,0 +1,126 @@
+package com.fsck.k9.controller;
+
+
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.activity.MessageReference;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.notification.NotificationController;
+import timber.log.Timber;
+
+
+class FlagSyncHelper {
+
+    private static final Set<Flag> SYNC_FLAGS = EnumSet.of(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED);
+
+    private final Context context;
+    private final MessagingController controller;
+    private final Contacts contacts;
+    private final NotificationController notificationController;
+
+    public static FlagSyncHelper newInstance(Context context, MessagingController controller) {
+        Context appContext = context.getApplicationContext();
+        Contacts contacts = Contacts.getInstance(context);
+        NotificationController notificationController = NotificationController.newInstance(appContext);
+        return new FlagSyncHelper(appContext, controller, contacts, notificationController);
+    }
+
+    private FlagSyncHelper(Context context, MessagingController controller, Contacts contacts,
+            NotificationController notificationController) {
+        this.context = context;
+        this.controller = controller;
+        this.contacts = contacts;
+        this.notificationController = notificationController;
+    }
+
+    void refreshLocalMessageFlags(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
+            List<Message> syncFlagMessages) throws MessagingException {
+        final String folderName = remoteFolder.getName();
+        if (remoteFolder.supportsFetchingFlags()) {
+            Timber.d("SYNC: About to sync flags for %d remote messages for folder %s", syncFlagMessages.size(),
+                    folderName);
+
+            FetchProfile fp = new FetchProfile();
+            fp.add(FetchProfile.Item.FLAGS);
+
+            List<Message> undeletedMessages = new LinkedList<>();
+            for (Message message : syncFlagMessages) {
+                if (!message.isSet(Flag.DELETED)) {
+                    undeletedMessages.add(message);
+                }
+            }
+
+            remoteFolder.fetch(undeletedMessages, fp, null);
+
+            final AtomicInteger progress = new AtomicInteger(0);
+            int todo = syncFlagMessages.size();
+            for (Message remoteMessage : syncFlagMessages) {
+                processDownloadedFlags(account, localFolder, remoteMessage);
+                progress.incrementAndGet();
+                for (MessagingListener l : controller.getListeners()) {
+                    l.synchronizeMailboxProgress(account, folderName, progress.get(), todo);
+                }
+            }
+        }
+    }
+
+    void processDownloadedFlags(Account account, LocalFolder localFolder, Message remoteMessage)
+            throws MessagingException {
+        String folderName = localFolder.getName();
+        LocalMessage localMessage = localFolder.getMessage(remoteMessage.getUid());
+        boolean messageChanged = syncFlags(localMessage, remoteMessage);
+        if (messageChanged) {
+            boolean shouldBeNotifiedOf = false;
+            if (localMessage.isSet(Flag.DELETED) || SyncUtils.isMessageSuppressed(localMessage, context)) {
+                for (MessagingListener l : controller.getListeners()) {
+                    l.synchronizeMailboxRemovedMessage(account, folderName, localMessage);
+                }
+            } else {
+                if (SyncUtils.shouldNotifyForMessage(account, localFolder, localMessage, contacts)) {
+                    shouldBeNotifiedOf = true;
+                }
+            }
+
+            // we're only interested in messages that need removing
+            if (!shouldBeNotifiedOf) {
+                MessageReference messageReference = localMessage.makeMessageReference();
+                notificationController.removeNewMailNotification(account, messageReference);
+            }
+        }
+    }
+
+    private boolean syncFlags(LocalMessage localMessage, Message remoteMessage) throws MessagingException {
+        boolean messageChanged = false;
+        if (localMessage == null || localMessage.isSet(Flag.DELETED)) {
+            return false;
+        }
+        if (remoteMessage.isSet(Flag.DELETED)) {
+            if (localMessage.getFolder().syncRemoteDeletions()) {
+                localMessage.setFlag(Flag.DELETED, true);
+                messageChanged = true;
+            }
+        } else {
+            for (Flag flag : SYNC_FLAGS) {
+                if (remoteMessage.isSet(flag) != localMessage.isSet(flag)) {
+                    localMessage.setFlag(flag, remoteMessage.isSet(flag));
+                    messageChanged = true;
+                }
+            }
+        }
+        return messageChanged;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -53,10 +53,8 @@ class ImapSyncInteractor {
                 commandException = e;
             }
 
-            getAndOpenLocalFolder(syncHelper);
+            initialize(syncHelper);
             localFolder.updateLastUid();
-
-            getImapFolder();
 
             if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
                 return;
@@ -205,8 +203,7 @@ class ImapSyncInteractor {
 
     void syncRemoteDeletions(Collection<String> deletedMessageUids, SyncHelper syncHelper) throws IOException,
             MessagingException {
-        getAndOpenLocalFolder(syncHelper);
-        getImapFolder();
+        initialize(syncHelper);
 
         MoreMessages moreMessages = localFolder.getMoreMessages();
 
@@ -231,14 +228,12 @@ class ImapSyncInteractor {
         }
     }
 
-    private void getAndOpenLocalFolder(SyncHelper syncHelper) throws MessagingException {
+    private void initialize(SyncHelper syncHelper) throws MessagingException {
         if (localFolder == null || !localFolder.isOpen()) {
             Timber.v("SYNC: About to get local folder %s and open it", folderName);
             localFolder = syncHelper.getOpenedLocalFolder(account, folderName);
         }
-    }
 
-    private void getImapFolder() throws MessagingException {
         if (imapFolder == null || !imapFolder.isOpen()) {
             Store remoteStore = account.getRemoteStore();
             Timber.v("SYNC: About to get remote folder %s", folderName);

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -110,6 +110,8 @@ class ImapSyncInteractor {
                         listener);
             }
 
+            syncHelper.updateMoreMessages(account, localFolder, imapFolder);
+
             localFolder.setUidValidity(imapFolder.getUidValidity());
             updateHighestModSeqIfNecessary(localFolder, imapFolder);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -88,21 +88,21 @@ class ImapSyncInteractor {
             int remoteMessageCount = imapFolder.getMessageCount();
             if (remoteMessageCount < 0) {
                 throw new IllegalStateException("Message count " + remoteMessageCount + " for folder " + folderName);
-            } else {
-                Timber.v("SYNC: Remote message count for folder %s is %d", folderName, remoteMessageCount);
             }
+
+            Timber.v("SYNC: Remote message count for folder %s is %d", folderName, remoteMessageCount);
 
             handleUidValidity();
             int newMessages;
             if (!qresyncEnabled) {
-                NonQresyncSyncInteractor syncInteractor = new NonQresyncSyncInteractor(account, localFolder, imapFolder,
+                NonQresyncExtensionHandler handler = new NonQresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = syncInteractor.performSync(messageDownloader);
+                newMessages = handler.continueSync(messageDownloader);
             } else {
                 Timber.v("SYNC: QRESYNC extension found and enabled for folder %s", folderName);
-                QresyncSyncInteractor syncInteractor = new QresyncSyncInteractor(account, localFolder, imapFolder,
+                QresyncExtensionHandler handler = new QresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = syncInteractor.performSync(qresyncParamResponse, expungedUids, messageDownloader);
+                newMessages = handler.continueSync(qresyncParamResponse, expungedUids, messageDownloader);
             }
 
             localFolder.setUidValidity(imapFolder.getUidValidity());

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -71,7 +71,7 @@ class ImapSyncInteractor {
 
             QresyncParamResponse qresyncParamResponse;
             Timber.v("SYNC: About to open remote IMAP folder %s", folderName);
-            qresyncParamResponse = imapFolder.open(Folder.OPEN_MODE_RW, localFolder.getUidValidity(),
+            qresyncParamResponse = imapFolder.openUsingQresyncParam(Folder.OPEN_MODE_RW, localFolder.getUidValidity(),
                     localFolder.getHighestModSeq());
 
             boolean qresyncEnabled = qresyncParamResponse != null;

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -39,7 +39,7 @@ class ImapSyncInteractor {
         this.controller = controller;
     }
 
-    void performSync(MessageDownloader messageDownloader) {
+    void performSync(FlagSyncHelper flagSyncHelper, MessageDownloader messageDownloader) {
         Exception commandException = null;
 
         try {
@@ -97,12 +97,12 @@ class ImapSyncInteractor {
             if (!qresyncEnabled) {
                 NonQresyncExtensionHandler handler = new NonQresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = handler.continueSync(messageDownloader);
+                newMessages = handler.continueSync(messageDownloader, flagSyncHelper);
             } else {
                 Timber.v("SYNC: QRESYNC extension found and enabled for folder %s", folderName);
                 QresyncExtensionHandler handler = new QresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = handler.continueSync(qresyncParamResponse, expungedUids, messageDownloader);
+                newMessages = handler.continueSync(qresyncParamResponse, expungedUids, messageDownloader, flagSyncHelper);
             }
 
             localFolder.setUidValidity(imapFolder.getUidValidity());
@@ -210,7 +210,7 @@ class ImapSyncInteractor {
         return remoteStart;
     }
 
-    static void updateHighestModSeqIfNecessary(final LocalFolder localFolder, final Folder remoteFolder)
+    private static void updateHighestModSeqIfNecessary(final LocalFolder localFolder, final Folder remoteFolder)
             throws MessagingException {
         if (remoteFolder instanceof ImapFolder) {
             ImapFolder imapFolder = (ImapFolder) remoteFolder;

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -64,7 +64,7 @@ class ImapSyncInteractor {
 
             QresyncParamResponse qresyncParamResponse = null;
             Timber.v("SYNC: About to open remote IMAP folder %s", folderName);
-            if (localFolder.isCachedUidValidityValid() && localFolder.isCachedHighestModSeqValid()) {
+            if (localFolder.hasCachedUidValidity() && localFolder.isCachedHighestModSeqValid()) {
                 qresyncParamResponse = imapFolder.openUsingQresyncParam(Folder.OPEN_MODE_RW,
                         localFolder.getUidValidity(), localFolder.getHighestModSeq());
             } else {
@@ -174,7 +174,7 @@ class ImapSyncInteractor {
         long cachedUidValidity = localFolder.getUidValidity();
         long currentUidValidity = imapFolder.getUidValidity();
 
-        if (localFolder.isCachedUidValidityValid() && cachedUidValidity != currentUidValidity) {
+        if (localFolder.hasCachedUidValidity() && cachedUidValidity != currentUidValidity) {
 
             Timber.v("SYNC: Deleting all local messages in folder %s due to UIDVALIDITY change", localFolder);
             Set<String> localUids = localFolder.getAllMessagesAndEffectiveDates().keySet();

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -16,6 +16,7 @@ import com.fsck.k9.mail.store.imap.ImapFolder;
 import com.fsck.k9.mail.store.imap.QresyncParamResponse;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.notification.NotificationController;
 import timber.log.Timber;
 
 
@@ -35,7 +36,8 @@ class ImapSyncInteractor {
         this.controller = controller;
     }
 
-    void performSync(FlagSyncHelper flagSyncHelper, MessageDownloader messageDownloader, SyncHelper syncHelper) {
+    void performSync(FlagSyncHelper flagSyncHelper, MessageDownloader messageDownloader,
+            NotificationController notificationController, SyncHelper syncHelper) {
         Exception commandException = null;
 
         try {
@@ -55,6 +57,8 @@ class ImapSyncInteractor {
             if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
                 return;
             }
+
+            notificationController.clearAuthenticationErrorNotification(account, true);
 
             QresyncParamResponse qresyncParamResponse = null;
             Timber.v("SYNC: About to open remote IMAP folder %s", folderName);

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -39,7 +39,7 @@ class ImapSyncInteractor {
         this.controller = controller;
     }
 
-    void performSync(FlagSyncHelper flagSyncHelper, MessageDownloader messageDownloader) {
+    void performSync(FlagSyncHelper flagSyncHelper, MessageDownloader messageDownloader, SyncHelper syncHelper) {
         Exception commandException = null;
 
         try {
@@ -54,7 +54,7 @@ class ImapSyncInteractor {
             }
 
             Timber.v("SYNC: About to get local folder %s and open it", folderName);
-            localFolder = SyncUtils.getOpenedLocalFolder(account, folderName);
+            localFolder = syncHelper.getOpenedLocalFolder(account, folderName);
             localFolder.updateLastUid();
 
             Store remoteStore = account.getRemoteStore();
@@ -65,7 +65,7 @@ class ImapSyncInteractor {
             }
             imapFolder = (ImapFolder) remoteFolder;
 
-            if (!SyncUtils.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
+            if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
                 return;
             }
 
@@ -97,12 +97,13 @@ class ImapSyncInteractor {
             if (!qresyncEnabled) {
                 NonQresyncExtensionHandler handler = new NonQresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = handler.continueSync(messageDownloader, flagSyncHelper);
+                newMessages = handler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
             } else {
                 Timber.v("SYNC: QRESYNC extension found and enabled for folder %s", folderName);
                 QresyncExtensionHandler handler = new QresyncExtensionHandler(account, localFolder, imapFolder,
                         listener, controller, this);
-                newMessages = handler.continueSync(qresyncParamResponse, expungedUids, messageDownloader, flagSyncHelper);
+                newMessages = handler.continueSync(qresyncParamResponse, expungedUids, messageDownloader,
+                        flagSyncHelper, syncHelper);
             }
 
             localFolder.setUidValidity(imapFolder.getUidValidity());

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -22,7 +22,10 @@ import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
 import timber.log.Timber;
 
-
+/* This class contains code that used to be present directly in the MessagingController. It used to represent a common
+synchronization mechanism for all types of accounts. Currently, it is used for synchronization of POP3 and WebDAV
+accounts only
+ */
 class LegacySyncInteractor {
 
     static void performSync(Account account, String folderName, MessagingListener listener,

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -31,26 +31,25 @@ accounts only
  */
 class LegacySyncInteractor {
 
-    private final Account account;
-    private final String folderName;
-    private LocalFolder localFolder;
-    private Folder<? extends Message> remoteFolder;
-    private final MessagingListener listener;
     private final MessagingController controller;
+    private final MessageDownloader messageDownloader;
+    private final NotificationController notificationController;
 
-    LegacySyncInteractor(Account account, String folderName, MessagingListener listener, MessagingController controller) {
-        this.account = account;
-        this.folderName = folderName;
-        this.listener = listener;
+    LegacySyncInteractor(MessagingController controller, MessageDownloader messageDownloader,
+            NotificationController notificationController) {
         this.controller = controller;
+        this.messageDownloader = messageDownloader;
+        this.notificationController = notificationController;
     }
 
-    void performSync(MessageDownloader messageDownloader, NotificationController notificationController) {
+    void performSync(Account account, String folderName, MessagingListener listener) {
         for (MessagingListener l : controller.getListeners(listener)) {
             l.synchronizeMailboxStarted(account, folderName);
         }
 
         Exception commandException = null;
+        LocalFolder localFolder = null;
+        Folder<? extends Message> remoteFolder = null;
 
         try {
             Timber.d("SYNC: About to process pending commands for account %s", account.getDescription());
@@ -309,7 +308,6 @@ class LegacySyncInteractor {
         }
         return true;
     }
-
 
     private void updateMoreMessages(Folder remoteFolder, LocalFolder localFolder, Date earliestDate, int remoteStart)
             throws MessagingException, IOException {

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -128,7 +128,7 @@ class LegacySyncInteractor {
              * Now we download the actual content of messages.
              */
             int newMessages =  messageDownloader.downloadMessages(account, remoteFolder, localFolder, remoteMessages,
-                    false, true, true);
+                    true, true);
             int unreadMessageCount = localFolder.getUnreadMessageCount();
             for (MessagingListener l : controller.getListeners()) {
                 l.folderStatusChanged(account, folderName, unreadMessageCount);

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -46,6 +46,10 @@ class LegacySyncInteractor {
     }
 
     void performSync(MessageDownloader messageDownloader, NotificationController notificationController) {
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxStarted(account, folderName);
+        }
+
         Exception commandException = null;
 
         try {

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -29,7 +29,7 @@ accounts only
 class LegacySyncInteractor {
 
     static void performSync(Account account, String folderName, MessagingListener listener,
-            MessagingController controller, MessageDownloader messageDownloader) {
+            MessagingController controller, MessageDownloader messageDownloader, SyncHelper syncHelper) {
 
         Exception commandException = null;
         LocalFolder localFolder = null;
@@ -51,14 +51,14 @@ class LegacySyncInteractor {
              * the uids within the list.
              */
             Timber.v("SYNC: About to get local folder %s", folderName);
-            localFolder = SyncUtils.getOpenedLocalFolder(account, folderName);
+            localFolder = syncHelper.getOpenedLocalFolder(account, folderName);
             localFolder.updateLastUid();
 
             Store remoteStore = account.getRemoteStore();
             Timber.v("SYNC: About to get remote folder %s", folderName);
             remoteFolder = remoteStore.getFolder(folderName);
 
-            if (!SyncUtils.verifyOrCreateRemoteSpecialFolder(account, folderName, remoteFolder, listener, controller)) {
+            if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, remoteFolder, listener, controller)) {
                 return;
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -11,7 +11,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.Expunge;
-import com.fsck.k9.K9;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Message;
@@ -80,25 +79,13 @@ class LegacySyncInteractor {
             int remoteMessageCount = remoteFolder.getMessageCount();
             Timber.v("SYNC: Remote message count for folder %s is %d", folderName, remoteMessageCount);
 
-            int visibleLimit = localFolder.getVisibleLimit();
-            if (visibleLimit < 0) {
-                visibleLimit = K9.DEFAULT_VISIBLE_LIMIT;
-            }
-
             final List<Message> remoteMessages = new ArrayList<>();
             Map<String, Message> remoteUidMap = new HashMap<>();
 
             final Date earliestDate = account.getEarliestPollDate();
 
-            int remoteStart = 1;
+            int remoteStart = syncHelper.getRemoteStart(localFolder, remoteFolder);
             if (remoteMessageCount > 0) {
-                /* Message numbers start at 1.  */
-                if (visibleLimit > 0) {
-                    remoteStart = Math.max(0, remoteMessageCount - visibleLimit) + 1;
-                } else {
-                    remoteStart = 1;
-                }
-
                 Timber.v("SYNC: About to get messages %d through %d for folder %s",
                         remoteStart, remoteMessageCount, folderName);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
@@ -83,8 +83,8 @@ class MessageDownloader {
      * @throws MessagingException
      */
     int downloadMessages(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
-            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit)
-            throws MessagingException {
+            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit,
+            boolean downloadFlags) throws MessagingException {
 
         final Date earliestDate = account.getEarliestPollDate();
         Date downloadStarted = new Date(); // now
@@ -140,7 +140,7 @@ class MessageDownloader {
             }
 
             FetchProfile fp = new FetchProfile();
-            if (remoteFolder.supportsFetchingFlags()) {
+            if (downloadFlags && remoteFolder.supportsFetchingFlags()) {
                 fp.add(FetchProfile.Item.FLAGS);
             }
             fp.add(FetchProfile.Item.ENVELOPE);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
@@ -83,8 +83,8 @@ class MessageDownloader {
      * @throws MessagingException
      */
     int downloadMessages(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
-            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit,
-            boolean syncFlagsForLocalMessages) throws MessagingException {
+            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit)
+            throws MessagingException {
 
         final Date earliestDate = account.getEarliestPollDate();
         Date downloadStarted = new Date(); // now
@@ -111,7 +111,7 @@ class MessageDownloader {
 
         for (Message message : messages) {
             evaluateMessageForDownload(message, folder, localFolder, remoteFolder, account, unsyncedMessages,
-                    syncFlagMessages, flagSyncOnly, syncFlagsForLocalMessages);
+                    syncFlagMessages, flagSyncOnly);
         }
 
         final AtomicInteger progress = new AtomicInteger(0);
@@ -234,8 +234,7 @@ class MessageDownloader {
             final Account account,
             final List<Message> unsyncedMessages,
             final List<Message> syncFlagMessages,
-            boolean flagSyncOnly,
-            boolean syncFlagsForLocalMessages) throws MessagingException {
+            boolean flagSyncOnly) throws MessagingException {
         if (message.isSet(Flag.DELETED)) {
             Timber.v("Message with uid %s is marked as deleted", message.getUid());
 
@@ -276,7 +275,7 @@ class MessageDownloader {
                 Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
 
                 unsyncedMessages.add(message);
-            } else if (syncFlagsForLocalMessages){
+            } else {
                 String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
                 if (newPushState != null) {
                     localFolder.setPushState(newPushState);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
@@ -73,15 +73,15 @@ class MessageDownloader {
      *         A list of message objects that store the UIDs of which messages to download.
      * @param purgeToVisibleLimit
      *         If true, local messages will be purged down to the limit of visible messages.
-     * @param downloadFlagsForRemoteMessages
-     *         If true, flags will be downloaded.
+     * @param downloadFlagsForNewMessages
+     *         If true, flags will be downloaded for messages that are not present locally.
      *
      * @return The number of downloaded messages that are not flagged as {@link Flag#SEEN}.
      *
      * @throws MessagingException
      */
     int downloadMessages(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
-            List<? extends Message> inputMessages, boolean purgeToVisibleLimit, boolean downloadFlagsForRemoteMessages)
+            List<? extends Message> inputMessages, boolean purgeToVisibleLimit, boolean downloadFlagsForNewMessages)
             throws MessagingException {
 
         final Date earliestDate = account.getEarliestPollDate();
@@ -138,7 +138,7 @@ class MessageDownloader {
             }
 
             FetchProfile fp = new FetchProfile();
-            if (downloadFlagsForRemoteMessages && remoteFolder.supportsFetchingFlags()) {
+            if (downloadFlagsForNewMessages && remoteFolder.supportsFetchingFlags()) {
                 fp.add(FetchProfile.Item.FLAGS);
             }
             fp.add(FetchProfile.Item.ENVELOPE);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -16,7 +15,6 @@ import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
-import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.BodyFactory;
 import com.fsck.k9.mail.DefaultBodyFactory;
@@ -70,19 +68,19 @@ class MessageDownloader {
      * @param localFolder
      *         The {@link LocalFolder} instance corresponding to the remote folder.
      * @param inputMessages
-     *         A list of messages objects that store the UIDs of which messages to download.
-     * @param flagSyncOnly
-     *         Only flags will be fetched from the remote store if this is {@code true}.
+     *         A list of message objects that store the UIDs of which messages to download.
      * @param purgeToVisibleLimit
      *         If true, local messages will be purged down to the limit of visible messages.
+     * @param downloadFlagsForRemoteMessages
+     *         If true, flags will be downloaded.
      *
      * @return The number of downloaded messages that are not flagged as {@link Flag#SEEN}.
      *
      * @throws MessagingException
      */
     int downloadMessages(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
-            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit,
-            boolean downloadFlags) throws MessagingException {
+            List<? extends Message> inputMessages, boolean purgeToVisibleLimit, boolean downloadFlagsForRemoteMessages)
+            throws MessagingException {
 
         final Date earliestDate = account.getEarliestPollDate();
         Date downloadStarted = new Date(); // now
@@ -90,7 +88,7 @@ class MessageDownloader {
         if (earliestDate != null) {
             Timber.d("Only syncing messages after %s", earliestDate);
         }
-        final String folder = remoteFolder.getName();
+        final String folderName = remoteFolder.getName();
 
         int unreadBeforeStart = 0;
         try {
@@ -108,14 +106,14 @@ class MessageDownloader {
         List<Message> messages = new ArrayList<>(inputMessages);
 
         for (Message message : messages) {
-            evaluateMessageForDownload(message, folder, localFolder, remoteFolder, account, unsyncedMessages,
-                    syncFlagMessages, flagSyncOnly);
+            SyncUtils.evaluateMessageForDownload(message, folderName, localFolder, remoteFolder, account, unsyncedMessages,
+                    syncFlagMessages, controller);
         }
 
         final AtomicInteger progress = new AtomicInteger(0);
-        final int todo = unsyncedMessages.size() + syncFlagMessages.size();
+        final int todo = unsyncedMessages.size();
         for (MessagingListener l : controller.getListeners()) {
-            l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
+            l.synchronizeMailboxProgress(account, folderName, progress.get(), todo);
         }
 
         Timber.d("SYNC: Have %d unsynced messages", unsyncedMessages.size());
@@ -138,12 +136,12 @@ class MessageDownloader {
             }
 
             FetchProfile fp = new FetchProfile();
-            if (downloadFlags && remoteFolder.supportsFetchingFlags()) {
+            if (downloadFlagsForRemoteMessages && remoteFolder.supportsFetchingFlags()) {
                 fp.add(FetchProfile.Item.FLAGS);
             }
             fp.add(FetchProfile.Item.ENVELOPE);
 
-            Timber.d("SYNC: About to fetch %d unsynced messages for folder %s", unsyncedMessages.size(), folder);
+            Timber.d("SYNC: About to fetch %d unsynced messages for folder %s", unsyncedMessages.size(), folderName);
 
             fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo,
                     fp);
@@ -157,7 +155,7 @@ class MessageDownloader {
             }
             localFolder.setPushState(updatedPushState);
 
-            Timber.d("SYNC: Synced unsynced messages for folder %s", folder);
+            Timber.d("SYNC: Synced unsynced messages for folder %s", folderName);
         }
 
         Timber.d("SYNC: Have %d large messages and %d small messages out of %d unsynced messages",
@@ -186,21 +184,19 @@ class MessageDownloader {
                 newMessages, todo, fp);
         largeMessages.clear();
 
-        /*
-         * Refresh the flags for any messages in the local store that we didn't just
-         * download.
-         */
+        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folderName, newMessages.get());
 
-        refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages, progress, todo);
+        FlagSyncHelper.newInstance(context, controller).refreshLocalMessageFlags(account, remoteFolder, localFolder,
+                syncFlagMessages);
 
-        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folder, newMessages.get());
+        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folderName, newMessages.get());
 
         if (purgeToVisibleLimit) {
             localFolder.purgeToVisibleLimit(new MessageRemovalListener() {
                 @Override
                 public void messageRemoved(Message message) {
                     for (MessagingListener l : controller.getListeners()) {
-                        l.synchronizeMailboxRemovedMessage(account, folder, message);
+                        l.synchronizeMailboxRemovedMessage(account, folderName, message);
                     }
                 }
 
@@ -225,65 +221,6 @@ class MessageDownloader {
 
         }
         return newMessages.get();
-    }
-
-    private void evaluateMessageForDownload(final Message message, final String folder,
-            final LocalFolder localFolder,
-            final Folder remoteFolder,
-            final Account account,
-            final List<Message> unsyncedMessages,
-            final List<Message> syncFlagMessages,
-            boolean flagSyncOnly) throws MessagingException {
-        if (message.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is marked as deleted", message.getUid());
-
-            syncFlagMessages.add(message);
-            return;
-        }
-
-        Message localMessage = localFolder.getMessage(message.getUid());
-
-        if (localMessage == null) {
-            if (!flagSyncOnly) {
-                if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                    Timber.v("Message with uid %s has not yet been downloaded", message.getUid());
-
-                    unsyncedMessages.add(message);
-                } else {
-                    Timber.v("Message with uid %s is partially or fully downloaded", message.getUid());
-
-                    // Store the updated message locally
-                    localFolder.appendMessages(Collections.singletonList(message));
-
-                    localMessage = localFolder.getMessage(message.getUid());
-
-                    localMessage.setFlag(Flag.X_DOWNLOADED_FULL, message.isSet(Flag.X_DOWNLOADED_FULL));
-                    localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, message.isSet(Flag.X_DOWNLOADED_PARTIAL));
-
-                    for (MessagingListener l : controller.getListeners()) {
-                        if (!localMessage.isSet(Flag.SEEN)) {
-                            l.synchronizeMailboxNewMessage(account, folder, localMessage);
-                        }
-                    }
-                }
-            }
-        } else if (!localMessage.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is present in the local store", message.getUid());
-
-            if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
-
-                unsyncedMessages.add(message);
-            } else {
-                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
-                if (newPushState != null) {
-                    localFolder.setPushState(newPushState);
-                }
-                syncFlagMessages.add(message);
-            }
-        } else {
-            Timber.v("Local copy of message with uid %s is marked as deleted", message.getUid());
-        }
     }
 
     private <T extends Message> void fetchUnsyncedMessages(final Account account, final Folder<T> remoteFolder,
@@ -405,7 +342,7 @@ class MessageDownloader {
                             }
                             // Send a notification of this message
 
-                            if (shouldNotifyForMessage(account, localFolder, message)) {
+                            if (SyncUtils.shouldNotifyForMessage(account, localFolder, message, contacts)) {
                                 // Notify with the localMessage so that we don't have to recalculate the content preview.
                                 notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
                             }
@@ -474,7 +411,7 @@ class MessageDownloader {
                 }
             }
             // Send a notification of this message
-            if (shouldNotifyForMessage(account, localFolder, message)) {
+            if (SyncUtils.shouldNotifyForMessage(account, localFolder, message, contacts)) {
                 // Notify with the localMessage so that we don't have to recalculate the content preview.
                 notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
             }
@@ -554,158 +491,5 @@ class MessageDownloader {
             }
         }
 
-    }
-
-    private void refreshLocalMessageFlags(final Account account, final Folder remoteFolder,
-            final LocalFolder localFolder,
-            List<Message> syncFlagMessages,
-            final AtomicInteger progress,
-            final int todo
-    ) throws MessagingException {
-
-        final String folderName = remoteFolder.getName();
-        if (remoteFolder.supportsFetchingFlags()) {
-            Timber.d("SYNC: About to sync flags for %d remote messages for folder %s", syncFlagMessages.size(), folderName);
-
-            FetchProfile fp = new FetchProfile();
-            fp.add(FetchProfile.Item.FLAGS);
-
-            List<Message> undeletedMessages = new LinkedList<>();
-            for (Message message : syncFlagMessages) {
-                if (!message.isSet(Flag.DELETED)) {
-                    undeletedMessages.add(message);
-                }
-            }
-
-            remoteFolder.fetch(undeletedMessages, fp, null);
-            for (Message remoteMessage : syncFlagMessages) {
-                processDownloadedFlags(account, localFolder, remoteMessage);
-                progress.incrementAndGet();
-                for (MessagingListener l : controller.getListeners()) {
-                    l.synchronizeMailboxProgress(account, folderName, progress.get(), todo);
-                }
-            }
-        }
-    }
-
-    void processDownloadedFlags(Account account, LocalFolder localFolder, Message remoteMessage)
-            throws MessagingException {
-        String folderName = localFolder.getName();
-        LocalMessage localMessage = localFolder.getMessage(remoteMessage.getUid());
-        boolean messageChanged = syncFlags(localMessage, remoteMessage);
-        if (messageChanged) {
-            boolean shouldBeNotifiedOf = false;
-            if (localMessage.isSet(Flag.DELETED) || SyncUtils.isMessageSuppressed(localMessage, context)) {
-                for (MessagingListener l : controller.getListeners()) {
-                    l.synchronizeMailboxRemovedMessage(account, folderName, localMessage);
-                }
-            } else {
-                if (shouldNotifyForMessage(account, localFolder, localMessage)) {
-                    shouldBeNotifiedOf = true;
-                }
-            }
-
-            // we're only interested in messages that need removing
-            if (!shouldBeNotifiedOf) {
-                MessageReference messageReference = localMessage.makeMessageReference();
-                notificationController.removeNewMailNotification(account, messageReference);
-            }
-        }
-    }
-
-    private boolean syncFlags(LocalMessage localMessage, Message remoteMessage) throws MessagingException {
-        boolean messageChanged = false;
-        if (localMessage == null || localMessage.isSet(Flag.DELETED)) {
-            return false;
-        }
-        if (remoteMessage.isSet(Flag.DELETED)) {
-            if (localMessage.getFolder().syncRemoteDeletions()) {
-                localMessage.setFlag(Flag.DELETED, true);
-                messageChanged = true;
-            }
-        } else {
-            for (Flag flag : SYNC_FLAGS) {
-                if (remoteMessage.isSet(flag) != localMessage.isSet(flag)) {
-                    localMessage.setFlag(flag, remoteMessage.isSet(flag));
-                    messageChanged = true;
-                }
-            }
-        }
-        return messageChanged;
-    }
-
-    private boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message) {
-        // If we don't even have an account name, don't show the notification.
-        // (This happens during initial account setup)
-        if (account.getName() == null) {
-            return false;
-        }
-
-        // Do not notify if the user does not have notifications enabled or if the message has
-        // been read.
-        if (!account.isNotifyNewMail() || message.isSet(Flag.SEEN)) {
-            return false;
-        }
-
-        Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
-        Account.FolderMode aNotifyMode = account.getFolderNotifyNewMailMode();
-        Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
-        Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
-
-        if (SyncUtils.modeMismatch(aDisplayMode, fDisplayClass)) {
-            // Never notify a folder that isn't displayed
-            return false;
-        }
-
-        if (SyncUtils.modeMismatch(aNotifyMode, fNotifyClass)) {
-            // Do not notify folders in the wrong class
-            return false;
-        }
-
-        // If the account is a POP3 account and the message is older than the oldest message we've
-        // previously seen, then don't notify about it.
-        if (account.getStoreUri().startsWith("pop3") &&
-                message.olderThan(new Date(account.getLatestOldMessageSeenTime()))) {
-            return false;
-        }
-
-        // No notification for new messages in Trash, Drafts, Spam or Sent folder.
-        // But do notify if it's the INBOX (see issue 1817).
-        Folder folder = message.getFolder();
-        if (folder != null) {
-            String folderName = folder.getName();
-            if (!account.getInboxFolderName().equals(folderName) &&
-                    (account.getTrashFolderName().equals(folderName)
-                            || account.getDraftsFolderName().equals(folderName)
-                            || account.getSpamFolderName().equals(folderName)
-                            || account.getSentFolderName().equals(folderName))) {
-                return false;
-            }
-        }
-
-        if (message.getUid() != null && localFolder.getLastUid() != null) {
-            try {
-                Integer messageUid = Integer.parseInt(message.getUid());
-                if (messageUid <= localFolder.getLastUid()) {
-                    Timber.d("Message uid is %s, max message uid is %s. Skipping notification.",
-                            messageUid, localFolder.getLastUid());
-                    return false;
-                }
-            } catch (NumberFormatException e) {
-                // Nothing to be done here.
-            }
-        }
-
-        // Don't notify if the sender address matches one of our identities and the user chose not
-        // to be notified for such messages.
-        if (account.isAnIdentity(message.getFrom()) && !account.isNotifySelfNewMail()) {
-            return false;
-        }
-
-        if (account.isNotifyContactsMailOnly() && !contacts.isAnyInContacts(message.getFrom())) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -751,11 +751,13 @@ public class MessagingController {
 
         String storeUri = account.getStoreUri();
         if (ImapStore.isStoreUriImap(storeUri)) {
-            ImapSyncInteractor syncInteractor = new ImapSyncInteractor(account, folderName, listener, this);
-            syncInteractor.performSync(flagSyncHelper, messageDownloader, notificationController, syncHelper);
+            ImapSyncInteractor syncInteractor = new ImapSyncInteractor(syncHelper, flagSyncHelper, this,
+                    messageDownloader, notificationController);
+            syncInteractor.performSync(account, folderName, listener);
         } else {
-            LegacySyncInteractor syncInteractor = new LegacySyncInteractor(account, folderName, listener, this);
-            syncInteractor.performSync(messageDownloader, notificationController);
+            LegacySyncInteractor syncInteractor = new LegacySyncInteractor(this, messageDownloader,
+                    notificationController);
+            syncInteractor.performSync(account, folderName, listener);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1616,7 +1616,7 @@ public class MessagingController {
 
                 if (loadPartialFromSearch) {
                     messageDownloader.downloadMessages(account, remoteFolder, localFolder,
-                            Collections.singletonList(remoteMessage), false, false);
+                            Collections.singletonList(remoteMessage), false, false, true);
                 } else {
                     FetchProfile fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);
@@ -3249,7 +3249,7 @@ public class MessagingController {
 
                     account.setRingNotified(false);
                     int newCount = messageDownloader.downloadMessages(account, remoteFolder, localFolder, messages,
-                            flagSyncOnly, true);
+                            flagSyncOnly, true, true);
 
                     int unreadMessageCount = localFolder.getUnreadMessageCount();
                     ImapSyncInteractor.updateHighestModSeqIfNecessary(localFolder, remoteFolder);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -739,15 +739,12 @@ public class MessagingController {
 
         Timber.i("Synchronizing folder %s:%s", account.getDescription(), folderName);
 
-        for (MessagingListener l : getListeners(listener)) {
-            l.synchronizeMailboxStarted(account, folderName);
-        }
-
         /*
          * We don't ever sync the Outbox or errors folder
          */
         if (folderName.equals(account.getOutboxFolderName()) || folderName.equals(account.getErrorFolderName())) {
             for (MessagingListener l : getListeners(listener)) {
+                l.synchronizeMailboxStarted(account, folderName);
                 l.synchronizeMailboxFinished(account, folderName, 0, 0);
             }
             return;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -756,9 +756,10 @@ public class MessagingController {
         String storeUri = account.getStoreUri();
         if (ImapStore.isStoreUriImap(storeUri)) {
             ImapSyncInteractor syncInteractor = new ImapSyncInteractor(account, folderName, listener, this);
-            syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+            syncInteractor.performSync(flagSyncHelper, messageDownloader, notificationController, syncHelper);
         } else {
-            LegacySyncInteractor.performSync(account, folderName, listener, this, messageDownloader, syncHelper);
+            LegacySyncInteractor syncInteractor = new LegacySyncInteractor(account, folderName, listener, this);
+            syncInteractor.performSync(messageDownloader, notificationController);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1616,7 +1616,7 @@ public class MessagingController {
 
                 if (loadPartialFromSearch) {
                     messageDownloader.downloadMessages(account, remoteFolder, localFolder,
-                            Collections.singletonList(remoteMessage), false, false, true);
+                            Collections.singletonList(remoteMessage), false, false);
                 } else {
                     FetchProfile fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);
@@ -3249,7 +3249,7 @@ public class MessagingController {
 
                     account.setRingNotified(false);
                     int newCount = messageDownloader.downloadMessages(account, remoteFolder, localFolder, messages,
-                            flagSyncOnly, true, true);
+                            flagSyncOnly, true);
 
                     int unreadMessageCount = localFolder.getUnreadMessageCount();
                     ImapSyncInteractor.updateHighestModSeqIfNecessary(localFolder, remoteFolder);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -87,6 +87,7 @@ import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
+import com.fsck.k9.mail.store.imap.ImapStore;
 import com.fsck.k9.mail.store.pop3.Pop3Store;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
@@ -749,7 +750,7 @@ public class MessagingController {
         }
 
         String storeUri = account.getStoreUri();
-        if (storeUri.startsWith("imap")) {
+        if (ImapStore.isStoreUriImap(storeUri)) {
             ImapSyncInteractor syncInteractor = new ImapSyncInteractor(account, folderName, listener, this);
             syncInteractor.performSync(messageDownloader);
         } else {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -128,6 +128,7 @@ public class MessagingController {
     private final Context context;
     private final Contacts contacts;
     private final NotificationController notificationController;
+    private final FlagSyncHelper flagSyncHelper;
     private final MessageDownloader messageDownloader;
 
     private final Thread controllerThread;
@@ -164,6 +165,7 @@ public class MessagingController {
         this.notificationController = notificationController;
         this.contacts = contacts;
         this.transportProvider = transportProvider;
+        flagSyncHelper = FlagSyncHelper.newInstance(context, this);
         messageDownloader = MessageDownloader.newInstance(context, this);
 
         controllerThread = new Thread(new Runnable() {
@@ -752,7 +754,7 @@ public class MessagingController {
         String storeUri = account.getStoreUri();
         if (ImapStore.isStoreUriImap(storeUri)) {
             ImapSyncInteractor syncInteractor = new ImapSyncInteractor(account, folderName, listener, this);
-            syncInteractor.performSync(messageDownloader);
+            syncInteractor.performSync(flagSyncHelper, messageDownloader);
         } else {
             LegacySyncInteractor.performSync(account, folderName, listener, this, messageDownloader);
         }
@@ -1616,7 +1618,7 @@ public class MessagingController {
 
                 if (loadPartialFromSearch) {
                     messageDownloader.downloadMessages(account, remoteFolder, localFolder,
-                            Collections.singletonList(remoteMessage), false, false, true);
+                            Collections.singletonList(remoteMessage), false, true);
                 } else {
                     FetchProfile fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -751,7 +751,8 @@ public class MessagingController {
 
         String storeUri = account.getStoreUri();
         if (storeUri.startsWith("imap")) {
-            ImapSyncInteractor.performSync(account, folderName, listener, this, messageDownloader);
+            ImapSyncInteractor syncInteractor = new ImapSyncInteractor(account, folderName, listener, this);
+            syncInteractor.performSync(messageDownloader);
         } else {
             LegacySyncInteractor.performSync(account, folderName, listener, this, messageDownloader);
         }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -690,7 +690,7 @@ public class MessagingController {
             if (localFolder.getVisibleLimit() > 0) {
                 localFolder.setVisibleLimit(localFolder.getVisibleLimit() + account.getDisplayCount());
             }
-            synchronizeMailbox(account, folder, listener, null);
+            synchronizeMailbox(account, folder, listener);
         } catch (MessagingException me) {
             addErrorMessage(account, null, me);
 
@@ -701,12 +701,11 @@ public class MessagingController {
     /**
      * Start background synchronization of the specified folder.
      */
-    public void synchronizeMailbox(final Account account, final String folder, final MessagingListener listener,
-            final Folder providedRemoteFolder) {
+    public void synchronizeMailbox(final Account account, final String folder, final MessagingListener listener) {
         putBackground("synchronizeMailbox", listener, new Runnable() {
             @Override
             public void run() {
-                synchronizeMailboxSynchronous(account, folder, listener, providedRemoteFolder);
+                synchronizeMailboxSynchronous(account, folder, listener);
             }
         });
     }
@@ -716,8 +715,8 @@ public class MessagingController {
      * by synchronizeMailbox.
      */
     @VisibleForTesting
-    void synchronizeMailboxSynchronous(final Account account, final String folderName, final MessagingListener listener,
-            Folder providedRemoteFolder) {
+    void synchronizeMailboxSynchronous(final Account account, final String folderName,
+            final MessagingListener listener) {
 
         /*
          * Synchronization process:
@@ -2914,7 +2913,7 @@ public class MessagingController {
                             }
                             showFetchingMailNotificationIfNecessary(account, folder);
                             try {
-                                synchronizeMailboxSynchronous(account, folder.getName(), listener, null);
+                                synchronizeMailboxSynchronous(account, folder.getName(), listener);
                             } finally {
                                 clearFetchingMailNotificationIfNecessary(account);
                             }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -29,17 +29,17 @@ public class MessagingControllerPushReceiver implements PushReceiver {
 
     @Override
     public void messagesFlagsChanged(Folder folder, List<Message> messages) {
-        controller.messagesArrived(account, folder, messages, true);
+        controller.synchronizeMailbox(account, folder.getName(), null, null);
     }
 
     @Override
     public void messagesArrived(Folder folder, List<Message> messages) {
-        controller.messagesArrived(account, folder, messages, false);
+        controller.synchronizeMailbox(account, folder.getName(), null, null);
     }
 
     @Override
     public void messagesRemoved(Folder folder, List<Message> messages) {
-        controller.messagesArrived(account, folder, messages, true);
+        controller.synchronizeMailbox(account, folder.getName(), null, null);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -29,17 +29,17 @@ public class MessagingControllerPushReceiver implements PushReceiver {
 
     @Override
     public void messagesFlagsChanged(Folder folder, List<Message> messages) {
-        controller.synchronizeMailbox(account, folder.getName(), null, null);
+        controller.synchronizeMailbox(account, folder.getName(), null);
     }
 
     @Override
     public void messagesArrived(Folder folder, List<Message> messages) {
-        controller.synchronizeMailbox(account, folder.getName(), null, null);
+        controller.synchronizeMailbox(account, folder.getName(), null);
     }
 
     @Override
     public void messagesRemoved(Folder folder, List<Message> messages) {
-        controller.synchronizeMailbox(account, folder.getName(), null, null);
+        controller.synchronizeMailbox(account, folder.getName(), null);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class MessagingControllerPushReceiver implements PushReceiver {
             String message) {
                 latch.countDown();
             }
-        }, folder);
+        });
 
         Timber.v("syncFolder(%s) about to await latch release", folder.getName());
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -68,7 +68,7 @@ class NonQresyncExtensionHandler {
                     syncFlagMessages, controller);
         }
 
-        if (localFolder.getHighestModSeq() != 0 && imapFolder.supportsModSeq() && K9.shouldUseCondstore()) {
+        if (localFolder.isCachedHighestModSeqValid() && imapFolder.supportsModSeq() && K9.shouldUseCondstore()) {
             downloadChangedMessageFlagsUsingCondstore(syncFlagMessages, flagSyncHelper);
         } else {
             flagSyncHelper.refreshLocalMessageFlags(account, imapFolder, localFolder, syncFlagMessages);

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -47,7 +47,7 @@ class NonQresyncExtensionHandler {
         Map<String, ImapMessage> remoteUidMap = new HashMap<>();
 
         int remoteMessageCount = imapFolder.getMessageCount();
-        int remoteStart = ImapSyncInteractor.getRemoteStart(localFolder, imapFolder);
+        int remoteStart = syncHelper.getRemoteStart(localFolder, imapFolder);
 
         Timber.v("SYNC: About to fetch UIDs for messages %d through %d in folder %s",
                 remoteStart, remoteMessageCount, folderName);
@@ -55,7 +55,7 @@ class NonQresyncExtensionHandler {
         findRemoteMessagesToDownload(localUidMap, remoteMessages, remoteUidMap, remoteStart);
 
         if (account.syncRemoteDeletions()) {
-            imapSyncInteractor.syncRemoteDeletions(findDeletedMessageUids(localUidMap, remoteUidMap));
+            imapSyncInteractor.syncRemoteDeletions(findDeletedMessageUids(localUidMap, remoteUidMap), syncHelper);
         }
 
         // noinspection UnusedAssignment, free memory early?

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -53,7 +53,7 @@ class NonQresyncExtensionHandler {
 
         if (account.syncRemoteDeletions()) {
             List<String> deletedUids = findDeletedMessageUids(localUidMap, remoteUidMap);
-            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, imapFolder, controller, listener);
+            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, controller, listener);
         }
 
         // noinspection UnusedAssignment, free memory early?

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -27,16 +27,14 @@ class NonQresyncExtensionHandler {
     private final ImapFolder imapFolder;
     private final MessagingListener listener;
     private final MessagingController controller;
-    private final ImapSyncInteractor imapSyncInteractor;
 
     NonQresyncExtensionHandler(Account account, LocalFolder localFolder, ImapFolder imapFolder,
-            MessagingListener listener, MessagingController controller, ImapSyncInteractor imapSyncInteractor) {
+            MessagingListener listener, MessagingController controller) {
         this.account = account;
         this.localFolder = localFolder;
         this.imapFolder = imapFolder;
         this.listener = listener;
         this.controller = controller;
-        this.imapSyncInteractor = imapSyncInteractor;
     }
 
     int continueSync(MessageDownloader messageDownloader, FlagSyncHelper flagSyncHelper, SyncHelper syncHelper)
@@ -55,7 +53,8 @@ class NonQresyncExtensionHandler {
         findRemoteMessagesToDownload(localUidMap, remoteMessages, remoteUidMap, remoteStart);
 
         if (account.syncRemoteDeletions()) {
-            imapSyncInteractor.syncRemoteDeletions(findDeletedMessageUids(localUidMap, remoteUidMap), syncHelper);
+            List<String> deletedUids = findDeletedMessageUids(localUidMap, remoteUidMap);
+            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, imapFolder, controller, listener);
         }
 
         // noinspection UnusedAssignment, free memory early?

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessageRetrievalListener;
@@ -61,7 +62,7 @@ class NonQresyncExtensionHandler {
         // noinspection UnusedAssignment, free memory early?
         localUidMap = null;
 
-        if (localFolder.getHighestModSeq() != 0 && imapFolder.supportsModSeq()) {
+        if (localFolder.getHighestModSeq() != 0 && imapFolder.supportsModSeq() && K9.shouldUseCondstore()) {
             downloadChangedMessageFlagsUsingCondstore(remoteMessages, messageDownloader);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -68,7 +68,11 @@ class NonQresyncExtensionHandler {
         }
 
         if (localFolder.isCachedHighestModSeqValid() && imapFolder.supportsModSeq() && K9.shouldUseCondstore()) {
-            downloadChangedMessageFlagsUsingCondstore(account, localFolder, imapFolder, syncFlagMessages);
+            if (localFolder.getHighestModSeq() == imapFolder.getHighestModSeq()) {
+                Timber.v("SYNC: HIGHESTMODSEQ has not changed, skipping flag synchronization");
+            } else {
+                downloadChangedMessageFlagsUsingCondstore(account, localFolder, imapFolder, syncFlagMessages);
+            }
         } else {
             flagSyncHelper.refreshLocalMessageFlags(account, imapFolder, localFolder, syncFlagMessages);
         }

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -62,7 +62,7 @@ class NonQresyncExtensionHandler {
         localUidMap = null;
 
         if (localFolder.getHighestModSeq() != 0 && imapFolder.supportsModSeq()) {
-            downloadChangedMessageFlags(remoteMessages, messageDownloader);
+            downloadChangedMessageFlagsUsingCondstore(remoteMessages, messageDownloader);
         }
 
         return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, true);
@@ -116,9 +116,8 @@ class NonQresyncExtensionHandler {
         return deletedMessageUids;
     }
 
-    private void downloadChangedMessageFlags(List<ImapMessage> messages, final MessageDownloader messageDownloader)
-            throws MessagingException {
-        final String folderName = imapFolder.getName();
+    private void downloadChangedMessageFlagsUsingCondstore(List<ImapMessage> messages,
+            final MessageDownloader messageDownloader) throws MessagingException {
         final Map<Long, Message> knownMessageMap = new HashMap<>();
         Iterator<ImapMessage> iterator = messages.iterator();
         while (iterator.hasNext()) {
@@ -134,7 +133,6 @@ class NonQresyncExtensionHandler {
         if (knownMessageMap.size() != 0) {
             Timber.v("SYNC: Fetching and syncing flags for %d local messages using CONDSTORE", knownMessageMap.size());
             long cachedHighestModSeq = localFolder.getHighestModSeq();
-            final AtomicInteger flagSyncProgress = new AtomicInteger(0);
             imapFolder.fetchChangedMessageFlagsUsingCondstore(new ArrayList<>(knownMessageMap.keySet()),
                     cachedHighestModSeq, new MessageRetrievalListener<ImapMessage>() {
                         @Override

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -39,7 +39,7 @@ class NonQresyncExtensionHandler {
         this.imapSyncInteractor = imapSyncInteractor;
     }
 
-    int continueSync(MessageDownloader messageDownloader, FlagSyncHelper flagSyncHelper)
+    int continueSync(MessageDownloader messageDownloader, FlagSyncHelper flagSyncHelper, SyncHelper syncHelper)
             throws MessagingException, IOException {
         Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
         String folderName = localFolder.getName();
@@ -65,7 +65,7 @@ class NonQresyncExtensionHandler {
         List<Message> syncFlagMessages = new ArrayList<>();
 
         for (Message message : remoteMessages) {
-            SyncUtils.evaluateMessageForDownload(message, folderName, localFolder, imapFolder, account, newMessages,
+            syncHelper.evaluateMessageForDownload(message, folderName, localFolder, imapFolder, account, newMessages,
                     syncFlagMessages, controller);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -21,7 +21,7 @@ import com.fsck.k9.mailstore.LocalFolder;
 import timber.log.Timber;
 
 
-class NonQresyncSyncInteractor {
+class NonQresyncExtensionHandler {
 
     private final Account account;
     private final LocalFolder localFolder;
@@ -30,7 +30,7 @@ class NonQresyncSyncInteractor {
     private final MessagingController controller;
     private final ImapSyncInteractor imapSyncInteractor;
 
-    NonQresyncSyncInteractor(Account account, LocalFolder localFolder, ImapFolder imapFolder,
+    NonQresyncExtensionHandler(Account account, LocalFolder localFolder, ImapFolder imapFolder,
             MessagingListener listener, MessagingController controller, ImapSyncInteractor imapSyncInteractor) {
         this.account = account;
         this.localFolder = localFolder;
@@ -40,7 +40,7 @@ class NonQresyncSyncInteractor {
         this.imapSyncInteractor = imapSyncInteractor;
     }
 
-    int performSync(MessageDownloader messageDownloader) throws MessagingException, IOException {
+    int continueSync(MessageDownloader messageDownloader) throws MessagingException, IOException {
         Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
         String folderName = localFolder.getName();
         final List<ImapMessage> remoteMessages = new ArrayList<>();
@@ -118,6 +118,7 @@ class NonQresyncSyncInteractor {
 
     private void downloadChangedMessageFlags(List<ImapMessage> messages, final MessageDownloader messageDownloader)
             throws MessagingException {
+        final String folderName = imapFolder.getName();
         final Map<Long, Message> knownMessageMap = new HashMap<>();
         Iterator<ImapMessage> iterator = messages.iterator();
         while (iterator.hasNext()) {
@@ -143,10 +144,8 @@ class NonQresyncSyncInteractor {
 
                         @Override
                         public void messageFinished(ImapMessage message, int number, int ofTotal) {
-                            flagSyncProgress.incrementAndGet();
                             try {
-                                messageDownloader.processDownloadedFlags(account, localFolder, message, flagSyncProgress,
-                                        ofTotal);
+                                messageDownloader.processDownloadedFlags(account, localFolder, message);
                             } catch (MessagingException e) {
                                 Timber.e(e, "Error while synchronizing flags using CONDSTORE.");
                                 controller.addErrorMessage(account, null, e);

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
@@ -72,7 +72,7 @@ class NonQresyncSyncInteractor {
             downloadChangedMessageFlags(remoteMessages);
         }
 
-        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true);
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, true);
     }
 
     private void findRemoteMessagesToDownload(Map<String, Long> localUidMap, List<ImapMessage> remoteMessages,

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
@@ -1,0 +1,118 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mailstore.LocalFolder;
+import timber.log.Timber;
+
+
+class NonQresyncSyncInteractor {
+
+    static int performSync(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener,
+            MessagingController controller, MessageDownloader messageDownloader) throws MessagingException, IOException {
+        Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
+        String folderName = localFolder.getName();
+        final List<ImapMessage> remoteMessages = new ArrayList<>();
+        Map<String, ImapMessage> remoteUidMap = new HashMap<>();
+
+        int remoteMessageCount = imapFolder.getMessageCount();
+        final Date earliestDate = account.getEarliestPollDate();
+        int remoteStart = ImapSyncInteractor.getRemoteStart(localFolder, imapFolder);
+
+        Timber.v("SYNC: About to get messages %d through %d for folder %s",
+                remoteStart, remoteMessageCount, folderName);
+
+        findRemoteMessagesToDownload(account, imapFolder, localUidMap, remoteMessages, remoteUidMap, remoteStart,
+                listener, controller);
+
+        /*
+         * Remove any messages that are in the local store but no longer on the remote store or are too old
+         */
+        if (account.syncRemoteDeletions()) {
+            ImapSyncInteractor.syncRemoteDeletions(account, localFolder, imapFolder,
+                    findDeletedMessageUids(localUidMap, remoteUidMap), listener, controller);
+        }
+
+        // noinspection UnusedAssignment, free memory early?
+        localUidMap = null;
+
+        /*
+         * Now we download the actual content of messages.
+         */
+        boolean useCondstore = false;
+        long cachedHighestModSeq = localFolder.getHighestModSeq();
+        if (cachedHighestModSeq != 0 && imapFolder.supportsModSeq()) {
+            useCondstore = true;
+        }
+        int newMessages = messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false,
+                true, !useCondstore);
+        if (useCondstore) {
+            Timber.v("SYNC: About to get messages having modseq greater that %d for IMAP folder %s",
+                    cachedHighestModSeq, folderName);
+            List<ImapMessage> syncFlagMessages = imapFolder.getChangedMessagesUsingCondstore(cachedHighestModSeq);
+            newMessages += messageDownloader.downloadMessages(account, imapFolder, localFolder, syncFlagMessages,
+                    false, true, true);
+        }
+        return newMessages;
+    }
+
+    private static void findRemoteMessagesToDownload(Account account, ImapFolder imapFolder,
+            Map<String, Long> localUidMap, List<ImapMessage> remoteMessages, Map<String, ImapMessage> remoteUidMap,
+            int remoteStart, MessagingListener listener, MessagingController controller)
+            throws MessagingException {
+
+        String folderName = imapFolder.getName();
+        final Date earliestDate = account.getEarliestPollDate();
+        long earliestTimestamp = earliestDate != null ? earliestDate.getTime() : 0L;
+        final AtomicInteger headerProgress = new AtomicInteger(0);
+        int remoteMessageCount = imapFolder.getMessageCount();
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersStarted(account, folderName);
+        }
+
+        List<ImapMessage> remoteMessageArray = imapFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
+
+        int messageCount = remoteMessageArray.size();
+
+        for (ImapMessage thisMess : remoteMessageArray) {
+            headerProgress.incrementAndGet();
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxHeadersProgress(account, folderName, headerProgress.get(), messageCount);
+            }
+            Long localMessageTimestamp = localUidMap.get(thisMess.getUid());
+            if (localMessageTimestamp == null || localMessageTimestamp >= earliestTimestamp) {
+                remoteMessages.add(thisMess);
+                remoteUidMap.put(thisMess.getUid(), thisMess);
+            }
+        }
+
+        Timber.v("SYNC: Got %d messages for folder %s", remoteUidMap.size(), folderName);
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersFinished(account, folderName, headerProgress.get(), remoteUidMap.size());
+        }
+    }
+
+    private static List<String> findDeletedMessageUids(Map<String, Long> localUidMap,
+            Map<String, ImapMessage> remoteUidMap) {
+        List<String> deletedMessageUids = new ArrayList<>();
+        for (String localMessageUid : localUidMap.keySet()) {
+            if (remoteUidMap.get(localMessageUid) == null) {
+                deletedMessageUids.add(localMessageUid);
+            }
+        }
+        return deletedMessageUids;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncSyncInteractor.java
@@ -80,7 +80,10 @@ class NonQresyncSyncInteractor {
             l.synchronizeMailboxHeadersStarted(account, folderName);
         }
 
-        List<ImapMessage> remoteMessageArray = imapFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
+        List<ImapMessage> remoteMessageArray = new ArrayList<>();
+        if (remoteMessageCount > 0) {
+            remoteMessageArray = imapFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
+        }
 
         int messageCount = remoteMessageArray.size();
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
@@ -24,16 +24,14 @@ class QresyncExtensionHandler {
     private final ImapFolder imapFolder;
     private final MessagingListener listener;
     private final MessagingController controller;
-    private final ImapSyncInteractor imapSyncInteractor;
 
     QresyncExtensionHandler(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener,
-            MessagingController controller, ImapSyncInteractor imapSyncInteractor) {
+            MessagingController controller) {
         this.account = account;
         this.localFolder = localFolder;
         this.imapFolder = imapFolder;
         this.listener = listener;
         this.controller = controller;
-        this.imapSyncInteractor = imapSyncInteractor;
     }
 
     int continueSync(QresyncParamResponse qresyncParamResponse, List<String> expungedUids,
@@ -45,7 +43,7 @@ class QresyncExtensionHandler {
         if (account.syncRemoteDeletions()) {
             List<String> deletedUids = new ArrayList<>(expungedUids);
             deletedUids.addAll(qresyncParamResponse.getExpungedUids());
-            imapSyncInteractor.syncRemoteDeletions(deletedUids, syncHelper);
+            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, imapFolder, controller, listener);
         }
 
         for (MessagingListener l : controller.getListeners(listener)) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
@@ -41,7 +41,7 @@ class QresyncExtensionHandler {
         if (account.syncRemoteDeletions()) {
             List<String> deletedUids = new ArrayList<>(expungedUids);
             deletedUids.addAll(qresyncParamResponse.getExpungedUids());
-            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, imapFolder, controller, listener);
+            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, controller, listener);
         }
 
         for (MessagingListener l : controller.getListeners(listener)) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
@@ -18,7 +18,7 @@ import com.fsck.k9.mailstore.LocalFolder;
 import timber.log.Timber;
 
 
-class QresyncSyncInteractor {
+class QresyncExtensionHandler {
 
     private final Account account;
     private final LocalFolder localFolder;
@@ -27,7 +27,7 @@ class QresyncSyncInteractor {
     private final MessagingController controller;
     private final ImapSyncInteractor imapSyncInteractor;
 
-    QresyncSyncInteractor(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener,
+    QresyncExtensionHandler(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener,
             MessagingController controller, ImapSyncInteractor imapSyncInteractor) {
         this.account = account;
         this.localFolder = localFolder;
@@ -37,9 +37,10 @@ class QresyncSyncInteractor {
         this.imapSyncInteractor = imapSyncInteractor;
     }
 
-    int performSync(QresyncParamResponse qresyncParamResponse, List<String> expungedUids, MessageDownloader messageDownloader)
-            throws MessagingException, IOException {
-        final List<ImapMessage> remoteMessages = new ArrayList<>();
+    int continueSync(QresyncParamResponse qresyncParamResponse, List<String> expungedUids,
+            MessageDownloader messageDownloader) throws MessagingException, IOException {
+        final String folderName = localFolder.getName();
+        final List<ImapMessage> remoteMessagesToDownload = new ArrayList<>();
 
         if (account.syncRemoteDeletions()) {
             List<String> deletedUids = new ArrayList<>(expungedUids);
@@ -47,24 +48,31 @@ class QresyncSyncInteractor {
             imapSyncInteractor.syncRemoteDeletions(deletedUids);
         }
 
-        findNewRemoteMessagesToDownload(remoteMessages, qresyncParamResponse, messageDownloader);
-        if (imapFolder.getMessageCount() >= localFolder.getVisibleLimit() && imapFolder.getMessageCount() >=
-                (remoteMessages.size() + localFolder.getMessageCount())) {
-            findOldRemoteMessagesToDownload(remoteMessages);
-        }
-
-        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, false);
-    }
-
-    private void findNewRemoteMessagesToDownload(List<ImapMessage> remoteMessages, QresyncParamResponse qresyncParamResponse,
-            MessageDownloader messageDownloader) throws MessagingException {
-
-        String folderName = imapFolder.getName();
-        final AtomicInteger headerProgress = new AtomicInteger(0);
-
         for (MessagingListener l : controller.getListeners(listener)) {
             l.synchronizeMailboxHeadersStarted(account, folderName);
         }
+
+        processFetchResponses(remoteMessagesToDownload, qresyncParamResponse, messageDownloader);
+
+        int newLocalMessageCount = remoteMessagesToDownload.size() + localFolder.getMessageCount();
+        if (imapFolder.getMessageCount() >= localFolder.getVisibleLimit() && imapFolder.getMessageCount() >=
+                newLocalMessageCount) {
+            findOldRemoteMessagesToDownload(remoteMessagesToDownload);
+        }
+
+        int messageDownloadCount = remoteMessagesToDownload.size();
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersFinished(account, folderName, messageDownloadCount, messageDownloadCount);
+        }
+
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessagesToDownload, false,
+                true, false);
+    }
+
+    private void processFetchResponses(List<ImapMessage> remoteMessagesToDownload, QresyncParamResponse
+            qresyncParamResponse, MessageDownloader messageDownloader) throws MessagingException {
+        String folderName = imapFolder.getName();
+        final AtomicInteger headerProgress = new AtomicInteger(0);
 
         List<ImapMessage> modifiedMessages = qresyncParamResponse.getModifiedMessages();
         Timber.v("SYNC: Received %d FETCH responses in QRESYNC response", modifiedMessages.size());
@@ -74,25 +82,28 @@ class QresyncSyncInteractor {
 
         for (ImapMessage imapMessage : modifiedMessages) {
             long remoteMessageUid = Long.parseLong(imapMessage.getUid());
-            Message localMessage = localFolder.getMessage(imapMessage.getUid());
-
             if (remoteMessageUid < smallestLocalUid) {
                 continue;
             }
+            Message localMessage = localFolder.getMessage(imapMessage.getUid());
 
             if (localMessage == null || (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) &&
                     !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL))) {
-                remoteMessages.add(imapMessage);
+                remoteMessagesToDownload.add(imapMessage);
             } else {
-                messageDownloader.processDownloadedFlags(account, localFolder, imapMessage, headerProgress,
-                        modifiedMessages.size());
+                messageDownloader.processDownloadedFlags(account, localFolder, imapMessage);
+            }
+
+            headerProgress.incrementAndGet();
+            for (MessagingListener l : controller.getListeners()) {
+                l.synchronizeMailboxProgress(account, folderName, headerProgress.get(), modifiedMessages.size());
             }
         }
 
-        Timber.v("SYNC: Received %d new message UIDs in QRESYNC response", remoteMessages.size());
+        Timber.v("SYNC: Received %d new message UIDs in QRESYNC response", remoteMessagesToDownload.size());
     }
 
-    private void findOldRemoteMessagesToDownload(List<ImapMessage> remoteMessages) throws MessagingException {
+    private void findOldRemoteMessagesToDownload(List<ImapMessage> remoteMessagesToDownload) throws MessagingException {
         /*At ths point, UIDs and flags for new messages and existing changed messages have been fetched, so all N
           messages in the local store should correspond to the most recent N messages in the remote store. We still need
           to download historical messages (messages older than the oldest message in the inbox) if necessary till we
@@ -102,24 +113,22 @@ class QresyncSyncInteractor {
         Date earliestDate = account.getEarliestPollDate();
         final AtomicInteger headerProgress = new AtomicInteger(0);
 
+        int newLocalMessageCount = remoteMessagesToDownload.size() + localFolder.getMessageCount();
         int oldMessagesStart = ImapSyncInteractor.getRemoteStart(localFolder, imapFolder);
-        int oldMessagesEnd = oldMessagesStart - 1 + localFolder.getVisibleLimit() - remoteMessages.size() -
-                localFolder.getMessageCount();
+        int oldMessagesEnd = oldMessagesStart - 1 + localFolder.getVisibleLimit() - newLocalMessageCount;
 
         if (oldMessagesEnd > oldMessagesStart) {
             List<ImapMessage> oldMessages = imapFolder.getMessages(oldMessagesStart, oldMessagesEnd, earliestDate, null);
             Timber.v("SYNC: Fetched %d old message UIDs for folder %s", oldMessages.size(), folderName);
+
             for (ImapMessage oldMessage : oldMessages) {
                 headerProgress.incrementAndGet();
                 for (MessagingListener l : controller.getListeners(listener)) {
                     l.synchronizeMailboxHeadersProgress(account, folderName, headerProgress.get(), oldMessages.size());
                 }
-                remoteMessages.add(oldMessage);
-            }
-        }
 
-        for (MessagingListener l : controller.getListeners(listener)) {
-            l.synchronizeMailboxHeadersFinished(account, folderName, headerProgress.get(), remoteMessages.size());
+                remoteMessagesToDownload.add(oldMessage);
+            }
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
@@ -37,7 +37,8 @@ class QresyncExtensionHandler {
     }
 
     int continueSync(QresyncParamResponse qresyncParamResponse, List<String> expungedUids,
-            MessageDownloader messageDownloader, FlagSyncHelper flagSyncHelper) throws MessagingException, IOException {
+            MessageDownloader messageDownloader, FlagSyncHelper flagSyncHelper, SyncHelper syncHelper)
+            throws MessagingException, IOException {
         final String folderName = localFolder.getName();
         final List<ImapMessage> remoteMessagesToDownload = new ArrayList<>();
 
@@ -51,7 +52,7 @@ class QresyncExtensionHandler {
             l.synchronizeMailboxHeadersStarted(account, folderName);
         }
 
-        processFetchResponses(remoteMessagesToDownload, qresyncParamResponse, flagSyncHelper);
+        processFetchResponses(remoteMessagesToDownload, qresyncParamResponse, flagSyncHelper, syncHelper);
 
         int newLocalMessageCount = remoteMessagesToDownload.size() + localFolder.getMessageCount();
         if (imapFolder.getMessageCount() >= localFolder.getVisibleLimit() && imapFolder.getMessageCount() >=
@@ -69,7 +70,7 @@ class QresyncExtensionHandler {
     }
 
     private void processFetchResponses(List<ImapMessage> remoteMessagesToDownload, QresyncParamResponse
-            qresyncParamResponse, FlagSyncHelper flagSyncHelper) throws MessagingException {
+            qresyncParamResponse, FlagSyncHelper flagSyncHelper, SyncHelper syncHelper) throws MessagingException {
         String folderName = imapFolder.getName();
         final AtomicInteger headerProgress = new AtomicInteger(0);
 
@@ -83,7 +84,7 @@ class QresyncExtensionHandler {
         List<Message> syncFlagMessages = new ArrayList<>();
 
         for (Message message : modifiedMessages) {
-            SyncUtils.evaluateMessageForDownload(message, folderName, localFolder, imapFolder, account, newMessages,
+            syncHelper.evaluateMessageForDownload(message, folderName, localFolder, imapFolder, account, newMessages,
                     syncFlagMessages, controller);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncExtensionHandler.java
@@ -60,8 +60,9 @@ class QresyncExtensionHandler {
         }
 
         int messageDownloadCount = remoteMessagesToDownload.size();
+        newLocalMessageCount = localFolder.getMessageCount() + remoteMessagesToDownload.size();
         for (MessagingListener l : controller.getListeners(listener)) {
-            l.synchronizeMailboxHeadersFinished(account, folderName, messageDownloadCount, messageDownloadCount);
+            l.synchronizeMailboxHeadersFinished(account, folderName, newLocalMessageCount, messageDownloadCount);
         }
 
         return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessagesToDownload, true,
@@ -97,7 +98,7 @@ class QresyncExtensionHandler {
 
             headerProgress.incrementAndGet();
             for (MessagingListener l : controller.getListeners()) {
-                l.synchronizeMailboxProgress(account, folderName, headerProgress.get(), modifiedMessages.size());
+                l.synchronizeMailboxProgress(account, folderName, headerProgress.get(), syncFlagMessages.size());
             }
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
@@ -37,12 +37,14 @@ class QresyncSyncInteractor {
         this.imapSyncInteractor = imapSyncInteractor;
     }
 
-    int performSync(QresyncResponse qresyncResponse, MessageDownloader messageDownloader) throws MessagingException,
-            IOException {
+    int performSync(QresyncResponse qresyncResponse, List<String> expungedUids, MessageDownloader messageDownloader)
+            throws MessagingException, IOException {
         final List<ImapMessage> remoteMessages = new ArrayList<>();
 
         if (account.syncRemoteDeletions()) {
-            imapSyncInteractor.syncRemoteDeletions(qresyncResponse.getExpungedUids());
+            List<String> deletedUids = new ArrayList<>(expungedUids);
+            deletedUids.addAll(qresyncResponse.getExpungedUids());
+            imapSyncInteractor.syncRemoteDeletions(deletedUids);
         }
 
         findNewRemoteMessagesToDownload(remoteMessages, qresyncResponse, messageDownloader);

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
@@ -69,11 +69,8 @@ class QresyncSyncInteractor {
         List<ImapMessage> modifiedMessages = qresyncParamResponse.getModifiedMessages();
         Timber.v("SYNC: Received %d FETCH responses in QRESYNC response", modifiedMessages.size());
 
-        String uid = localFolder.getSmallestMessageUid();
-        long smallestLocalUid = 1;
-        if (uid != null) {
-            smallestLocalUid = Long.parseLong(uid);
-        }
+        Long cachedSmallestUid = localFolder.getSmallestMessageUid();
+        long smallestLocalUid = cachedSmallestUid == null ? 1 : cachedSmallestUid;
 
         for (ImapMessage imapMessage : modifiedMessages) {
             long remoteMessageUid = Long.parseLong(imapMessage.getUid());

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
@@ -54,7 +54,7 @@ class QresyncSyncInteractor {
         }
 
         //TODO no need to download flags here
-        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, false);
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true);
     }
 
     private void findRemoteMessagesToDownload(List<ImapMessage> remoteMessages, QresyncResponse qresyncResponse)

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
@@ -53,8 +53,7 @@ class QresyncSyncInteractor {
             imapSyncInteractor.syncRemoteDeletions(qresyncResponse.getExpungedUids());
         }
 
-        //TODO no need to download flags here
-        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true);
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, false);
     }
 
     private void findRemoteMessagesToDownload(List<ImapMessage> remoteMessages, QresyncResponse qresyncResponse)

--- a/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/QresyncSyncInteractor.java
@@ -1,0 +1,90 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mail.store.imap.QresyncResponse;
+import com.fsck.k9.mailstore.LocalFolder;
+import timber.log.Timber;
+
+import static com.fsck.k9.controller.ImapSyncInteractor.getRemoteStart;
+
+
+class QresyncSyncInteractor {
+
+    static int performSync(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener,
+            MessagingController controller, QresyncResponse qresyncResponse, MessageDownloader messageDownloader)
+            throws MessagingException, IOException {
+        String folderName = localFolder.getName();
+        final List<ImapMessage> remoteMessages = new ArrayList<>();
+
+        findRemoteMessagesToDownload(account, localFolder, imapFolder, remoteMessages, listener, controller,
+                qresyncResponse);
+
+        /*
+         * Remove any messages that are in the local store but no longer on the remote store or are too old
+         */
+        if (account.syncRemoteDeletions()) {
+            ImapSyncInteractor.syncRemoteDeletions(account, localFolder, imapFolder, qresyncResponse.getExpungedUids(),
+                    listener, controller);
+        }
+
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, remoteMessages, false, true, false);
+    }
+
+    private static void findRemoteMessagesToDownload(Account account, LocalFolder localFolder,
+            ImapFolder imapFolder, List<ImapMessage> remoteMessages, MessagingListener listener,
+            MessagingController controller, QresyncResponse qresyncResponse) throws MessagingException {
+
+        String folderName = imapFolder.getName();
+        final AtomicInteger headerProgress = new AtomicInteger(0);
+        int remoteMessageCount = imapFolder.getMessageCount();
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersStarted(account, folderName);
+        }
+
+        for (ImapMessage imapMessage : qresyncResponse.getModifiedMessages()) {
+            Message localMessage = localFolder.getMessage(imapMessage.getUid());
+            if (localMessage == null) {
+                remoteMessages.add(imapMessage);
+            } else {
+                localMessage.setFlags(imapMessage.getFlags(), true);
+                localFolder.appendMessages(Collections.singletonList(localMessage));
+            }
+        }
+
+        Date earliestDate = account.getEarliestPollDate();
+        int oldMessagesStart = getRemoteStart(localFolder, imapFolder);
+        int oldMessagesEnd = imapFolder.getMessageCount() - localFolder.getMessageCount();
+
+        if (oldMessagesEnd > oldMessagesStart) {
+            remoteMessages.addAll(imapFolder.getMessages(oldMessagesStart, oldMessagesEnd, earliestDate, null));
+        }
+
+        int messageCount = remoteMessages.size();
+
+        for (ImapMessage thisMess : remoteMessages) {
+            headerProgress.incrementAndGet();
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxHeadersProgress(account, folderName, headerProgress.get(), messageCount);
+            }
+        }
+
+        Timber.v("SYNC: Got %d messages for folder %s", remoteMessages.size(), folderName);
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersFinished(account, folderName, headerProgress.get(), remoteMessages.size());
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -47,19 +47,15 @@ class SyncHelper {
      */
     boolean verifyOrCreateRemoteSpecialFolder(Account account, String folderName, Folder remoteFolder,
             MessagingListener listener, MessagingController controller) throws MessagingException {
-        if (folderName.equals(account.getTrashFolderName()) ||
-                folderName.equals(account.getSentFolderName()) ||
-                folderName.equals(account.getDraftsFolderName())) {
-            if (!remoteFolder.exists()) {
-                if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
-                    for (MessagingListener l : controller.getListeners(listener)) {
-                        l.synchronizeMailboxFinished(account, folderName, 0, 0);
-                    }
-
-                    Timber.i("Done synchronizing folder %s", folderName);
-                    return false;
-                }
+        if ((folderName.equals(account.getTrashFolderName()) || folderName.equals(account.getSentFolderName()) ||
+                folderName.equals(account.getDraftsFolderName())) && !remoteFolder.exists() &&
+                !remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFinished(account, folderName, 0, 0);
             }
+
+            Timber.i("Done synchronizing folder %s", folderName);
+            return false;
         }
         return true;
     }

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -45,18 +45,18 @@ class SyncHelper {
      * designed and on Imap folders during error conditions. This allows us
      * to treat Pop3 and Imap the same in this code.
      */
-    boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
+    boolean verifyOrCreateRemoteSpecialFolder(Account account, String folderName, Folder remoteFolder,
             MessagingListener listener, MessagingController controller) throws MessagingException {
-        if (folder.equals(account.getTrashFolderName()) ||
-                folder.equals(account.getSentFolderName()) ||
-                folder.equals(account.getDraftsFolderName())) {
+        if (folderName.equals(account.getTrashFolderName()) ||
+                folderName.equals(account.getSentFolderName()) ||
+                folderName.equals(account.getDraftsFolderName())) {
             if (!remoteFolder.exists()) {
                 if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
                     for (MessagingListener l : controller.getListeners(listener)) {
-                        l.synchronizeMailboxFinished(account, folder, 0, 0);
+                        l.synchronizeMailboxFinished(account, folderName, 0, 0);
                     }
 
-                    Timber.i("Done synchronizing folder %s", folder);
+                    Timber.i("Done synchronizing folder %s", folderName);
                     return false;
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -21,9 +21,21 @@ import com.fsck.k9.mailstore.LocalStore;
 import timber.log.Timber;
 
 
-class SyncUtils {
+class SyncHelper {
 
-    static LocalFolder getOpenedLocalFolder(Account account, String folderName) throws MessagingException{
+    private static SyncHelper INSTANCE;
+
+    private SyncHelper() {
+    }
+
+    static SyncHelper getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SyncHelper();
+        }
+        return INSTANCE;
+    }
+
+    LocalFolder getOpenedLocalFolder(Account account, String folderName) throws MessagingException{
         final LocalStore localStore = account.getLocalStore();
         LocalFolder localFolder = localStore.getFolder(folderName);
         localFolder.open(Folder.OPEN_MODE_RW);
@@ -37,7 +49,7 @@ class SyncUtils {
      * designed and on Imap folders during error conditions. This allows us
      * to treat Pop3 and Imap the same in this code.
      */
-    static boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
+    boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
             MessagingListener listener, MessagingController controller) throws MessagingException {
         if (folder.equals(account.getTrashFolderName()) ||
                 folder.equals(account.getSentFolderName()) ||
@@ -56,7 +68,7 @@ class SyncUtils {
         return true;
     }
 
-    static boolean isMessageSuppressed(LocalMessage message, Context context) {
+    boolean isMessageSuppressed(LocalMessage message, Context context) {
         long messageId = message.getId();
         long folderId = message.getFolder().getId();
 
@@ -64,7 +76,7 @@ class SyncUtils {
         return cache.isMessageHidden(messageId, folderId);
     }
 
-    static boolean modeMismatch(Account.FolderMode aMode, Folder.FolderClass fMode) {
+    boolean modeMismatch(Account.FolderMode aMode, Folder.FolderClass fMode) {
         if (aMode == Account.FolderMode.NONE
                 || (aMode == Account.FolderMode.FIRST_CLASS &&
                 fMode != Folder.FolderClass.FIRST_CLASS)
@@ -79,7 +91,7 @@ class SyncUtils {
         }
     }
 
-    static void evaluateMessageForDownload(final Message message, final String folderName, final LocalFolder localFolder,
+    void evaluateMessageForDownload(final Message message, final String folderName, final LocalFolder localFolder,
             final Folder remoteFolder, final Account account, final List<Message> unsyncedMessages,
             final List< Message> syncFlagMessages, MessagingController controller) throws MessagingException {
         if (message.isSet(Flag.DELETED)) {
@@ -133,7 +145,7 @@ class SyncUtils {
         }
     }
 
-    static boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message, Contacts contacts) {
+    boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message, Contacts contacts) {
         // If we don't even have an account name, don't show the notification.
         // (This happens during initial account setup)
         if (account.getName() == null) {
@@ -151,12 +163,12 @@ class SyncUtils {
         Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
         Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
 
-        if (SyncUtils.modeMismatch(aDisplayMode, fDisplayClass)) {
+        if (modeMismatch(aDisplayMode, fDisplayClass)) {
             // Never notify a folder that isn't displayed
             return false;
         }
 
-        if (SyncUtils.modeMismatch(aNotifyMode, fNotifyClass)) {
+        if (modeMismatch(aNotifyMode, fNotifyClass)) {
             // Do not notify folders in the wrong class
             return false;
         }

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -83,8 +83,7 @@ class SyncHelper {
     }
 
     void deleteLocalMessages(Collection<String> deletedMessageUids, Account account, LocalFolder localFolder,
-            Folder remoteFolder, MessagingController controller, MessagingListener listener) throws IOException,
-            MessagingException {
+            MessagingController controller, MessagingListener listener) throws IOException, MessagingException {
         String folderName = localFolder.getName();
         Timber.v("SYNC: Deleting %d messages in the local cache that are not present in the remote mailbox for folder %s",
                 deletedMessageUids.size(), folderName);
@@ -98,8 +97,6 @@ class SyncHelper {
                     l.synchronizeMailboxRemovedMessage(account, folderName, destroyMessage);
                 }
             }
-
-            updateMoreMessages(account, localFolder, remoteFolder);
         }
     }
 
@@ -255,8 +252,8 @@ class SyncHelper {
         return true;
     }
 
-    private void updateMoreMessages(Account account, LocalFolder localFolder, Folder remoteFolder)
-            throws IOException, MessagingException {
+    void updateMoreMessages(Account account, LocalFolder localFolder, Folder remoteFolder) throws IOException,
+            MessagingException {
         final Date earliestDate = account.getEarliestPollDate();
         int remoteStart = getRemoteStart(localFolder, remoteFolder);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -21,7 +21,6 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
-import com.fsck.k9.mailstore.LocalStore;
 import timber.log.Timber;
 
 
@@ -37,13 +36,6 @@ class SyncHelper {
             INSTANCE = new SyncHelper();
         }
         return INSTANCE;
-    }
-
-    LocalFolder getOpenedLocalFolder(Account account, String folderName) throws MessagingException{
-        final LocalStore localStore = account.getLocalStore();
-        LocalFolder localFolder = localStore.getFolder(folderName);
-        localFolder.open(Folder.OPEN_MODE_RW);
-        return localFolder;
     }
 
     /*

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -8,6 +8,7 @@ import java.util.List;
 import android.content.Context;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9;
 import com.fsck.k9.cache.EmailProviderCache;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Flag;
@@ -66,6 +67,24 @@ class SyncHelper {
             }
         }
         return true;
+    }
+
+    int getRemoteStart(LocalFolder localFolder, Folder remoteFolder) throws MessagingException {
+        int remoteMessageCount = remoteFolder.getMessageCount();
+
+        int visibleLimit = localFolder.getVisibleLimit();
+        if (visibleLimit < 0) {
+            visibleLimit = K9.DEFAULT_VISIBLE_LIMIT;
+        }
+
+        int remoteStart;
+        /* Message numbers start at 1.  */
+        if (visibleLimit > 0) {
+            remoteStart = Math.max(0, remoteMessageCount - visibleLimit) + 1;
+        } else {
+            remoteStart = 1;
+        }
+        return remoteStart;
     }
 
     boolean isMessageSuppressed(LocalMessage message, Context context) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -133,8 +133,7 @@ class SyncHelper {
             return;
         }
 
-        //TODO: Use an optimized query here without fetching unnecessary message fields
-        Message localMessage = localFolder.getMessage(message.getUid());
+        Message localMessage = localFolder.getMessageUidAndFlags(message.getUid());
 
         if (localMessage == null) {
             if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncUtils.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncUtils.java
@@ -1,12 +1,19 @@
 package com.fsck.k9.controller;
 
 
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.cache.EmailProviderCache;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
@@ -70,5 +77,134 @@ class SyncUtils {
         } else {
             return false;
         }
+    }
+
+    static void evaluateMessageForDownload(final Message message, final String folderName, final LocalFolder localFolder,
+            final Folder remoteFolder, final Account account, final List<Message> unsyncedMessages,
+            final List< Message> syncFlagMessages, MessagingController controller) throws MessagingException {
+        if (message.isSet(Flag.DELETED)) {
+            Timber.v("Message with uid %s is marked as deleted", message.getUid());
+
+            syncFlagMessages.add(message);
+            return;
+        }
+
+        //TODO: Use an optimized query here without fetching unnecessary message fields
+        Message localMessage = localFolder.getMessage(message.getUid());
+
+        if (localMessage == null) {
+            if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
+                Timber.v("Message with uid %s has not yet been downloaded", message.getUid());
+
+                unsyncedMessages.add(message);
+            } else {
+                Timber.v("Message with uid %s is partially or fully downloaded", message.getUid());
+
+                // Store the updated message locally
+                localFolder.appendMessages(Collections.singletonList(message));
+
+                localMessage = localFolder.getMessage(message.getUid());
+
+                localMessage.setFlag(Flag.X_DOWNLOADED_FULL, message.isSet(Flag.X_DOWNLOADED_FULL));
+                localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, message.isSet(Flag.X_DOWNLOADED_PARTIAL));
+
+                for (MessagingListener l : controller.getListeners()) {
+                    if (!localMessage.isSet(Flag.SEEN)) {
+                        l.synchronizeMailboxNewMessage(account, folderName, localMessage);
+                    }
+                }
+            }
+        } else if (!localMessage.isSet(Flag.DELETED)) {
+            Timber.v("Message with uid %s is present in the local store", message.getUid());
+
+            if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
+                Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
+
+                unsyncedMessages.add(message);
+            } else {
+                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
+                if (newPushState != null) {
+                    localFolder.setPushState(newPushState);
+                }
+                syncFlagMessages.add(message);
+            }
+        } else {
+            Timber.v("Local copy of message with uid %s is marked as deleted", message.getUid());
+        }
+    }
+
+    static boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message, Contacts contacts) {
+        // If we don't even have an account name, don't show the notification.
+        // (This happens during initial account setup)
+        if (account.getName() == null) {
+            return false;
+        }
+
+        // Do not notify if the user does not have notifications enabled or if the message has
+        // been read.
+        if (!account.isNotifyNewMail() || message.isSet(Flag.SEEN)) {
+            return false;
+        }
+
+        Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
+        Account.FolderMode aNotifyMode = account.getFolderNotifyNewMailMode();
+        Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
+        Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
+
+        if (SyncUtils.modeMismatch(aDisplayMode, fDisplayClass)) {
+            // Never notify a folder that isn't displayed
+            return false;
+        }
+
+        if (SyncUtils.modeMismatch(aNotifyMode, fNotifyClass)) {
+            // Do not notify folders in the wrong class
+            return false;
+        }
+
+        // If the account is a POP3 account and the message is older than the oldest message we've
+        // previously seen, then don't notify about it.
+        if (account.getStoreUri().startsWith("pop3") &&
+                message.olderThan(new Date(account.getLatestOldMessageSeenTime()))) {
+            return false;
+        }
+
+        // No notification for new messages in Trash, Drafts, Spam or Sent folder.
+        // But do notify if it's the INBOX (see issue 1817).
+        Folder folder = message.getFolder();
+        if (folder != null) {
+            String folderName = folder.getName();
+            if (!account.getInboxFolderName().equals(folderName) &&
+                    (account.getTrashFolderName().equals(folderName)
+                            || account.getDraftsFolderName().equals(folderName)
+                            || account.getSpamFolderName().equals(folderName)
+                            || account.getSentFolderName().equals(folderName))) {
+                return false;
+            }
+        }
+
+        if (message.getUid() != null && localFolder.getLastUid() != null) {
+            try {
+                Integer messageUid = Integer.parseInt(message.getUid());
+                if (messageUid <= localFolder.getLastUid()) {
+                    Timber.d("Message uid is %s, max message uid is %s. Skipping notification.",
+                            messageUid, localFolder.getLastUid());
+                    return false;
+                }
+            } catch (NumberFormatException e) {
+                // Nothing to be done here.
+            }
+        }
+
+        // Don't notify if the sender address matches one of our identities and the user chose not
+        // to be notified for such messages.
+        if (account.isAnIdentity(message.getFrom()) && !account.isNotifySelfNewMail()) {
+            return false;
+        }
+
+        if (account.isNotifyContactsMailOnly() && !contacts.isAnyInContacts(message.getFrom())) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -2221,7 +2221,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
     public void checkMail() {
         if (isSingleAccountMode() && isSingleFolderMode()) {
-            messagingController.synchronizeMailbox(account, folderName, activityListener, null);
+            messagingController.synchronizeMailbox(account, folderName, activityListener);
             messagingController.sendPendingMessages(account, activityListener);
         } else if (allAccounts) {
             messagingController.checkMail(context, null, true, true, activityListener);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -188,16 +188,23 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
     }
 
-    void open(Cursor cursor) throws MessagingException {
+    public void open(Cursor cursor) throws MessagingException {
         mFolderId = cursor.getInt(LocalStore.FOLDER_ID_INDEX);
         mName = cursor.getString(LocalStore.FOLDER_NAME_INDEX);
         mVisibleLimit = cursor.getInt(LocalStore.FOLDER_VISIBLE_LIMIT_INDEX);
-        if (!cursor.isNull(LocalStore.FOLDER_UID_VALIDITY_INDEX)) {
-            uidValidity = cursor.getLong(LocalStore.FOLDER_UID_VALIDITY_INDEX);
+
+        //The index check here is because of an issue that occurs while upgrading the db to V55 - at that point, the
+        //uid_validity and highest_mod_Seq columns do not exist yet
+        int uidUalidityIndex = cursor.getColumnIndex("uid_validity");
+        if (uidUalidityIndex != -1 && !cursor.isNull(uidUalidityIndex)) {
+            uidValidity = cursor.getLong(uidUalidityIndex);
         }
-        if (!cursor.isNull(LocalStore.FOLDER_HIGHEST_MOD_SEQ_INDEX)) {
-            highestModSeq = cursor.getInt(LocalStore.FOLDER_HIGHEST_MOD_SEQ_INDEX);
+
+        int highestModSeqIndex = cursor.getColumnIndex("highest_mod_seq");
+        if (highestModSeqIndex != -1 && !cursor.isNull(highestModSeqIndex)) {
+            highestModSeq = cursor.getLong(highestModSeqIndex);
         }
+
         mPushState = cursor.getString(LocalStore.FOLDER_PUSH_STATE_INDEX);
         super.setStatus(cursor.getString(LocalStore.FOLDER_STATUS_INDEX));
         // Only want to set the local variable stored in the super class.  This class

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -452,7 +452,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         updateFolderColumn("uid_validity", uidValidity);
     }
 
-    public boolean isCachedUidValidityValid() throws MessagingException {
+    public boolean hasCachedUidValidity() throws MessagingException {
         return uidValidity != INVALID_UID_VALIDITY;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -27,6 +27,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.NonNull;
+
+import com.fsck.k9.mail.store.imap.ImapFolder;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
@@ -75,8 +77,6 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     private static final long serialVersionUID = -1973296520918624767L;
     private static final int MAX_BODY_SIZE_FOR_DATABASE = 16 * 1024;
     static final long INVALID_MESSAGE_PART_ID = -1;
-    private static final int INVALID_UID_VALIDITY = -1;
-    private static final int INVALID_HIGHEST_MOD_SEQ = -1;
 
     private final LocalStore localStore;
     private final AttachmentInfoExtractor attachmentInfoExtractor;
@@ -85,8 +85,8 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     private long mFolderId = -1;
     private int mVisibleLimit = -1;
     private String prefId = null;
-    private long uidValidity = INVALID_UID_VALIDITY;
-    private long highestModSeq = INVALID_HIGHEST_MOD_SEQ;
+    private long uidValidity = ImapFolder.INVALID_UID_VALIDITY;
+    private long highestModSeq = ImapFolder.INVALID_HIGHEST_MOD_SEQ;
     private FolderClass mDisplayClass = FolderClass.NO_CLASS;
     private FolderClass mSyncClass = FolderClass.INHERITED;
     private FolderClass mPushClass = FolderClass.SECOND_CLASS;
@@ -460,7 +460,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     public boolean hasCachedUidValidity() throws MessagingException {
-        return uidValidity != INVALID_UID_VALIDITY;
+        return uidValidity != ImapFolder.INVALID_UID_VALIDITY;
     }
 
     public void setHighestModSeq(final long highestModSeq) throws MessagingException {
@@ -469,12 +469,12 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     public void invalidateHighestModSeq() throws MessagingException {
-        this.highestModSeq = INVALID_HIGHEST_MOD_SEQ;
+        this.highestModSeq = ImapFolder.INVALID_HIGHEST_MOD_SEQ;
         updateFolderColumn("highest_mod_seq", null);
     }
 
     public boolean isCachedHighestModSeqValid() throws MessagingException {
-        return highestModSeq != INVALID_HIGHEST_MOD_SEQ;
+        return highestModSeq != ImapFolder.INVALID_HIGHEST_MOD_SEQ;
     }
 
     public void setPushState(final String pushState) throws MessagingException {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -452,9 +452,22 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         updateFolderColumn("uid_validity", uidValidity);
     }
 
+    public boolean isCachedUidValidityValid() throws MessagingException {
+        return uidValidity != INVALID_UID_VALIDITY;
+    }
+
     public void setHighestModSeq(final long highestModSeq) throws MessagingException {
         this.highestModSeq = highestModSeq;
         updateFolderColumn("highest_mod_seq", highestModSeq);
+    }
+
+    public void invalidateHighestModSeq() throws MessagingException {
+        this.highestModSeq = INVALID_HIGHEST_MOD_SEQ;
+        updateFolderColumn("highest_mod_seq", null);
+    }
+
+    public boolean isCachedHighestModSeqValid() throws MessagingException {
+        return highestModSeq != INVALID_HIGHEST_MOD_SEQ;
     }
 
     public void setPushState(final String pushState) throws MessagingException {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1016,10 +1016,9 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                                         "folder_id = ? ORDER BY date DESC",
                                 new String[] { Long.toString(mFolderId) });
 
-                        if (cursor.getCount() != 1) {
+                        if (!cursor.moveToFirst()) {
                             return null;
                         }
-                        cursor.moveToFirst();
                         return cursor.getLong(0);
                     } catch (MessagingException e) {
                         throw new WrappedException(e);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -909,6 +909,42 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
     }
 
+    public LocalMessage getMessageUidAndFlags(final String uid) throws MessagingException {
+        try {
+            return this.localStore.database.execute(false, new DbCallback<LocalMessage>() {
+                @Override
+                public LocalMessage doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
+                    try {
+                        open(OPEN_MODE_RW);
+                        LocalMessage message = new LocalMessage(LocalFolder.this.localStore, uid, LocalFolder.this);
+                        Cursor cursor = null;
+
+                        try {
+                            cursor = db.rawQuery(
+                                    "SELECT " +
+                                            "uid, flags, deleted, read, flagged, answered, forwarded " +
+                                            "FROM messages " +
+                                            "WHERE uid = ? AND folder_id = ?",
+                                    new String[] { message.getUid(), Long.toString(mFolderId) });
+
+                            if (!cursor.moveToNext()) {
+                                return null;
+                            }
+                            message.populateUidAndFlags(cursor);
+                        } finally {
+                            Utility.closeQuietly(cursor);
+                        }
+                        return message;
+                    } catch (MessagingException e) {
+                        throw new WrappedException(e);
+                    }
+                }
+            });
+        } catch (WrappedException e) {
+            throw(MessagingException) e.getCause();
+        }
+    }
+
     public Map<String,Long> getAllMessagesAndEffectiveDates() throws MessagingException {
         try {
             return  localStore.database.execute(false, new DbCallback<Map<String, Long>>() {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -113,14 +113,16 @@ public class LocalMessage extends MimeMessage {
             String[] flags = flagList.split(",");
 
             for (String flag : flags) {
+                if ("X_BAD_FLAG".equals(flag)) {
+                    continue;
+                }
+
                 try {
                     setFlagInternal(Flag.valueOf(flag), true);
                 }
 
                 catch (Exception e) {
-                    if (!"X_BAD_FLAG".equals(flag)) {
-                        Timber.w("Unable to parse flag %s", flag);
-                    }
+                    Timber.w("Unable to parse flag %s", flag);
                 }
             }
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -104,25 +104,25 @@ public class LocalStore extends Store implements Serializable {
                     "forwarded, message_part_id, messages.mime_type, preview_type, header ";
 
     static final String GET_FOLDER_COLS =
-            "folders.id, name, visible_limit, last_updated, status, uid_validity, highest_mod_seq, push_state, " +
-                    "last_pushed, integrate, top_group, poll_class, push_class, display_class, notify_class, more_messages";
+            "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, integrate, top_group, " +
+                    "poll_class, push_class, display_class, notify_class, more_messages, uid_validity, highest_mod_seq";
 
     static final int FOLDER_ID_INDEX = 0;
     static final int FOLDER_NAME_INDEX = 1;
     static final int FOLDER_VISIBLE_LIMIT_INDEX = 2;
     static final int FOLDER_LAST_CHECKED_INDEX = 3;
     static final int FOLDER_STATUS_INDEX = 4;
-    static final int FOLDER_UID_VALIDITY_INDEX = 5;
-    static final int FOLDER_HIGHEST_MOD_SEQ_INDEX = 6;
-    static final int FOLDER_PUSH_STATE_INDEX = 7;
-    static final int FOLDER_LAST_PUSHED_INDEX = 8;
-    static final int FOLDER_INTEGRATE_INDEX = 9;
-    static final int FOLDER_TOP_GROUP_INDEX = 10;
-    static final int FOLDER_SYNC_CLASS_INDEX = 11;
-    static final int FOLDER_PUSH_CLASS_INDEX = 12;
-    static final int FOLDER_DISPLAY_CLASS_INDEX = 13;
-    static final int FOLDER_NOTIFY_CLASS_INDEX = 14;
-    static final int MORE_MESSAGES_INDEX = 15;
+    static final int FOLDER_PUSH_STATE_INDEX = 5;
+    static final int FOLDER_LAST_PUSHED_INDEX = 6;
+    static final int FOLDER_INTEGRATE_INDEX = 7;
+    static final int FOLDER_TOP_GROUP_INDEX = 8;
+    static final int FOLDER_SYNC_CLASS_INDEX = 9;
+    static final int FOLDER_PUSH_CLASS_INDEX = 10;
+    static final int FOLDER_DISPLAY_CLASS_INDEX = 11;
+    static final int FOLDER_NOTIFY_CLASS_INDEX = 12;
+    static final int MORE_MESSAGES_INDEX = 13;
+    static final int FOLDER_UID_VALIDITY_INDEX = 14;
+    static final int FOLDER_HIGHEST_MOD_SEQ_INDEX = 15;
 
     static final String[] UID_CHECK_PROJECTION = { "uid" };
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -81,8 +81,8 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 "unread_count INTEGER, " +
                 "visible_limit INTEGER, " +
                 "status TEXT, " +
-                "uid_validity INTEGER default 0," +
-                "highest_mod_seq INTEGER default 0," +
+                "uid_validity INTEGER default null," +
+                "highest_mod_seq INTEGER default null," +
                 "push_state TEXT, " +
                 "last_pushed INTEGER, " +
                 "flagged_count INTEGER default 0, " +

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -81,8 +81,6 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 "unread_count INTEGER, " +
                 "visible_limit INTEGER, " +
                 "status TEXT, " +
-                "uid_validity INTEGER default null," +
-                "highest_mod_seq INTEGER default null," +
                 "push_state TEXT, " +
                 "last_pushed INTEGER, " +
                 "flagged_count INTEGER default 0, " +
@@ -92,7 +90,9 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 "push_class TEXT, " +
                 "display_class TEXT, " +
                 "notify_class TEXT default '"+ Folder.FolderClass.INHERITED.name() + "', " +
-                "more_messages TEXT default \"unknown\"" +
+                "more_messages TEXT default \"unknown\", " +
+                "uid_validity INTEGER default null, " +
+                "highest_mod_seq INTEGER default null" +
                 ")");
 
         db.execSQL("CREATE INDEX IF NOT EXISTS folder_name ON folders (name)");

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo55.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo55.java
@@ -2,11 +2,19 @@ package com.fsck.k9.mailstore.migrations;
 
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import android.content.ContentValues;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
+
+import com.fsck.k9.helper.Utility;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mailstore.LockableDatabase;
+import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
+import com.fsck.k9.mailstore.LockableDatabase.WrappedException;
 import timber.log.Timber;
 
 import com.fsck.k9.K9;
@@ -26,7 +34,7 @@ class MigrationTo55 {
         MessageFulltextCreator fulltextCreator = localStore.getMessageFulltextCreator();
 
         try {
-            List<LocalFolder> folders = localStore.getPersonalNamespaces(true);
+            List<LocalFolder> folders = getPersonalNamespaces(localStore);
             ContentValues cv = new ContentValues();
             FetchProfile fp = new FetchProfile();
             fp.add(FetchProfile.Item.BODY);
@@ -51,5 +59,43 @@ class MigrationTo55 {
         } catch (MessagingException e) {
             Timber.e(e, "error indexing fulltext - skipping rest, fts index is incomplete!");
         }
+    }
+
+    private static List<LocalFolder> getPersonalNamespaces(final LocalStore localStore) throws MessagingException {
+        final String FOLDER_COLS = "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, " +
+                "integrate, top_group, poll_class, push_class, display_class, notify_class, more_messages";
+        final List<LocalFolder> folders = new LinkedList<>();
+        LockableDatabase database = localStore.getDatabase();
+        try {
+            database.execute(false, new DbCallback< List <? extends Folder>>() {
+                @Override
+                public List <? extends Folder> doDbWork(final SQLiteDatabase db) throws WrappedException {
+                    Cursor cursor = null;
+
+                    try {
+                        cursor = db.rawQuery("SELECT " + FOLDER_COLS + " FROM folders " +
+                                "ORDER BY name ASC", null);
+                        while (cursor.moveToNext()) {
+                            if (cursor.isNull(0)) {
+                                continue;
+                            }
+                            String folderName = cursor.getString(1);
+                            LocalFolder folder = new LocalFolder(localStore, folderName);
+                            folder.open(cursor);
+
+                            folders.add(folder);
+                        }
+                        return folders;
+                    } catch (MessagingException e) {
+                        throw new WrappedException(e);
+                    } finally {
+                        Utility.closeQuietly(cursor);
+                    }
+                }
+            });
+        } catch (WrappedException e) {
+            throw(MessagingException) e.getCause();
+        }
+        return folders;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo61.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo61.java
@@ -8,7 +8,7 @@ import android.database.sqlite.SQLiteException;
 class MigrationTo61 {
     public static void foldersAddUidValidityColumn(SQLiteDatabase db) {
         try {
-            db.execSQL("ALTER TABLE folders ADD uid_validity INTEGER default 0");
+            db.execSQL("ALTER TABLE folders ADD uid_validity INTEGER default null");
         } catch (SQLiteException e) {
             if (!e.getMessage().startsWith("duplicate column name:")) {
                 throw e;
@@ -18,7 +18,7 @@ class MigrationTo61 {
 
     public static void foldersAddHighestModSeqColumn(SQLiteDatabase db) {
         try {
-            db.execSQL("ALTER TABLE folders ADD highest_mod_seq INTEGER default 0");
+            db.execSQL("ALTER TABLE folders ADD highest_mod_seq INTEGER default null");
         } catch (SQLiteException e) {
             if (!e.getMessage().startsWith("duplicate column name:")) {
                 throw e;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -82,6 +82,12 @@ public class GlobalSettings {
         s.put("enableSensitiveLogging", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));
+        s.put("useCondstore", Settings.versions(
+                new V(48, new BooleanSetting(true))
+        ));
+        s.put("useQresync", Settings.versions(
+                new V(48, new BooleanSetting(true))
+        ));
         s.put("fontSizeAccountDescription", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
         ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 47;
+    public static final int VERSION = 48;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -256,6 +256,12 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="debug_enable_debug_logging_summary">Log extra diagnostic information</string>
     <string name="debug_enable_sensitive_logging_title">Log sensitive information</string>
     <string name="debug_enable_sensitive_logging_summary">May show passwords in logs.</string>
+    <string name="debug_do_not_use_condstore_extension_summary">Do not use the CONDSTORE extension even if available
+        during synchronization</string>
+    <string name="debug_do_not_use_condstore_extension_title">Don\'t use CONDSTORE</string>
+    <string name="debug_do_not_use_qresync_extension_summary">Do not use the QRESYNC extension even if available during
+        synchronization</string>
+    <string name="debug_do_not_use_qresync_extension_title">Don\'t use QRESYNC</string>
 
     <string name="message_list_load_more_messages_action">Load more messages</string>
     <string name="message_to_fmt">To:<xliff:g id="counterParty">%s</xliff:g></string>

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -401,6 +401,18 @@
             android:title="@string/debug_enable_sensitive_logging_title"
             android:summary="@string/debug_enable_sensitive_logging_summary" />
 
+        <CheckBoxPreference
+            android:key="condstore_extension"
+            android:persistent="false"
+            android:summary="@string/debug_do_not_use_condstore_extension_summary"
+            android:title="@string/debug_do_not_use_condstore_extension_title" />
+
+        <CheckBoxPreference
+            android:key="qresync_extension"
+            android:persistent="false"
+            android:summary="@string/debug_do_not_use_qresync_extension_summary"
+            android:title="@string/debug_do_not_use_qresync_extension_title" />
+
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
@@ -1,0 +1,207 @@
+package com.fsck.k9.controller;
+
+
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.FetchProfile.Item;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest=Config.NONE)
+public class FlagSyncHelperTest {
+
+    private Account account;
+    private Folder remoteFolder;
+    private LocalFolder localFolder;
+    private MessagingListener listener;
+
+    private SyncHelper syncHelper;
+    private FlagSyncHelper flagSyncHelper;
+
+    @Before
+    public void setUp() {
+        account = mock(Account.class);
+        remoteFolder = mock(Folder.class);
+        localFolder = mock(LocalFolder.class);
+        Context appContext = ShadowApplication.getInstance().getApplicationContext();
+        MessagingController controller = mock(MessagingController.class);
+        listener = mock(MessagingListener.class);
+        when(controller.getListeners()).thenReturn(singleton(listener));
+
+        syncHelper = mock(SyncHelper.class);
+        flagSyncHelper = FlagSyncHelper.newInstance(appContext, controller, syncHelper);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withSupportsFetchingFlagsTrue_shouldFetchAndProcessRemoteFlags()
+            throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder).fetch(syncFlagMessages, flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withSupportsFetchingFlagsFalse_shouldNotFetchRemoteFlags() throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder, never()).fetch(syncFlagMessages, flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withDeletedMessages_shouldNotFetchFlagsForDeletedMessages() throws Exception {
+        Message nonDeletedMessage = createMessage(false);
+        Message deletedMessage = createMessage(true);
+        List<Message> syncFlagMessages = asList(nonDeletedMessage, deletedMessage);
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder).fetch(singletonList(nonDeletedMessage), flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withListener_shouldCallListener() throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(listener).synchronizeMailboxProgress(account, localFolder.getName(), 1, 1);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessage_shouldUpdateLocalMessage() throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false, true);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage).setFlag(Flag.SEEN, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedLocalMessage_shouldNotUpdateLocalMessage() throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false, true);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+        when(localMessage.isSet(Flag.DELETED)).thenReturn(true);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage, never()).setFlag(any(Flag.class), anyBoolean());
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedRemoteMessageAndSyncRemoteDeletionsTrue_shouldDeleteLocalMessage()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false, true);
+        when(remoteMessage.isSet(Flag.DELETED)).thenReturn(true);
+        when(localMessage.getFolder()).thenReturn(localFolder);
+        when(localFolder.syncRemoteDeletions()).thenReturn(true);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage).setFlag(Flag.DELETED, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedRemoteMessageAndSyncRemoteDeletionsFalse_shouldNotDeleteLocalMessage()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false, true);
+        when(remoteMessage.isSet(Flag.DELETED)).thenReturn(true);
+        when(localMessage.getFolder()).thenReturn(localFolder);
+        when(localFolder.syncRemoteDeletions()).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage, never()).setFlag(Flag.DELETED, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessageAndSuppressedLocalMessage_shouldNotifyListener()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(true, true);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, localFolder.getName(), localMessage);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessageAndNonSuppressedLocalMessage_shouldNotNotifyListener()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false, true);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(listener, never()).synchronizeMailboxRemovedMessage(account, localFolder.getName(), localMessage);
+    }
+
+    private Message createMessage(boolean deletedFlagSet) {
+        Message message = mock(Message.class);
+        when(message.isSet(Flag.DELETED)).thenReturn(deletedFlagSet);
+        return message;
+    }
+
+    private LocalMessage createLocalMessageInFolder(boolean suppressed, boolean notifiedOf) throws MessagingException {
+        LocalMessage localMessage = mock(LocalMessage.class);
+        when(localFolder.getMessage(anyString())).thenReturn(localMessage);
+        when(syncHelper.isMessageSuppressed(eq(localMessage), any(Context.class))).thenReturn(suppressed);
+        when(syncHelper.shouldNotifyForMessage(eq(account), eq(localFolder), eq(localMessage), any(Contacts.class)))
+                .thenReturn(notifiedOf);
+        return localMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
 public class FlagSyncHelperTest {
 
     private Account account;

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class ImapSyncInteractorTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -1,0 +1,359 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Account.Expunge;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Store;
+import com.fsck.k9.mail.store.RemoteStore;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.QresyncParamResponse;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
+import static edu.emory.mathcs.backport.java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ImapSyncInteractorTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final long CACHED_UID_VALIDITY = 1L;
+    private static final long CURRENT_UID_VALIDITY = 2L;
+    private static final long CACHED_HIGHEST_MOD_SEQ = 3L;
+    private static final long CURRENT_HIGHEST_MOD_SEQ = 4L;
+    private static final List<String> LOCAL_MESSAGE_UIDS = singletonList("1");
+
+    private ImapSyncInteractor syncInteractor;
+    private Account account;
+    private LocalFolder localFolder;
+    private ImapFolder imapFolder;
+    private MessagingListener listener;
+    private MessagingController controller;
+    private FlagSyncHelper flagSyncHelper;
+    private MessageDownloader messageDownloader;
+    private SyncHelper syncHelper;
+
+    @Before
+    public void setUp() throws Exception {
+        account = mock(Account.class);
+        localFolder = mock(LocalFolder.class);
+        imapFolder = mock(ImapFolder.class);
+        listener = mock(MessagingListener.class);
+        controller = mock(MessagingController.class);
+        flagSyncHelper = mock(FlagSyncHelper.class);
+        messageDownloader = mock(MessageDownloader.class);
+        syncHelper = mock(SyncHelper.class);
+
+        configureLocalFolder();
+        configureRemoteFolder();
+
+        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
+                .thenReturn(true);
+        when(syncHelper.getOpenedLocalFolder(account, FOLDER_NAME)).thenReturn(localFolder);
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+        Store remoteStore = mock(RemoteStore.class);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn((Folder) imapFolder);
+
+        syncInteractor = new ImapSyncInteractor(account, FOLDER_NAME, listener, controller);
+    }
+
+    @Test
+    public void performSync_withProcessPendingCommandsSynchronousThrowingException_shouldFinishWithError()
+            throws Exception {
+        doThrow(MessagingException.class).when(controller).processPendingCommandsSynchronous(account);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+    @Test
+    public void performSync_withImapFolder_shouldFinishWithoutError() throws Exception {
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(listener).synchronizeMailboxFinished(eq(account), eq(FOLDER_NAME), anyInt(), anyInt());
+    }
+
+    @Test
+    public void performSync_withNonImapFolder_shouldFinishWithError() throws Exception {
+        Store remoteStore = mock(RemoteStore.class);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(mock(Folder.class));
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+
+    @Test
+    public void performSync_withRemoteFolderCreationFailed_shouldExitWithoutOpeningRemoteFolder() throws Exception {
+        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
+                .thenReturn(false);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder, never()).openUsingQresyncParam(anyInt(), anyLong(), anyLong());
+    }
+
+    @Test
+    public void performSync_withValidCachedUidValidityAndHighestModSeq_shouldOpenFolderUsingQresyncParams()
+            throws Exception {
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder).openUsingQresyncParam(OPEN_MODE_RW, CACHED_UID_VALIDITY, CACHED_HIGHEST_MOD_SEQ);
+    }
+    @Test
+    public void performSync_withInvalidCachedUidValidity_shouldOpenImapFolderNormally() throws Exception {
+        when(localFolder.isCachedUidValidityValid()).thenReturn(false);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder).open(OPEN_MODE_RW);
+    }
+
+    @Test
+    public void performSync_withInvalidCachedHighestModSeq_shouldOpenImapFolderNormally() throws Exception {
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(false);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder).open(OPEN_MODE_RW);
+    }
+
+    @Test
+    public void performSync_withQresyncEnabledAndAccountSetToExpungeOnPoll_shouldExpungeRemoteFolder()
+            throws Exception {
+        when(imapFolder.openUsingQresyncParam(OPEN_MODE_RW, CACHED_UID_VALIDITY, CACHED_HIGHEST_MOD_SEQ))
+                .thenReturn(mock(QresyncParamResponse.class));
+        when(account.getExpungePolicy()).thenReturn(Expunge.EXPUNGE_ON_POLL);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder).expungeUsingQresync();
+    }
+
+    @Test
+    public void performSync_withoutQresyncEnabledAndAccountSetToExpungeOnPoll_shouldExpungeRemoteFolder()
+            throws Exception {
+        when(imapFolder.openUsingQresyncParam(OPEN_MODE_RW, CACHED_UID_VALIDITY, CACHED_HIGHEST_MOD_SEQ))
+                .thenReturn(null);
+        when(account.getExpungePolicy()).thenReturn(Expunge.EXPUNGE_ON_POLL);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder).expunge();
+    }
+
+    @Test
+    public void performSync_withAccountNotSetToExpungeOnPoll_shouldNotExpungeRemoteFolder() throws Exception {
+        when(account.getExpungePolicy()).thenReturn(Expunge.EXPUNGE_MANUALLY);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(imapFolder, never()).expunge();
+        verify(imapFolder, never()).expungeUsingQresync();
+    }
+
+    @Test
+    public void performSync_withNegativeMessageCount_shouldFinishWithError() throws Exception {
+        when(imapFolder.getMessageCount()).thenReturn(-1);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+
+    @Test
+    public void performSync_withDifferentUidValidity_shouldDeleteAllLocallyStoredMessages() throws Exception {
+        when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder).destroyMessages(localMessages);
+    }
+
+    @Test
+    public void performSync_withDifferentUidValidity_shouldNotifyListenersOfDeletion() throws Exception {
+        when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, FOLDER_NAME, localMessages.get(0));
+    }
+
+    @Test
+    public void performSync_withDifferentUidValidity_shouldClearHighestModSeq() throws Exception {
+        when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
+        configureLocalFolderWithSingleMessage();
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder, atLeastOnce()).invalidateHighestModSeq();
+    }
+
+    @Test
+    public void performSync_withEqualUidValidity_shouldNotDeleteAllLocallyStoredMessages() throws Exception {
+        when(imapFolder.getUidValidity()).thenReturn(CACHED_UID_VALIDITY);
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder, never()).destroyMessages(localMessages);
+    }
+
+    @Test
+    public void performSync_withInvalidCachedUidValidity_shouldNotDeleteAllLocallyStoredMessages() throws Exception {
+        when(localFolder.isCachedUidValidityValid()).thenReturn(false);
+        when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder, never()).destroyMessages(localMessages);
+    }
+
+    @Test
+    public void performSync_shouldUpdateCachedUidValidity() throws Exception {
+        when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder).setUidValidity(CURRENT_UID_VALIDITY);
+    }
+
+    @Test
+    public void performSync_withFolderSupportingModSeqs_shouldUpdateCachedHighestModSeq() throws Exception {
+        when(imapFolder.supportsModSeq()).thenReturn(true);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder).setHighestModSeq(CURRENT_HIGHEST_MOD_SEQ);
+    }
+
+    @Test
+    public void performSync_withFolderNotSupportingModSeqs_shouldInvalidateCachedHighestModSeq() throws Exception {
+        when(imapFolder.supportsModSeq()).thenReturn(false);
+
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder).invalidateHighestModSeq();
+    }
+
+    @Test
+    public void performSync_afterCompletion_shouldCloseFolders() throws Exception {
+        syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
+
+        verify(localFolder).close();
+        verify(imapFolder).close();
+    }
+
+    @Test
+    public void syncRemoteDeletions_withNonEmptyMessageUidList_shouldDeleteLocalCopiesOfMessages() throws Exception {
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.syncRemoteDeletions(LOCAL_MESSAGE_UIDS, syncHelper);
+
+        verify(localFolder).destroyMessages(localMessages);
+    }
+
+    @Test
+    public void syncRemoteDeletions_withNonEmptyMessageUidList_shouldNotifyListeners() throws Exception {
+        List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
+
+        syncInteractor.syncRemoteDeletions(LOCAL_MESSAGE_UIDS, syncHelper);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, FOLDER_NAME, localMessages.get(0));
+    }
+
+    @Test
+    public void syncRemoteDeletions_withNonEmptyMessageUidListAndRemoteStartAsOne_shouldNotCheckForMoreMessages()
+            throws Exception {
+        configureLocalFolderWithSingleMessage();
+        when(syncHelper.getRemoteStart(localFolder, imapFolder)).thenReturn(1);
+
+        syncInteractor.syncRemoteDeletions(LOCAL_MESSAGE_UIDS, syncHelper);
+
+        verify(imapFolder, never()).areMoreMessagesAvailable(anyInt(), any(Date.class));
+        verify(localFolder).setMoreMessages(MoreMessages.FALSE);
+    }
+
+    @Test
+    public void syncRemoteDeletions_withNonEmptyMessageUidListAndMoreMessagesAvailable_shouldSetMoreMessagesAsTrue()
+            throws Exception {
+        configureLocalFolderWithSingleMessage();
+        when(imapFolder.areMoreMessagesAvailable(anyInt(), any(Date.class))).thenReturn(true);
+
+        syncInteractor.syncRemoteDeletions(LOCAL_MESSAGE_UIDS, syncHelper);
+
+        verify(localFolder).setMoreMessages(MoreMessages.TRUE);
+    }
+
+    @Test
+    public void syncRemoteDeletions_withNonEmptyMessageUidListAndNoMoreMessagesAvailable_shouldSetMoreMessagesAsFalse()
+            throws Exception {
+        configureLocalFolderWithSingleMessage();
+        when(imapFolder.areMoreMessagesAvailable(anyInt(), any(Date.class))).thenReturn(false);
+
+        syncInteractor.syncRemoteDeletions(LOCAL_MESSAGE_UIDS, syncHelper);
+
+        verify(localFolder).setMoreMessages(MoreMessages.FALSE);
+    }
+
+    @Test
+    public void syncRemoteDeletions_withEmptyMessageUidList_shouldNotCheckForMoreMessages() throws Exception {
+        syncInteractor.syncRemoteDeletions(emptyList(), syncHelper);
+
+        verify(imapFolder, never()).areMoreMessagesAvailable(anyInt(), any(Date.class));
+    }
+
+    private void configureLocalFolder() throws Exception {
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.isCachedUidValidityValid()).thenReturn(true);
+        when(localFolder.getUidValidity()).thenReturn(CACHED_UID_VALIDITY);
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
+        when(localFolder.getHighestModSeq()).thenReturn(CACHED_HIGHEST_MOD_SEQ);
+    }
+
+    private void configureRemoteFolder() throws Exception {
+        when(imapFolder.getName()).thenReturn(FOLDER_NAME);
+        when(imapFolder.getUidValidity()).thenReturn(CACHED_UID_VALIDITY);
+        when(imapFolder.getHighestModSeq()).thenReturn(CURRENT_HIGHEST_MOD_SEQ);
+    }
+
+    private List<LocalMessage> configureLocalFolderWithSingleMessage() throws Exception {
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap(LOCAL_MESSAGE_UIDS.get(0), 1L));
+        List<LocalMessage> localMessages = singletonList(mock(LocalMessage.class));
+        when(localFolder.getMessagesByUids(anyCollection())).thenReturn(localMessages);
+        return localMessages;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -26,7 +26,6 @@ import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -241,27 +240,6 @@ public class ImapSyncInteractorTest {
 
         verify(localFolder, never()).destroyMessages(localMessages);
     }
-
-    @Test
-    public void performSync_withSyncRemoteDeletionsSetToTrue_shouldDeleteLocalCopiesIfNecessary() throws Exception {
-        when(account.syncRemoteDeletions()).thenReturn(true);
-
-        syncInteractor.performSync(account, FOLDER_NAME, listener);
-
-        verify(syncHelper).deleteLocalMessages(anyCollection(), eq(account), eq(localFolder), eq(imapFolder),
-                eq(controller), eq(listener));
-    }
-
-    @Test
-    public void performSync_withSyncRemoteDeletionsSetToFalse_shouldDeleteLocalCopiesIfNecessary() throws Exception {
-        when(account.syncRemoteDeletions()).thenReturn(false);
-
-        syncInteractor.performSync(account, FOLDER_NAME, listener);
-
-        verify(syncHelper, never()).deleteLocalMessages(anyCollection(), any(Account.class), any(LocalFolder.class),
-                any(Folder.class), any(MessagingController.class), any(MessagingListener.class));
-    }
-
 
     @Test
     public void performSync_shouldUpdateCachedUidValidity() throws Exception {

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -131,8 +131,8 @@ public class ImapSyncInteractorTest {
         verify(imapFolder).openUsingQresyncParam(OPEN_MODE_RW, CACHED_UID_VALIDITY, CACHED_HIGHEST_MOD_SEQ);
     }
     @Test
-    public void performSync_withInvalidCachedUidValidity_shouldOpenImapFolderNormally() throws Exception {
-        when(localFolder.isCachedUidValidityValid()).thenReturn(false);
+    public void performSync_withoutCachedUidValidity_shouldOpenImapFolderNormally() throws Exception {
+        when(localFolder.hasCachedUidValidity()).thenReturn(false);
 
         syncInteractor.performSync(flagSyncHelper, messageDownloader, syncHelper);
 
@@ -232,8 +232,8 @@ public class ImapSyncInteractorTest {
     }
 
     @Test
-    public void performSync_withInvalidCachedUidValidity_shouldNotDeleteAllLocallyStoredMessages() throws Exception {
-        when(localFolder.isCachedUidValidityValid()).thenReturn(false);
+    public void performSync_withoutCachedUidValidity_shouldNotDeleteAllLocallyStoredMessages() throws Exception {
+        when(localFolder.hasCachedUidValidity()).thenReturn(false);
         when(imapFolder.getUidValidity()).thenReturn(CURRENT_UID_VALIDITY);
         List<LocalMessage> localMessages = configureLocalFolderWithSingleMessage();
 
@@ -338,7 +338,7 @@ public class ImapSyncInteractorTest {
 
     private void configureLocalFolder() throws Exception {
         when(localFolder.getName()).thenReturn(FOLDER_NAME);
-        when(localFolder.isCachedUidValidityValid()).thenReturn(true);
+        when(localFolder.hasCachedUidValidity()).thenReturn(true);
         when(localFolder.getUidValidity()).thenReturn(CACHED_UID_VALIDITY);
         when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
         when(localFolder.getHighestModSeq()).thenReturn(CACHED_HIGHEST_MOD_SEQ);

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -14,6 +14,7 @@ import com.fsck.k9.mail.store.imap.ImapFolder;
 import com.fsck.k9.mail.store.imap.QresyncParamResponse;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.notification.NotificationController;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,13 +76,17 @@ public class ImapSyncInteractorTest {
         configureLocalFolder();
         configureRemoteFolder();
 
-        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
-                .thenReturn(true);
-        when(syncHelper.getOpenedLocalFolder(account, FOLDER_NAME)).thenReturn(localFolder);
-        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+        LocalStore localStore = mock(LocalStore.class);
+        when(account.getLocalStore()).thenReturn(localStore);
+        when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+
         Store remoteStore = mock(RemoteStore.class);
         when(account.getRemoteStore()).thenReturn(remoteStore);
         when(remoteStore.getFolder(FOLDER_NAME)).thenReturn((Folder) imapFolder);
+
+        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
+                .thenReturn(true);
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
 
         syncInteractor = new ImapSyncInteractor(account, FOLDER_NAME, listener, controller);
     }

--- a/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
@@ -1,0 +1,235 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.RemoteStore;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.notification.NotificationController;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.Config;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class LegacySyncInteractorTest {
+
+    private static final String FOLDER_NAME = "Folder";
+
+    private LegacySyncInteractor syncInteractor;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private NotificationController notificationController;
+    @Captor
+    private ArgumentCaptor<List<Message>> messageListCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        syncInteractor = new LegacySyncInteractor(account, FOLDER_NAME, listener, controller);
+
+        configureLocalStoreWithFolder();
+        configureRemoteStoreWithFolder();
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+    }
+
+    @Test
+    public void performSync_withOneMessageInRemoteFolder_shouldFinishWithoutError() throws Exception {
+        messageCountInRemoteFolder(1);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 1, 0);
+    }
+
+    @Test
+    public void performSync_withEmptyRemoteFolder_shouldFinishWithoutError() throws Exception {
+        messageCountInRemoteFolder(0);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 0, 0);
+    }
+
+    @Test
+    public void performSync_withNegativeMessageCountInRemoteFolder_shouldFinishWithError() throws Exception {
+        messageCountInRemoteFolder(-1);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(listener).synchronizeMailboxFailed(account, FOLDER_NAME,
+                "Exception: Message count -1 for folder Folder");
+    }
+
+    @Test
+    public void performSync_shouldOpenRemoteFolderFromStore() throws Exception {
+        messageCountInRemoteFolder(1);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(remoteFolder).open(Folder.OPEN_MODE_RW);
+    }
+
+    @Test
+    public void performSync_withAccountPolicySetToExpungeOnPoll_shouldExpungeRemoteFolder() throws Exception {
+        messageCountInRemoteFolder(1);
+        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(remoteFolder).expunge();
+    }
+
+    @Test
+    public void performSync_withAccountPolicySetToExpungeManually_shouldNotExpungeRemoteFolder() throws Exception {
+        messageCountInRemoteFolder(1);
+        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_MANUALLY);
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(remoteFolder, never()).expunge();
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages() throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap("1", 0L));
+        when(localFolder.getMessagesByUids(any(List.class)))
+                .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate()
+            throws Exception {
+        messageCountInRemoteFolder(1);
+        Date dateOfEarliestPoll = new Date();
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate()
+            throws Exception {
+        messageCountInRemoteFolder(1);
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        Date dateOfEarliestPoll = new Date();
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(true);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap("1", 0L));
+        when(localFolder.getMessagesByUids(any(List.class))).thenReturn(Collections.singletonList(localMessage));
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void performSync_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages()
+            throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage remoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(remoteDeletedMessage));
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+    @Test
+    public void performSync_shouldDownloadUnsyncedMessagesAndSyncLocalMessageFlags() throws Exception {
+        messageCountInRemoteFolder(1);
+        localMessageWithCopyOnServer();
+
+        syncInteractor.performSync(messageDownloader, notificationController);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(remoteFolder), eq(localFolder),
+                messageListCaptor.capture(), eq(true), eq(true));
+        assertEquals(messageListCaptor.getValue().size(), 1);
+    }
+
+    private void configureLocalStoreWithFolder() throws MessagingException {
+        LocalStore localStore = mock(LocalStore.class);
+        when(account.getLocalStore()).thenReturn(localStore);
+        when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+
+    private void configureRemoteStoreWithFolder() throws MessagingException {
+        RemoteStore remoteStore = mock(RemoteStore.class);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+
+    private void messageCountInRemoteFolder(int value) throws MessagingException {
+        when(remoteFolder.getMessageCount()).thenReturn(value);
+    }
+
+    private LocalMessage localMessageWithCopyOnServer() throws MessagingException {
+        String messageUid = "UID";
+        Message remoteMessage = mock(Message.class);
+        LocalMessage localMessage = mock(LocalMessage.class);
+
+        when(remoteMessage.getUid()).thenReturn(messageUid);
+        when(localMessage.getUid()).thenReturn(messageUid);
+        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(Collections.singletonList(remoteMessage));
+        return localMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class LegacySyncInteractorTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class MessageDownloaderTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
@@ -1,0 +1,201 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Date;
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.AccountStats;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.shadows.ShadowLog;
+
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class MessageDownloaderTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
+
+    private MessageDownloader messageDownloader;
+
+    @Mock
+    private Account account;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private SyncHelper syncHelper;
+    @Mock
+    private Message unsyncedRemoteMessage;
+    @Captor
+    private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
+
+    @Before
+    public void setUp() throws MessagingException {
+        ShadowLog.stream = System.out;
+        MockitoAnnotations.initMocks(this);
+        Context context = ShadowApplication.getInstance().getApplicationContext();
+
+        messageDownloader = MessageDownloader.newInstance(context, controller, syncHelper);
+
+        when(account.getStats(any(Context.class))).thenReturn(mock(AccountStats.class));
+        when(account.getMaximumAutoDownloadMessageSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE);
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Message remoteMessage = invocation.getArgumentAt(0, Message.class);
+                List<Message> unsyncedMessages = invocation.getArgumentAt(5, List.class);
+                unsyncedMessages.add(remoteMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(any(Message.class), eq(FOLDER_NAME), eq(localFolder),
+                eq(remoteFolder), eq(account), any(List.class), any(List.class), eq(controller));
+    }
+
+    @Test
+    public void downloadMessages_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesEnvelopeAndFlags()
+            throws Exception {
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(unsyncedRemoteMessage), true,
+                true);
+
+        verify(remoteFolder, atLeastOnce()).fetch(anyList(), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.FLAGS));
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+        assertEquals(2, fetchProfileCaptor.getAllValues().get(0).size());
+    }
+
+    @Test
+    public void downloadMessages_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessagesEnvelope()
+            throws Exception {
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(unsyncedRemoteMessage), true,
+                true);
+
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(0).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+    }
+
+    @Test
+    public void downloadMessages_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage()
+            throws Exception {
+        Message smallMessage = buildSmallNewMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        respondToFetchEnvelopesWithMessage(smallMessage);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(smallMessage), true,
+                true);
+
+        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(1).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(1).contains(FetchProfile.Item.BODY));
+    }
+
+    @Test
+    public void downloadMessages_withUnsyncedNewLargeMessage_shouldFetchStructureAndLimitedBodyOfLargeMessage()
+            throws Exception {
+        final Message largeMessage = buildLargeNewMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        respondToFetchEnvelopesWithMessage(largeMessage);
+        when(localFolder.appendMessages(anyList())).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                when(localFolder.getMessage(anyString())).thenReturn(mock(LocalMessage.class));
+                return null;
+            }
+        });
+        when(localFolder.getMessage(anyString())).thenReturn(mock(LocalMessage.class));
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(largeMessage), true,
+                true);
+
+        //TODO: Don't bother fetching messages of a size we don't have
+        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(2).size());
+        assertEquals(FetchProfile.Item.STRUCTURE, fetchProfileCaptor.getAllValues().get(2).get(0));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
+        assertEquals(FetchProfile.Item.BODY_SANE, fetchProfileCaptor.getAllValues().get(3).get(0));
+    }
+
+    private Message buildSmallNewMessage() {
+        Message message = mock(Message.class);
+        when(message.olderThan(any(Date.class))).thenReturn(false);
+        when(message.getSize()).thenReturn((long) MAXIMUM_SMALL_MESSAGE_SIZE);
+        return message;
+    }
+
+    private Message buildLargeNewMessage() {
+        Message message = mock(Message.class);
+        when(message.olderThan(any(Date.class))).thenReturn(false);
+        when(message.getSize()).thenReturn((long) (MAXIMUM_SMALL_MESSAGE_SIZE + 1));
+        return message;
+    }
+
+    private void respondToFetchEnvelopesWithMessage(final Message message) throws MessagingException {
+        doAnswer(new Answer() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                FetchProfile fetchProfile = (FetchProfile) invocation.getArguments()[1];
+                if (invocation.getArguments()[2] != null) {
+                    MessageRetrievalListener listener = (MessageRetrievalListener) invocation.getArguments()[2];
+                    if (fetchProfile.contains(FetchProfile.Item.ENVELOPE)) {
+                        listener.messageStarted("UID", 1, 1);
+                        listener.messageFinished(message, 1, 1);
+                        listener.messagesFinished(1);
+                    }
+                }
+                return null;
+            }
+        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -4,7 +4,6 @@ package com.fsck.k9.controller;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,17 +45,16 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLog;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -71,14 +69,15 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MessagingControllerTest {
+
     private static final String FOLDER_NAME = "Folder";
     private static final String SENT_FOLDER_NAME = "Sent";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
-    private static final String MESSAGE_UID1 = "message-uid1";
-
 
     private MessagingController controller;
+
     @Mock
     private Contacts contacts;
     @Mock
@@ -108,8 +107,6 @@ public class MessagingControllerTest {
     @Mock
     private Transport transport;
     @Captor
-    private ArgumentCaptor<List<Message>> messageListCaptor;
-    @Captor
     private ArgumentCaptor<List<LocalFolder>> localFolderListCaptor;
     @Captor
     private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
@@ -134,7 +131,6 @@ public class MessagingControllerTest {
     @Mock
     private LocalMessage localMessageToSend1;
     private volatile boolean hasFetchedMessage = false;
-
 
     @Before
     public void setUp() throws MessagingException {
@@ -425,7 +421,7 @@ public class MessagingControllerTest {
                  return null;
              }
         }).when(remoteFolder).fetch(
-            Matchers.<List<Message>>eq(Collections.singletonList(remoteNewMessage2)),
+            Matchers.eq(Collections.singletonList(remoteNewMessage2)),
             any(FetchProfile.class),
             Matchers.<MessageRetrievalListener>eq(null));
         reqFlags = Collections.singleton(Flag.ANSWERED);
@@ -625,232 +621,6 @@ public class MessagingControllerTest {
         verify(listener).sendPendingMessagesCompleted(account);
     }
 
-
-    @Test
-    public void synchronizeMailboxSynchronous_withOneMessageInRemoteFolder_shouldFinishWithoutError()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 1, 0);
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withEmptyRemoteFolder_shouldFinishWithoutError()
-            throws Exception {
-        messageCountInRemoteFolder(0);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 0, 0);
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withNegativeMessageCountInRemoteFolder_shouldFinishWithError()
-            throws Exception {
-        messageCountInRemoteFolder(-1);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(listener).synchronizeMailboxFailed(account, FOLDER_NAME,
-                "Exception: Message count -1 for folder Folder");
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotOpenRemoteFolder() throws Exception {
-        messageCountInRemoteFolder(1);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, never()).open(Folder.OPEN_MODE_RW);
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldOpenRemoteFolderFromStore()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        configureRemoteStoreWithFolder();
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder).open(Folder.OPEN_MODE_RW);
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotCloseRemoteFolder() throws Exception {
-        messageCountInRemoteFolder(1);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, never()).close();
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldCloseRemoteFolderFromStore()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        configureRemoteStoreWithFolder();
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder).close();
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeOnPoll_shouldExpungeRemoteFolder()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
-        configureRemoteStoreWithFolder();
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder).expunge();
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeManually_shouldNotExpungeRemoteFolder()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_MANUALLY);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, never()).expunge();
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages()
-            throws Exception {
-        messageCountInRemoteFolder(0);
-        LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
-        when(account.syncRemoteDeletions()).thenReturn(true);
-        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
-        when(localFolder.getMessagesByUids(any(List.class)))
-                .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(localFolder).destroyMessages(messageListCaptor.capture());
-        assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        Date dateOfEarliestPoll = new Date();
-        LocalMessage localMessage = localMessageWithCopyOnServer();
-        when(account.syncRemoteDeletions()).thenReturn(true);
-        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
-        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(false);
-        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        LocalMessage localMessage = localMessageWithCopyOnServer();
-        Date dateOfEarliestPoll = new Date();
-        when(account.syncRemoteDeletions()).thenReturn(true);
-        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
-        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(true);
-        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
-        when(localFolder.getMessagesByUids(any(List.class))).thenReturn(Collections.singletonList(localMessage));
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(localFolder).destroyMessages(messageListCaptor.capture());
-        assertEquals(localMessage, messageListCaptor.getValue().get(0));
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages()
-            throws Exception {
-        messageCountInRemoteFolder(0);
-        LocalMessage remoteDeletedMessage = mock(LocalMessage.class);
-        when(account.syncRemoteDeletions()).thenReturn(false);
-        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(remoteDeletedMessage));
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesListAndFlags()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        hasUnsyncedRemoteMessage();
-        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
-                any(MessageRetrievalListener.class));
-        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.FLAGS));
-        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
-        assertEquals(2, fetchProfileCaptor.getAllValues().get(0).size());
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessages()
-            throws Exception {
-        messageCountInRemoteFolder(1);
-        hasUnsyncedRemoteMessage();
-        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
-                any(MessageRetrievalListener.class));
-        assertEquals(1, fetchProfileCaptor.getAllValues().get(0).size());
-        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage()
-            throws Exception {
-        Message smallMessage = buildSmallNewMessage();
-        messageCountInRemoteFolder(1);
-        hasUnsyncedRemoteMessage();
-        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
-        respondToFetchEnvelopesWithMessage(smallMessage);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(),
-                any(MessageRetrievalListener.class));
-        assertEquals(1, fetchProfileCaptor.getAllValues().get(1).size());
-        assertTrue(fetchProfileCaptor.getAllValues().get(1).contains(FetchProfile.Item.BODY));
-    }
-
-    @Test
-    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchStructureAndLimitedBodyOfLargeMessage()
-            throws Exception {
-        Message largeMessage = buildLargeNewMessage();
-        messageCountInRemoteFolder(1);
-        hasUnsyncedRemoteMessage();
-        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
-        respondToFetchEnvelopesWithMessage(largeMessage);
-
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
-
-        //TODO: Don't bother fetching messages of a size we don't have
-        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(),
-                any(MessageRetrievalListener.class));
-        assertEquals(1, fetchProfileCaptor.getAllValues().get(2).size());
-        assertEquals(FetchProfile.Item.STRUCTURE, fetchProfileCaptor.getAllValues().get(2).get(0));
-        assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
-        assertEquals(FetchProfile.Item.BODY_SANE, fetchProfileCaptor.getAllValues().get(3).get(0));
-    }
-
     private void setupAccountWithMessageToSend() throws MessagingException {
         when(account.getOutboxFolderName()).thenReturn(FOLDER_NAME);
         when(account.hasSentFolder()).thenReturn(true);
@@ -863,62 +633,6 @@ public class MessagingControllerTest {
         when(localMessageToSend1.getUid()).thenReturn("localMessageToSend1");
         when(localMessageToSend1.getHeader(K9.IDENTITY_HEADER)).thenReturn(new String[]{});
         controller.addListener(listener);
-    }
-
-    private void respondToFetchEnvelopesWithMessage(final Message message) throws MessagingException {
-        doAnswer(new Answer() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                FetchProfile fetchProfile = (FetchProfile) invocation.getArguments()[1];
-                if (invocation.getArguments()[2] != null) {
-                    MessageRetrievalListener listener = (MessageRetrievalListener) invocation.getArguments()[2];
-                    if (fetchProfile.contains(FetchProfile.Item.ENVELOPE)) {
-                        listener.messageStarted("UID", 1, 1);
-                        listener.messageFinished(message, 1, 1);
-                        listener.messagesFinished(1);
-                    }
-                }
-                return null;
-            }
-        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
-    }
-
-    private Message buildSmallNewMessage() {
-        Message message = mock(Message.class);
-        when(message.olderThan(any(Date.class))).thenReturn(false);
-        when(message.getSize()).thenReturn((long) MAXIMUM_SMALL_MESSAGE_SIZE);
-        return message;
-    }
-
-    private Message buildLargeNewMessage() {
-        Message message = mock(Message.class);
-        when(message.olderThan(any(Date.class))).thenReturn(false);
-        when(message.getSize()).thenReturn((long) (MAXIMUM_SMALL_MESSAGE_SIZE + 1));
-        return message;
-    }
-
-    private void messageCountInRemoteFolder(int value) throws MessagingException {
-        when(remoteFolder.getMessageCount()).thenReturn(value);
-    }
-
-    private LocalMessage localMessageWithCopyOnServer() throws MessagingException {
-        String messageUid = "UID";
-        Message remoteMessage = mock(Message.class);
-        LocalMessage localMessage = mock(LocalMessage.class);
-
-        when(remoteMessage.getUid()).thenReturn(messageUid);
-        when(localMessage.getUid()).thenReturn(messageUid);
-        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
-                .thenReturn(Collections.singletonList(remoteMessage));
-        return localMessage;
-    }
-
-    private void hasUnsyncedRemoteMessage() throws MessagingException {
-        String messageUid = "UID";
-        Message remoteMessage = mock(Message.class);
-        when(remoteMessage.getUid()).thenReturn(messageUid);
-        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
-                .thenReturn(Collections.singletonList(remoteMessage));
     }
 
     private void configureAccount() throws MessagingException {

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -631,7 +631,7 @@ public class MessagingControllerTest {
             throws Exception {
         messageCountInRemoteFolder(1);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 1, 0);
     }
@@ -641,7 +641,7 @@ public class MessagingControllerTest {
             throws Exception {
         messageCountInRemoteFolder(0);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 0, 0);
     }
@@ -651,7 +651,7 @@ public class MessagingControllerTest {
             throws Exception {
         messageCountInRemoteFolder(-1);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(listener).synchronizeMailboxFailed(account, FOLDER_NAME,
                 "Exception: Message count -1 for folder Folder");
@@ -661,7 +661,7 @@ public class MessagingControllerTest {
     public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotOpenRemoteFolder() throws Exception {
         messageCountInRemoteFolder(1);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, never()).open(Folder.OPEN_MODE_RW);
     }
@@ -672,7 +672,7 @@ public class MessagingControllerTest {
         messageCountInRemoteFolder(1);
         configureRemoteStoreWithFolder();
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder).open(Folder.OPEN_MODE_RW);
     }
@@ -681,7 +681,7 @@ public class MessagingControllerTest {
     public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotCloseRemoteFolder() throws Exception {
         messageCountInRemoteFolder(1);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, never()).close();
     }
@@ -692,7 +692,7 @@ public class MessagingControllerTest {
         messageCountInRemoteFolder(1);
         configureRemoteStoreWithFolder();
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder).close();
     }
@@ -704,7 +704,7 @@ public class MessagingControllerTest {
         when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
         configureRemoteStoreWithFolder();
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder).expunge();
     }
@@ -715,7 +715,7 @@ public class MessagingControllerTest {
         messageCountInRemoteFolder(1);
         when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_MANUALLY);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, never()).expunge();
     }
@@ -730,7 +730,7 @@ public class MessagingControllerTest {
         when(localFolder.getMessagesByUids(any(List.class)))
                 .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(localFolder).destroyMessages(messageListCaptor.capture());
         assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
@@ -747,7 +747,7 @@ public class MessagingControllerTest {
         when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(false);
         when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
     }
@@ -764,7 +764,7 @@ public class MessagingControllerTest {
         when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
         when(localFolder.getMessagesByUids(any(List.class))).thenReturn(Collections.singletonList(localMessage));
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(localFolder).destroyMessages(messageListCaptor.capture());
         assertEquals(localMessage, messageListCaptor.getValue().get(0));
@@ -778,7 +778,7 @@ public class MessagingControllerTest {
         when(account.syncRemoteDeletions()).thenReturn(false);
         when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(remoteDeletedMessage));
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
     }
@@ -790,7 +790,7 @@ public class MessagingControllerTest {
         hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
                 any(MessageRetrievalListener.class));
@@ -806,7 +806,7 @@ public class MessagingControllerTest {
         hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
                 any(MessageRetrievalListener.class));
@@ -823,7 +823,7 @@ public class MessagingControllerTest {
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
         respondToFetchEnvelopesWithMessage(smallMessage);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(),
                 any(MessageRetrievalListener.class));
@@ -840,7 +840,7 @@ public class MessagingControllerTest {
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
         respondToFetchEnvelopesWithMessage(largeMessage);
 
-        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener);
 
         //TODO: Don't bother fetching messages of a size we don't have
         verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(),

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -69,7 +69,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class MessagingControllerTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
@@ -1,0 +1,218 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mailstore.LocalFolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.annotation.Config;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class NonQresyncExtensionHandlerTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final String NEW_MESSAGE_UID = "2";
+    private static final String OLD_MESSAGE_UID = "1";
+
+    private NonQresyncExtensionHandler extensionHandler;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private ImapFolder imapFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private ImapMessage remoteNewMessage;
+    @Mock
+    private ImapMessage remoteOldMessage;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private FlagSyncHelper flagSyncHelper;
+    @Mock
+    private SyncHelper syncHelper;
+    @Captor
+    private ArgumentCaptor<List<String>> deletedUidsCaptor;
+    @Captor
+    private ArgumentCaptor<List<ImapMessage>> condstoreFlagSyncCaptor;
+    @Captor
+    private ArgumentCaptor<List<Message>> syncFlagCaptor;
+    @Captor
+    private ArgumentCaptor<List<ImapMessage>> downloadMessagesCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        extensionHandler = new NonQresyncExtensionHandler(account, localFolder, imapFolder, listener, controller);
+
+        configureLocalFolder();
+        configureImapFolder();
+        configureRemainingMocks();
+    }
+
+    @Test
+    public void continueSync_shouldNotifyListenersOfHeaderSynchronization() throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(true);
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(listener).synchronizeMailboxHeadersStarted(account, FOLDER_NAME);
+        verify(listener).synchronizeMailboxHeadersProgress(account, FOLDER_NAME, 1, 2);
+        verify(listener).synchronizeMailboxHeadersProgress(account, FOLDER_NAME, 2, 2);
+        verify(listener).synchronizeMailboxHeadersFinished(account, FOLDER_NAME, 2, 2);
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToTrue_shouldDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(remoteNewMessage));
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder), eq(imapFolder),
+                eq(controller), eq(listener));
+        assertEquals(deletedUidsCaptor.getValue(), singletonList(OLD_MESSAGE_UID));
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToFalse_shouldNotDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(false);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(remoteNewMessage));
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(syncHelper, never()).deleteLocalMessages(anyList(), eq(account), eq(localFolder), eq(imapFolder),
+                eq(controller), eq(listener));
+    }
+
+    @Test
+    public void continueSync_withCondstoreEnabled_shouldFetchChangedMessageFlagsUsingCondstore() throws Exception {
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
+        when(imapFolder.supportsModSeq()).thenReturn(true);
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(imapFolder).fetchChangedMessageFlagsUsingCondstore(condstoreFlagSyncCaptor.capture(), anyLong(),
+                any(MessageRetrievalListener.class));
+        assertEquals(condstoreFlagSyncCaptor.getValue(), singletonList(remoteOldMessage));
+    }
+
+    @Test
+    public void continueSync_withoutCondstore_shouldFetchFlagsForAllMessages() throws Exception {
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(false);
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(flagSyncHelper).refreshLocalMessageFlags(eq(account), eq(imapFolder), eq(localFolder),
+                syncFlagCaptor.capture());
+        assertEquals(syncFlagCaptor.getValue(), singletonList(remoteOldMessage));
+    }
+
+    @Test
+    public void continueSync_withFolderNotSupportingModSeqs_shouldFetchFlagsForAllMessages() throws Exception {
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
+        when(imapFolder.supportsModSeq()).thenReturn(false);
+
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(flagSyncHelper).refreshLocalMessageFlags(eq(account), eq(imapFolder), eq(localFolder),
+                syncFlagCaptor.capture());
+        assertEquals(syncFlagCaptor.getValue(), singletonList(remoteOldMessage));
+    }
+
+    @Test
+    public void continueSync_shouldDownloadNewMessages() throws Exception {
+        extensionHandler.continueSync(messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadMessagesCaptor.capture(), eq(true), eq(true));
+        assertEquals(downloadMessagesCaptor.getValue(), singletonList(remoteNewMessage));
+    }
+
+    private void configureLocalFolder() throws MessagingException {
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.getMessage(NEW_MESSAGE_UID)).thenReturn(null);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap(OLD_MESSAGE_UID, 0L));
+    }
+
+    private void configureImapFolder() throws MessagingException {
+        when(imapFolder.getName()).thenReturn(FOLDER_NAME);
+        when(imapFolder.getMessageCount()).thenReturn(2);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(asList(remoteNewMessage, remoteOldMessage));
+    }
+
+    private void configureRemainingMocks() throws MessagingException {
+        when(remoteNewMessage.getUid()).thenReturn(NEW_MESSAGE_UID);
+        when(remoteOldMessage.getUid()).thenReturn(OLD_MESSAGE_UID);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                List<Message> unsyncedMessages = (List) args[5];
+                unsyncedMessages.add(remoteNewMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(eq(remoteNewMessage), eq(FOLDER_NAME), eq(localFolder),
+                eq(imapFolder), eq(account), any(List.class), any(List.class), eq(controller));
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                List<Message> flagSyncMessages = (List) args[6];
+                flagSyncMessages.add(remoteOldMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(eq(remoteOldMessage), eq(FOLDER_NAME), eq(localFolder),
+                eq(imapFolder), eq(account), any(List.class), any(List.class), eq(controller));
+
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+        when(syncHelper.getRemoteStart(localFolder, imapFolder)).thenReturn(1);
+        when(account.getDisplayCount()).thenReturn(2);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
@@ -129,15 +129,32 @@ public class NonQresyncExtensionHandlerTest {
     }
 
     @Test
-    public void continueSync_withCondstoreEnabled_shouldFetchChangedMessageFlagsUsingCondstore() throws Exception {
+    public void continueSync_withCondstoreEnabledAndHighestModSeqChanged_shouldFetchChangedMessageFlagsUsingCondstore()
+            throws Exception {
         when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
         when(imapFolder.supportsModSeq()).thenReturn(true);
+        when(localFolder.getHighestModSeq()).thenReturn(1L);
+        when(imapFolder.getHighestModSeq()).thenReturn(2L);
 
         extensionHandler.continueSync(account, localFolder, imapFolder, listener);
 
         verify(imapFolder).fetchChangedMessageFlagsUsingCondstore(condstoreFlagSyncCaptor.capture(), anyLong(),
                 any(MessageRetrievalListener.class));
         assertEquals(condstoreFlagSyncCaptor.getValue(), singletonList(remoteOldMessage));
+    }
+
+    @Test
+    public void continueSync_withCondstoreEnabledAndHighestModSeqNotChanged_shouldNotFetchChangedMessageFlags()
+            throws Exception {
+        when(localFolder.isCachedHighestModSeqValid()).thenReturn(true);
+        when(imapFolder.supportsModSeq()).thenReturn(true);
+        when(localFolder.getHighestModSeq()).thenReturn(1L);
+        when(imapFolder.getHighestModSeq()).thenReturn(1L);
+
+        extensionHandler.continueSync(account, localFolder, imapFolder, listener);
+
+        verify(imapFolder, never()).fetchChangedMessageFlagsUsingCondstore(anyList(), anyLong(),
+                any(MessageRetrievalListener.class));
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
@@ -110,7 +110,7 @@ public class NonQresyncExtensionHandlerTest {
 
         extensionHandler.continueSync(account, localFolder, imapFolder, listener);
 
-        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder), eq(imapFolder),
+        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder),
                 eq(controller), eq(listener));
         assertEquals(deletedUidsCaptor.getValue(), singletonList(OLD_MESSAGE_UID));
     }
@@ -124,8 +124,8 @@ public class NonQresyncExtensionHandlerTest {
 
         extensionHandler.continueSync(account, localFolder, imapFolder, listener);
 
-        verify(syncHelper, never()).deleteLocalMessages(anyList(), eq(account), eq(localFolder), eq(imapFolder),
-                eq(controller), eq(listener));
+        verify(syncHelper, never()).deleteLocalMessages(anyList(), eq(account), eq(localFolder), eq(controller),
+                eq(listener));
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class NonQresyncExtensionHandlerTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
@@ -1,0 +1,247 @@
+package com.fsck.k9.controller;
+
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mail.store.imap.QresyncParamResponse;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.annotation.Config;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class QresyncExtensionHandlerTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final List<String> VANISHED_EARLIER_UIDS = new ArrayList<>(0);
+    private static final List<ImapMessage> MODIFIED_MESSAGES = new ArrayList<>(0);
+    private static final List<String> EXPUNGED_UIDS = new ArrayList<>(0);
+    private static final long SMALLEST_LOCAL_UID = 10L;
+
+    private QresyncExtensionHandler extensionHandler;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private ImapFolder imapFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private QresyncParamResponse qresyncParamResponse;
+    @Mock
+    private List<String> expungedUids;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private FlagSyncHelper flagSyncHelper;
+    @Mock
+    private SyncHelper syncHelper;
+    @Captor
+    private ArgumentCaptor<List> downloadedMessagesCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        extensionHandler = new QresyncExtensionHandler(account, localFolder, imapFolder, listener, controller);
+
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.getSmallestMessageUid()).thenReturn(SMALLEST_LOCAL_UID);
+        when(imapFolder.getName()).thenReturn(FOLDER_NAME);
+        when(controller.getListeners()).thenReturn(singleton(listener));
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+        when(syncHelper.getRemoteStart(localFolder, imapFolder)).thenReturn(1);
+
+        when(qresyncParamResponse.getExpungedUids()).thenReturn(VANISHED_EARLIER_UIDS);
+        when(qresyncParamResponse.getModifiedMessages()).thenReturn(MODIFIED_MESSAGES);
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToTrue_shouldDeleteLocalCopiesOfDeletedMessages() throws Exception {
+        String vanishedUid = "1", expungedUid = "2";
+        VANISHED_EARLIER_UIDS.add(vanishedUid);
+        EXPUNGED_UIDS.add(expungedUid);
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        ArgumentCaptor<List> deletedUidsCaptor = ArgumentCaptor.forClass(List.class);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder), eq(imapFolder),
+                eq(controller), eq(listener));
+        List<String> deletedUids = deletedUidsCaptor.getValue();
+        assertTrue(deletedUids.contains(vanishedUid));
+        assertTrue(deletedUids.contains(expungedUid));
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToFalse_shouldNotDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
+        EXPUNGED_UIDS.add("1");
+        when(account.syncRemoteDeletions()).thenReturn(false);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(syncHelper, never()).deleteLocalMessages(anyCollection(), eq(account), eq(localFolder), eq(imapFolder),
+                eq(controller), eq(listener));
+    }
+
+    @Test
+    public void continueSync_withModifiedMessage_shouldProcessFlags() throws Exception {
+        ImapMessage modifiedMessage = addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 1, false);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(flagSyncHelper).processDownloadedFlags(account, localFolder, modifiedMessage);
+    }
+
+    @Test
+    public void continueSync_withChangesToOutdatedMessage_shouldNotProcessFlags() throws Exception {
+        ImapMessage modifiedMessage = addModifiedMessageToResponse(SMALLEST_LOCAL_UID - 1, false);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(flagSyncHelper, never()).processDownloadedFlags(account, localFolder, modifiedMessage);
+    }
+
+    @Test
+    public void continueSync_withNewMessage_shouldDownloadNewMessage() throws Exception {
+        ImapMessage modifiedMessage = addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 1, true);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadedMessagesCaptor.capture(), eq(true), eq(false));
+        assertTrue(downloadedMessagesCaptor.getValue().contains(modifiedMessage));
+    }
+
+    @Test
+    public void continueSync_withVisibleLimitNotReached_shouldDownloadOldMessages() throws Exception {
+        when(localFolder.getVisibleLimit()).thenReturn(2);
+        when(localFolder.getMessageCount()).thenReturn(0);
+        when(imapFolder.getMessageCount()).thenReturn(3);
+        when(syncHelper.getRemoteStart(localFolder, imapFolder)).thenReturn(2);
+        addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 1, true);
+        ImapMessage oldMessage = mock(ImapMessage.class);
+        when(imapFolder.getMessages(eq(2), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(oldMessage));
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadedMessagesCaptor.capture(), eq(true), eq(true));
+        assertTrue(downloadedMessagesCaptor.getValue().contains(oldMessage));
+    }
+
+    @Test
+    public void continueSync_withVisibleLimitReached_shouldNotDownloadOldMessages() throws Exception {
+        when(localFolder.getVisibleLimit()).thenReturn(2);
+        when(localFolder.getMessageCount()).thenReturn(2);
+        when(imapFolder.getMessageCount()).thenReturn(3);
+        ImapMessage newMessage = addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 1, true);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadedMessagesCaptor.capture(), eq(true), eq(false));
+        List<ImapMessage> downloadedMessages = downloadedMessagesCaptor.getValue();
+        assertEquals(downloadedMessages.size(), 1);
+        assertEquals(downloadedMessages.get(0), newMessage);
+    }
+
+    @Test
+    public void continueSync_withNoMoreMessagesInRemoteMailbox_shouldNotDownloadOldMessages() throws Exception {
+        when(localFolder.getVisibleLimit()).thenReturn(4);
+        when(localFolder.getMessageCount()).thenReturn(3);
+        when(imapFolder.getMessageCount()).thenReturn(3);
+        ImapMessage newMessage = addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 1, true);
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadedMessagesCaptor.capture(), eq(true), eq(false));
+        List<ImapMessage> downloadedMessages = downloadedMessagesCaptor.getValue();
+        assertEquals(downloadedMessages.size(), 1);
+        assertEquals(downloadedMessages.get(0), newMessage);
+    }
+
+    @Test
+    public void continueSync_withModifiedMessages_shouldNotifyListenersOfHeaderSynchronization() throws Exception {
+        addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 2, false);
+        addModifiedMessageToResponse(SMALLEST_LOCAL_UID + 3, true);
+        when(localFolder.getVisibleLimit()).thenReturn(3);
+        when(localFolder.getMessageCount()).thenReturn(1);
+        when(imapFolder.getMessageCount()).thenReturn(3);
+        when(imapFolder.getMessages(eq(1), eq(1), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(mock(ImapMessage.class)));
+
+        extensionHandler.continueSync(qresyncParamResponse, EXPUNGED_UIDS, messageDownloader, flagSyncHelper, syncHelper);
+
+        verify(listener).synchronizeMailboxHeadersStarted(account, FOLDER_NAME);
+        verify(listener).synchronizeMailboxHeadersProgress(account, FOLDER_NAME, 1, 1);
+        verify(listener).synchronizeMailboxHeadersFinished(account, FOLDER_NAME, 3, 2);
+    }
+
+    private ImapMessage addModifiedMessageToResponse(Long uid, final boolean newMessage) throws MessagingException {
+        final ImapMessage modifiedMessage = mock(ImapMessage.class);
+        when(modifiedMessage.getUid()).thenReturn(Long.toString(uid));
+
+        LocalMessage localMessage = null;
+        if (!newMessage) {
+            localMessage = mock(LocalMessage.class);
+            when(localMessage.isSet(Flag.X_DOWNLOADED_FULL)).thenReturn(true);
+        }
+        when(localFolder.getMessage(Long.toString(uid))).thenReturn(localMessage);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                int argIndex = newMessage ? 5 : 6;
+                List<Message> messageList = (List) args[argIndex];
+                messageList.add(modifiedMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(eq(modifiedMessage), eq(FOLDER_NAME), eq(localFolder),
+                eq(imapFolder), eq(account), any(List.class), any(List.class), eq(controller));
+
+        MODIFIED_MESSAGES.add(modifiedMessage);
+        return modifiedMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
@@ -103,7 +103,7 @@ public class QresyncExtensionHandlerTest {
 
         extensionHandler.continueSync(account, localFolder, imapFolder, qresyncParamResponse, EXPUNGED_UIDS, listener);
 
-        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder), eq(imapFolder),
+        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder),
                 eq(controller), eq(listener));
         List<String> deletedUids = deletedUidsCaptor.getValue();
         assertTrue(deletedUids.contains(vanishedUid));
@@ -118,8 +118,8 @@ public class QresyncExtensionHandlerTest {
 
         extensionHandler.continueSync(account, localFolder, imapFolder, qresyncParamResponse, EXPUNGED_UIDS, listener);
 
-        verify(syncHelper, never()).deleteLocalMessages(anyCollection(), eq(account), eq(localFolder), eq(imapFolder),
-                eq(controller), eq(listener));
+        verify(syncHelper, never()).deleteLocalMessages(anyCollection(), eq(account), eq(localFolder), eq(controller),
+                eq(listener));
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/QresyncExtensionHandlerTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class QresyncExtensionHandlerTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(K9RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public class SyncHelperTest {
 
     private static final String FOLDER_NAME = "Folder";

--- a/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
@@ -136,7 +136,7 @@ public class SyncHelperTest {
         if (availableLocally) {
             LocalMessage localMessage = mock(LocalMessage.class);
             when(localMessage.isSet(Flag.X_DOWNLOADED_FULL)).thenReturn(true);
-            when(localFolder.getMessage(uid)).thenReturn(localMessage);
+            when(localFolder.getMessageUidAndFlags(uid)).thenReturn(localMessage);
         } else {
             when(localFolder.getMessage(uid)).thenReturn(null);
         }

--- a/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
@@ -1,0 +1,162 @@
+package com.fsck.k9.controller;
+
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.Config;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class SyncHelperTest {
+
+    private static final String FOLDER_NAME = "Folder";
+
+    private SyncHelper syncHelper;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private ImapMessage remoteNewMessage;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        syncHelper = SyncHelper.getInstance();
+
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+    }
+
+    @Test
+    public void verifyOrCreateRemoteSpecialFolder_withUnavailableRemoteFolder_shouldTryToCreateRemoteFolder()
+            throws Exception {
+        when(account.getTrashFolderName()).thenReturn("Trash");
+        when(remoteFolder.exists()).thenReturn(false);
+
+        syncHelper.verifyOrCreateRemoteSpecialFolder(account, "Trash", remoteFolder, listener, controller);
+
+        verify(remoteFolder).create(FolderType.HOLDS_MESSAGES);
+    }
+
+    @Test
+    public void verifyOrCreateRemoteSpecialFolder_withFolderCreationFailed_shouldNotifyListeners() throws Exception {
+        String folderName = "Trash";
+        when(account.getTrashFolderName()).thenReturn(folderName);
+        when(remoteFolder.exists()).thenReturn(false);
+        when(remoteFolder.create(FolderType.HOLDS_MESSAGES)).thenReturn(false);
+
+        syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, remoteFolder, listener, controller);
+
+        verify(listener).synchronizeMailboxFinished(account, folderName, 0, 0);
+    }
+
+    @Test
+    public void getRemoteStart() throws Exception {
+        when(remoteFolder.getMessageCount()).thenReturn(152);
+        when(localFolder.getVisibleLimit()).thenReturn(100);
+
+        int remoteStart = syncHelper.getRemoteStart(localFolder, remoteFolder);
+
+        assertEquals(remoteStart, 53);
+    }
+
+    @Test
+    public void deleteLocalMessages_withDeletedMessages_shouldNotifyListeners() throws Exception {
+        LocalMessage destroyedMessage = mock(LocalMessage.class);
+        when(localFolder.getMessagesByUids(singleton("1"))).thenReturn(singletonList(destroyedMessage));
+
+        syncHelper.deleteLocalMessages(singleton("1"), account, localFolder, remoteFolder, controller, listener);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, FOLDER_NAME, destroyedMessage);
+    }
+
+    @Test
+    public void deleteLocalMessages_withDeletedMessages_shouldUpdateMoreMessages() throws Exception {
+        LocalMessage destroyedMessage = mock(LocalMessage.class);
+        when(localFolder.getMessagesByUids(singleton("1"))).thenReturn(singletonList(destroyedMessage));
+        when(remoteFolder.getMessageCount()).thenReturn(152);
+        when(localFolder.getVisibleLimit()).thenReturn(100);
+        when(remoteFolder.areMoreMessagesAvailable(eq(53), any(Date.class))).thenReturn(true);
+
+        syncHelper.deleteLocalMessages(singleton("1"), account, localFolder, remoteFolder, controller, listener);
+
+        verify(localFolder).setMoreMessages(MoreMessages.TRUE);
+    }
+
+    @Test
+    public void evaluateMessageForDownload_withoutLocalCopy_shouldAddMessageToUnsyncedMessagesList() throws Exception {
+        Message message = createRemoteMessage(false);
+        List<Message> unsyncedMessages = new ArrayList<>(0);
+        List<Message> syncFlagMessages = new ArrayList<>(0);
+
+        syncHelper.evaluateMessageForDownload(message, FOLDER_NAME, localFolder, remoteFolder, account, unsyncedMessages,
+                syncFlagMessages, controller);
+
+        assertEquals(singletonList(message), unsyncedMessages);
+    }
+
+    @Test
+    public void evaluateMessageForDownload_withLocalCopy_shouldAddMessageToSyncFlagMessagesList() throws Exception {
+        Message message = createRemoteMessage(true);
+        List<Message> unsyncedMessages = new ArrayList<>(0);
+        List<Message> syncFlagMessages = new ArrayList<>(0);
+
+        syncHelper.evaluateMessageForDownload(message, FOLDER_NAME, localFolder, remoteFolder, account, unsyncedMessages,
+                syncFlagMessages, controller);
+
+        assertEquals(singletonList(message), syncFlagMessages);
+    }
+
+    private Message createRemoteMessage(boolean availableLocally) throws MessagingException {
+        String uid = "1";
+        Message remoteMessage = mock(Message.class);
+        when(remoteMessage.getUid()).thenReturn(uid);
+        if (availableLocally) {
+            LocalMessage localMessage = mock(LocalMessage.class);
+            when(localMessage.isSet(Flag.X_DOWNLOADED_FULL)).thenReturn(true);
+            when(localFolder.getMessage(uid)).thenReturn(localMessage);
+        } else {
+            when(localFolder.getMessage(uid)).thenReturn(null);
+        }
+        return remoteMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
@@ -2,7 +2,6 @@ package com.fsck.k9.controller;
 
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.fsck.k9.Account;
@@ -14,7 +13,6 @@ import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.store.imap.ImapMessage;
 import com.fsck.k9.mailstore.LocalFolder;
-import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,8 +24,6 @@ import org.robolectric.annotation.Config;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,22 +100,9 @@ public class SyncHelperTest {
         LocalMessage destroyedMessage = mock(LocalMessage.class);
         when(localFolder.getMessagesByUids(singleton("1"))).thenReturn(singletonList(destroyedMessage));
 
-        syncHelper.deleteLocalMessages(singleton("1"), account, localFolder, remoteFolder, controller, listener);
+        syncHelper.deleteLocalMessages(singleton("1"), account, localFolder, controller, listener);
 
         verify(listener).synchronizeMailboxRemovedMessage(account, FOLDER_NAME, destroyedMessage);
-    }
-
-    @Test
-    public void deleteLocalMessages_withDeletedMessages_shouldUpdateMoreMessages() throws Exception {
-        LocalMessage destroyedMessage = mock(LocalMessage.class);
-        when(localFolder.getMessagesByUids(singleton("1"))).thenReturn(singletonList(destroyedMessage));
-        when(remoteFolder.getMessageCount()).thenReturn(152);
-        when(localFolder.getVisibleLimit()).thenReturn(100);
-        when(remoteFolder.areMoreMessagesAvailable(eq(53), any(Date.class))).thenReturn(true);
-
-        syncHelper.deleteLocalMessages(singleton("1"), account, localFolder, remoteFolder, controller, listener);
-
-        verify(localFolder).setMoreMessages(MoreMessages.TRUE);
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -339,6 +339,7 @@ public class StoreSchemaDefinitionTest {
         localStore.database = lockableDatabase;
         when(localStore.getContext()).thenReturn(context);
         when(localStore.getAccount()).thenReturn(account);
+        when(localStore.getDatabase()).thenReturn(lockableDatabase);
 
         return new StoreSchemaDefinition(localStore);
     }


### PR DESCRIPTION
This PR does several things 

- Moves the folder synchronization code from `MessagingController` into separate classes depending on the protocol (`ImapSyncInteractor` for IMAP accounts and `LegacySyncInteractor` for POP3 and WebDAV accounts)
- Modifies the `MessagingControllerPushReceiver` so that a normal synchronization is performed when untagged responses are received through IDLE, instead of response-specific actions. This synchronization is done through a separate connection instead of reusing the connection through which IDLE responses are received.
- Adds support for the CONDSTORE and QRESYNC IMAP extensions  as described in [RFC 7162](https://tools.ietf.org/html/rfc7162).

