### PR TITLE
WIP : Enable and rewrite full text search

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -1677,9 +1677,9 @@ public class Account implements BaseAccount, StoreConfig {
     public synchronized void setAlwaysShowCcBcc(boolean show) {
         alwaysShowCcBcc = show;
     }
+
     public boolean isRemoteSearchFullText() {
-        return false;   // Temporarily disabled
-        //return remoteSearchFullText;
+        return remoteSearchFullText;
     }
 
     public void setRemoteSearchFullText(boolean val) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -184,11 +184,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference cloudSearchEnabled;
     private ListPreference remoteSearchNumResults;
 
-    /*
-     * Temporarily removed because search results aren't displayed to the user.
-     * So this feature is useless.
-     */
-    //private CheckBoxPreference mRemoteSearchFullText;
+    private CheckBoxPreference mRemoteSearchFullText;
 
     private ListPreference localStorageProvider;
     private ListPreference archiveFolder;
@@ -516,7 +512,7 @@ public class AccountSettings extends K9PreferenceActivity {
                 }
             }
         );
-        //mRemoteSearchFullText = (CheckBoxPreference) findPreference(PREFERENCE_REMOTE_SEARCH_FULL_TEXT);
+        mRemoteSearchFullText = (CheckBoxPreference) findPreference(PREFERENCE_REMOTE_SEARCH_FULL_TEXT);
 
         pushPollOnConnect = (CheckBoxPreference) findPreference(PREFERENCE_PUSH_POLL_ON_CONNECT);
         idleRefreshPeriod = (ListPreference) findPreference(PREFERENCE_IDLE_REFRESH_PERIOD);
@@ -528,7 +524,7 @@ public class AccountSettings extends K9PreferenceActivity {
             String searchNumResults = Integer.toString(account.getRemoteSearchNumResults());
             remoteSearchNumResults.setValue(searchNumResults);
             updateRemoteSearchLimit(searchNumResults);
-            //mRemoteSearchFullText.setChecked(account.isRemoteSearchFullText());
+            mRemoteSearchFullText.setChecked(account.isRemoteSearchFullText());
 
             idleRefreshPeriod.setValue(String.valueOf(account.getIdleRefreshMinutes()));
             idleRefreshPeriod.setSummary(idleRefreshPeriod.getEntry());
@@ -814,7 +810,7 @@ public class AccountSettings extends K9PreferenceActivity {
             account.setMaxPushFolders(Integer.parseInt(mMaxPushFolders.getValue()));
             account.setAllowRemoteSearch(cloudSearchEnabled.isChecked());
             account.setRemoteSearchNumResults(Integer.parseInt(remoteSearchNumResults.getValue()));
-            //account.setRemoteSearchFullText(mRemoteSearchFullText.isChecked());
+            account.setRemoteSearchFullText(mRemoteSearchFullText.isChecked());
         }
 
         boolean needsRefresh = account.setAutomaticCheckIntervalMinutes(Integer.parseInt(checkFrequency.getValue()));

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -603,7 +603,7 @@ public class MessagingController {
                 remoteMessages = remoteMessages.subList(0, resultLimit);
             }
 
-            loadSearchResultsSynchronous(remoteMessages, localFolder, remoteFolder, listener);
+            loadSearchResultsSynchronous(remoteMessages, acct, localFolder, remoteFolder);
 
 
         } catch (Exception e) {
@@ -646,7 +646,7 @@ public class MessagingController {
                         throw new MessagingException("Folder not found");
                     }
 
-                    loadSearchResultsSynchronous(messages, localFolder, remoteFolder, listener);
+                    loadSearchResultsSynchronous(messages, account, localFolder, remoteFolder);
                 } catch (MessagingException e) {
                     Timber.e(e, "Exception in loadSearchResults");
                     addErrorMessage(account, null, e);
@@ -659,27 +659,9 @@ public class MessagingController {
         });
     }
 
-    private void loadSearchResultsSynchronous(List<Message> messages, LocalFolder localFolder, Folder remoteFolder,
-            MessagingListener listener) throws MessagingException {
-        final FetchProfile header = new FetchProfile();
-        header.add(FetchProfile.Item.FLAGS);
-        header.add(FetchProfile.Item.ENVELOPE);
-        final FetchProfile structure = new FetchProfile();
-        structure.add(FetchProfile.Item.STRUCTURE);
-
-        int i = 0;
-        for (Message message : messages) {
-            i++;
-            LocalMessage localMsg = localFolder.getMessage(message.getUid());
-
-            if (localMsg == null) {
-                remoteFolder.fetch(Collections.singletonList(message), header, null);
-                //fun fact: ImapFolder.fetch can't handle getting STRUCTURE at same time as headers
-                remoteFolder.fetch(Collections.singletonList(message), structure, null);
-                localFolder.appendMessages(Collections.singletonList(message));
-                localMsg = localFolder.getMessage(message.getUid());
-            }
-        }
+    private void loadSearchResultsSynchronous(List<Message> messages, Account account, LocalFolder localFolder,
+            Folder remoteFolder) throws MessagingException {
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, messages, false, true);
     }
 
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1076,6 +1076,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="pull_to_refresh_remote_search_from_local_search_release">Release to search server…</string>
     <string name="remote_search_unavailable_no_network">A network connection is required for server search.</string>
 
+    <string name="account_settings_remote_search_full_text">Enable full text search</string>
+    <string name="account_settings_remote_search_full_text_summary">Search the contents of the messages on the server</string>
+
     <string name="global_settings_background_as_unread_indicator_label">Change colour when read</string>
     <string name="global_settings_background_as_unread_indicator_summary">A different background will show that the message has been read</string>
 

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -208,10 +208,10 @@
             android:title="@string/account_settings_always_show_cc_bcc_label" />
 
         <CheckBoxPreference
-        android:persistent="false"
-        android:key="message_read_receipt"
-        android:title="@string/account_settings_message_read_receipt_label"
-        android:summary="@string/account_settings_message_read_receipt_summary" />
+            android:persistent="false"
+            android:key="message_read_receipt"
+            android:title="@string/account_settings_message_read_receipt_label"
+            android:summary="@string/account_settings_message_read_receipt_summary" />
 
         <ListPreference
             android:persistent="false"
@@ -441,8 +441,8 @@
     </PreferenceScreen>
 
     <PreferenceScreen
-            android:title="@string/account_settings_search"
-            android:key="search">
+        android:title="@string/account_settings_search"
+        android:key="search">
 
         <CheckBoxPreference
             android:key="remote_search_enabled"
@@ -459,14 +459,12 @@
             android:dialogTitle="@string/account_settings_remote_search_num_label"
             android:dependency="remote_search_enabled"/>
 
-        <!-- Temporarily removed
         <CheckBoxPreference
             android:key="account_remote_search_full_text"
             android:title="@string/account_settings_remote_search_full_text"
             android:summary="@string/account_settings_remote_search_full_text_summary"
             android:persistent="false"
             android:dependency="remote_search_enabled"/>
-        -->
 
     </PreferenceScreen>
 


### PR DESCRIPTION
[Related discussion](https://github.com/k9mail/k-9/pull/689)

I have re-enabled full text search and made it so that it downloads messages using the same rules as during synchronization.

Regarding how to load search results into the UI without writing them into the database, I'm not sure what the best way is. Some approaches :

- I was thinking of modifying `MessageListAdapter` so that it accepts either a `Cursor` object or a list of `Message` objects to populate the list with - cursor for the message list and local search and `Message` objects for remote search.

- Valodim suggested making a separate table to store the search results.

@cketti @Valodim @philipwhiuk 