### PR TITLE
Optionally suppress notifications for mails matching certain criteria

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build.xml
 proguard-project.txt
 .idea/
 *.iml
+/app/k9mail/release

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -18,6 +18,7 @@ import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import org.jetbrains.annotations.NotNull;
@@ -187,6 +188,7 @@ public class Account implements BaseAccount {
     private long lastSyncTime;
     private long lastFolderListRefreshTime;
     private boolean isFinishedSetup = false;
+    private boolean muteMailingLists;
 
     private boolean changedVisibleLimits = false;
 
@@ -384,6 +386,18 @@ public class Account implements BaseAccount {
 
     public synchronized void setFolderNotifyNewMailMode(FolderMode folderNotifyNewMailMode) {
         this.folderNotifyNewMailMode = folderNotifyNewMailMode;
+    }
+
+    public synchronized boolean getMuteMailingLists() {
+        return muteMailingLists;
+    }
+
+    public synchronized void setMuteMailingLists(boolean muteMailingLists) {
+        this.muteMailingLists = muteMailingLists;
+    }
+
+    public boolean isNotificationSuppressed(MimeMessage message) {
+        return muteMailingLists && message.getHeader("List-ID").length > 0;
     }
 
     public synchronized DeletePolicy getDeletePolicy() {

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -425,6 +425,10 @@ public class Account implements BaseAccount {
         this.mutedSenders = new HashSet<String>(mutedSenders);
     }
 
+    public synchronized void addMutedSender(String sender) {
+        this.mutedSenders.add(sender);
+    }
+
     public synchronized String getMuteIfSentToAsString() {
         return TextUtils.join(";", getMuteIfSentTo());
     }

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -51,6 +51,7 @@ class AccountPreferenceSerializer(
             isNotifyNewMail = storage.getBoolean("$accountUuid.notifyNewMail", false)
             setMuteMailingLists(storage.getBoolean("$accountUuid.muteMailingLists", false))
             setMutedSenders(storage.getString("$accountUuid.mutedSenders", ""))
+            setMuteIfSentTo(storage.getString("$accountUuid.muteIfSentTo", ""))
 
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderNotifyNewMailMode", FolderMode.ALL)
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
@@ -261,6 +262,7 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
             editor.putBoolean("$accountUuid.muteMailingLists", getMuteMailingLists())
             editor.putString("$accountUuid.mutedSenders", getMutedSendersAsString())
+            editor.putString("$accountUuid.muteIfSentTo", getMuteIfSentToAsString())
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
@@ -572,6 +574,7 @@ class AccountPreferenceSerializer(
             isNotifyNewMail = true
             muteMailingLists = false
             setMutedSenders(Collections.emptyList())
+            setMuteIfSentTo(Collections.emptyList())
             folderNotifyNewMailMode = FolderMode.ALL
             isNotifySync = false
             isNotifySelfNewMail = true

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -19,6 +19,7 @@ import com.fsck.k9.mail.NetworkType
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.preferences.Storage
 import com.fsck.k9.preferences.StorageEditor
+import java.util.Collections
 import timber.log.Timber
 
 class AccountPreferenceSerializer(
@@ -49,6 +50,7 @@ class AccountPreferenceSerializer(
             }
             isNotifyNewMail = storage.getBoolean("$accountUuid.notifyNewMail", false)
             setMuteMailingLists(storage.getBoolean("$accountUuid.muteMailingLists", false))
+            setMutedSenders(storage.getString("$accountUuid.mutedSenders", ""))
 
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderNotifyNewMailMode", FolderMode.ALL)
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
@@ -258,6 +260,7 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.displayCount", displayCount)
             editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
             editor.putBoolean("$accountUuid.muteMailingLists", getMuteMailingLists())
+            editor.putString("$accountUuid.mutedSenders", getMutedSendersAsString())
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
@@ -568,6 +571,7 @@ class AccountPreferenceSerializer(
             accountNumber = UNASSIGNED_ACCOUNT_NUMBER
             isNotifyNewMail = true
             muteMailingLists = false
+            setMutedSenders(Collections.emptyList())
             folderNotifyNewMailMode = FolderMode.ALL
             isNotifySync = false
             isNotifySelfNewMail = true

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -48,6 +48,7 @@ class AccountPreferenceSerializer(
                 displayCount = K9.DEFAULT_VISIBLE_LIMIT
             }
             isNotifyNewMail = storage.getBoolean("$accountUuid.notifyNewMail", false)
+            setMuteMailingLists(storage.getBoolean("$accountUuid.muteMailingLists", false))
 
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderNotifyNewMailMode", FolderMode.ALL)
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
@@ -256,6 +257,7 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.pushPollOnConnect", isPushPollOnConnect)
             editor.putInt("$accountUuid.displayCount", displayCount)
             editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
+            editor.putBoolean("$accountUuid.muteMailingLists", getMuteMailingLists())
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
@@ -565,6 +567,7 @@ class AccountPreferenceSerializer(
             displayCount = K9.DEFAULT_VISIBLE_LIMIT
             accountNumber = UNASSIGNED_ACCOUNT_NUMBER
             isNotifyNewMail = true
+            muteMailingLists = false
             folderNotifyNewMailMode = FolderMode.ALL
             isNotifySync = false
             isNotifySelfNewMail = true

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.controller;
 
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -17,6 +18,7 @@ public class MessagingControllerCommands {
     static final String COMMAND_REPLACE = "replace";
     static final String COMMAND_MARK_ALL_AS_READ = "mark_all_as_read";
     static final String COMMAND_SET_FLAG = "set_flag";
+    static final String COMMAND_MUTE_SENDER = "mute_sender";
     static final String COMMAND_DELETE = "delete";
     static final String COMMAND_EXPUNGE = "expunge";
     static final String COMMAND_MOVE_OR_COPY = "move_or_copy";
@@ -139,6 +141,32 @@ public class MessagingControllerCommands {
         @Override
         public void execute(MessagingController controller, Account account) throws MessagingException {
             controller.processPendingSetFlag(this, account);
+        }
+    }
+
+    public static class PendingMuteSender extends PendingCommand {
+        public final long folderId;
+        public final String uid;
+
+
+        public static PendingMuteSender create(long folderId, String uid) {
+            requireValidUids(Arrays.asList(uid));
+            return new PendingMuteSender(folderId, uid);
+        }
+
+        private PendingMuteSender(long folderId, String uid) {
+            this.folderId = folderId;
+            this.uid = uid;
+        }
+
+        @Override
+        public String getCommandName() {
+            return COMMAND_MUTE_SENDER;
+        }
+
+        @Override
+        public void execute(MessagingController controller, Account account) throws MessagingException {
+            controller.processPendingMuteSender(this, account);
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/DeviceNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/DeviceNotifications.java
@@ -102,6 +102,7 @@ class DeviceNotifications extends BaseNotifications {
                 .setGroupSummary(true);
 
         NotificationContent content = holder.content;
+        addMuteSenderAction(builder, content, notificationId);
         addReplyAction(builder, content, notificationId);
         addMarkAsReadAction(builder, content, notificationId);
         addDeleteAction(builder, content, notificationId);
@@ -217,6 +218,16 @@ class DeviceNotifications extends BaseNotifications {
                 actionCreator.createReplyPendingIntent(messageReference, notificationId);
 
         builder.addAction(icon, title, replyToMessagePendingIntent);
+    }
+
+    private void addMuteSenderAction(Builder builder, NotificationContent content, int notificationId) {
+        int icon = resourceProvider.getIconMuteSender();
+        String title = resourceProvider.actionMuteSender();
+
+        MessageReference messageReference = content.messageReference;
+        PendingIntent action = actionCreator.createMuteSenderPendingIntent(messageReference, notificationId);
+
+        builder.addAction(icon, title, action);
     }
 
     private boolean isPrivacyModeActive() {

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
@@ -32,6 +32,8 @@ public interface NotificationActionCreator {
     PendingIntent createMarkAllAsReadPendingIntent(Account account, List<MessageReference> messageReferences,
             int notificationId);
 
+    PendingIntent createMuteSenderPendingIntent(MessageReference messageReference, int notificationId);
+
     PendingIntent getEditIncomingServerSettingsIntent(Account account);
 
     PendingIntent getEditOutgoingServerSettingsIntent(Account account);

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
@@ -5,6 +5,7 @@ interface NotificationResourceProvider {
     val iconMarkAsRead: Int
     val iconDelete: Int
     val iconReply: Int
+    val iconMuteSender: Int
     val iconNewMail: Int
     val iconSendingMail: Int
     val iconCheckingMail: Int
@@ -13,6 +14,7 @@ interface NotificationResourceProvider {
     val wearIconArchive: Int
     val wearIconReplyAll: Int
     val wearIconMarkAsSpam: Int
+    val wearIconMuteSender: Int
 
     val messagesChannelName: String
     val messagesChannelDescription: String
@@ -50,4 +52,5 @@ interface NotificationResourceProvider {
     fun actionArchive(): String
     fun actionArchiveAll(): String
     fun actionMarkAsSpam(): String
+    fun actionMuteSender(): String
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/WearNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/WearNotifications.java
@@ -103,6 +103,7 @@ class WearNotifications extends BaseNotifications {
         addDeviceReplyAction(builder, holder);
         addDeviceMarkAsReadAction(builder, holder);
         addDeviceDeleteAction(builder, holder);
+        addDeviceMuteSenderAction(builder, holder);
     }
 
     private void addDeviceReplyAction(Builder builder, NotificationHolder holder) {
@@ -145,6 +146,18 @@ class WearNotifications extends BaseNotifications {
         builder.addAction(icon, title, action);
     }
 
+    private void addDeviceMuteSenderAction(Builder builder, NotificationHolder holder) {
+        int icon = resourceProvider.getIconMuteSender();
+        String title = resourceProvider.actionMuteSender();
+
+        NotificationContent content = holder.content;
+        MessageReference messageReference = content.messageReference;
+        PendingIntent muteSenderPendingIntent =
+                actionCreator.createMuteSenderPendingIntent(messageReference, holder.notificationId);
+
+        builder.addAction(icon, title, muteSenderPendingIntent);
+    }
+
     private void addWearActions(Builder builder, Account account, NotificationHolder holder) {
         NotificationCompat.WearableExtender wearableExtender = new NotificationCompat.WearableExtender();
 
@@ -162,6 +175,8 @@ class WearNotifications extends BaseNotifications {
         if (isSpamActionAvailableForWear(account)) {
             addMarkAsSpamAction(wearableExtender, holder);
         }
+
+        addMuteSenderAction(wearableExtender, holder);
 
         builder.extend(wearableExtender);
     }
@@ -224,6 +239,18 @@ class WearNotifications extends BaseNotifications {
 
         NotificationCompat.Action spamAction = new NotificationCompat.Action.Builder(icon, title, action).build();
         wearableExtender.addAction(spamAction);
+    }
+
+    private void addMuteSenderAction(WearableExtender wearableExtender, NotificationHolder holder) {
+        int icon = resourceProvider.getWearIconMuteSender();
+        String title = resourceProvider.actionMuteSender();
+
+        MessageReference messageReference = holder.content.messageReference;
+        int notificationId = holder.notificationId;
+        PendingIntent action = actionCreator.createMuteSenderPendingIntent(messageReference, notificationId);
+
+        NotificationCompat.Action muteSenderAction = new NotificationCompat.Action.Builder(icon, title, action).build();
+        wearableExtender.addAction(muteSenderAction);
     }
 
     private boolean isDeleteActionAvailableForWear() {

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRule.kt
@@ -1,0 +1,21 @@
+package com.fsck.k9.notification.rules
+
+import com.fsck.k9.mail.internet.MimeMessage
+
+class NotificationRule(val description: String, val enabled: Boolean = true, val action: Action, val actionExtra: String?, val clauses: List<NotificationRuleClause>) {
+    public fun isMuted(message: MimeMessage): Boolean {
+        if (enabled && action == Action.MUTE) {
+            for (clause in clauses) {
+                if (!clause.matches(message)) {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
+    }
+
+    enum class Action {
+        MUTE
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRule.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification.rules
 
 import com.fsck.k9.mail.internet.MimeMessage
 
-class NotificationRule(val description: String, val enabled: Boolean = true, val action: Action, val actionExtra: String?, val clauses: List<NotificationRuleClause>) {
+class NotificationRule(val id: Long, val description: String, val enabled: Boolean = true, val action: Action, val actionExtra: String?, val clauses: List<NotificationRuleClause>) {
     public fun isMuted(message: MimeMessage): Boolean {
         if (enabled && action == Action.MUTE) {
             for (clause in clauses) {
@@ -17,5 +17,12 @@ class NotificationRule(val description: String, val enabled: Boolean = true, val
 
     enum class Action {
         MUTE
+    }
+
+    companion object {
+        @JvmStatic
+        fun create(id: Long, description: String, enabled: Long, action: String, actionExtra: String?, clauses: List<NotificationRuleClause>): NotificationRule {
+            return NotificationRule(id, description, enabled > 0, Action.valueOf(action), actionExtra, clauses)
+        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleClause.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleClause.kt
@@ -1,0 +1,72 @@
+package com.fsck.k9.notification.rules
+
+import com.fsck.k9.mail.Message
+import com.fsck.k9.mail.internet.MimeMessage
+
+class NotificationRuleClause(val property: PropertyType, val propertyExtra: String?, val match: MatchType, val matchExtra: String) {
+    fun matches(message: MimeMessage): Boolean {
+        when (property) {
+            PropertyType.SENDER -> {
+                for (from in message.from) {
+                    if (matches(from.address)) {
+                        return true
+                    }
+                }
+                for (sender in message.sender) {
+                    if (matches(sender.address)) {
+                        return true
+                    }
+                }
+            }
+            PropertyType.RECIPIENT -> {
+                for (recipient in message.getRecipients(Message.RecipientType.TO)) {
+                    if (matches(recipient.address)) {
+                        return true
+                    }
+                }
+            }
+            PropertyType.HEADER -> {
+                for (header in message.getHeader(propertyExtra)) {
+                    if (matches(header)) {
+                        return true
+                    }
+                }
+            }
+            PropertyType.SUBJECT -> {
+                if (matches(message.subject)) {
+                    return true
+                }
+            }
+            PropertyType.BODY -> {
+                if (matches(message.body.toString())) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    fun matches(string: String): Boolean {
+        when (match) {
+            MatchType.EQUALS -> return string.equals(matchExtra)
+            MatchType.EQUALS_IGNORE_CASE -> return string.equals(matchExtra, ignoreCase = true)
+            MatchType.CONTAINS -> return string.indexOf(matchExtra) >= 0
+            MatchType.STARTS_WITH -> return string.startsWith(matchExtra)
+        }
+    }
+
+    enum class PropertyType {
+        SENDER,
+        RECIPIENT,
+        HEADER,
+        SUBJECT,
+        BODY
+    }
+
+    enum class MatchType {
+        EQUALS,
+        EQUALS_IGNORE_CASE,
+        CONTAINS,
+        STARTS_WITH
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleClause.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleClause.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification.rules
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.internet.MimeMessage
 
-class NotificationRuleClause(val property: PropertyType, val propertyExtra: String?, val match: MatchType, val matchExtra: String) {
+class NotificationRuleClause(val id: Long, val property: PropertyType, val propertyExtra: String?, val match: MatchType, val matchExtra: String) {
     fun matches(message: MimeMessage): Boolean {
         when (property) {
             PropertyType.SENDER -> {
@@ -68,5 +68,12 @@ class NotificationRuleClause(val property: PropertyType, val propertyExtra: Stri
         EQUALS_IGNORE_CASE,
         CONTAINS,
         STARTS_WITH
+    }
+
+    companion object {
+        @JvmStatic
+        fun create(id: Long, property: String, propertyExtra: String?, match: String, matchExtra: String): NotificationRuleClause {
+            return NotificationRuleClause(id, PropertyType.valueOf(property), propertyExtra, MatchType.valueOf(match), matchExtra)
+        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleList.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRuleList.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.notification.rules
+
+import com.fsck.k9.mail.internet.MimeMessage
+
+class NotificationRuleList(val rules: List<NotificationRule>) {
+    fun isMuted(message: MimeMessage): Boolean {
+        for (rule in rules) {
+            if (rule.isMuted(message)) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRulesRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRulesRepository.kt
@@ -1,0 +1,69 @@
+package com.fsck.k9.notification.rules
+
+import androidx.core.database.getStringOrNull
+import com.fsck.k9.Account
+import com.fsck.k9.helper.map
+import com.fsck.k9.mailstore.LocalStoreProvider
+
+class NotificationRulesRepository(
+    private val localStoreProvider: LocalStoreProvider,
+    private val account: Account
+) {
+    fun getRules(): NotificationRuleList {
+        val database = localStoreProvider.getInstance(account).database
+        return NotificationRuleList(
+            database.execute(false) { db ->
+                db.query(
+                    "notification_rules",
+                    arrayOf(
+                        "id",
+                        "description",
+                        "enabled",
+                        "action",
+                        "action_extra"
+                    ),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ).use { cursor ->
+                    cursor.map {
+                        val id = cursor.getLong(0)
+                        val description = cursor.getString(1)
+                        val enabled = cursor.getLong(2)
+                        val action = cursor.getString(3)
+                        val actionExtra = cursor.getStringOrNull(4)
+                        val clauses = database.execute(false) { db ->
+                            db.query(
+                                "notification_rule_clauses",
+                                arrayOf(
+                                    "id",
+                                    "property",
+                                    "property_extra",
+                                    "action",
+                                    "action_extra"
+                                ),
+                                "notification_rule_id = " + id,
+                                null,
+                                null,
+                                null,
+                                null
+                            ).use { cursor ->
+                                cursor.map {
+                                    val clauseId = cursor.getLong(0)
+                                    val property = cursor.getString(1)
+                                    val propertyExtra = cursor.getStringOrNull(2)
+                                    val match = cursor.getString(3)
+                                    val matchExtra = cursor.getString(4)
+                                    NotificationRuleClause.create(clauseId, property, propertyExtra, match, matchExtra)
+                                }
+                            }
+                        }
+                        NotificationRule.create(id, description, enabled, action, actionExtra, clauses)
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRulesRepositoryManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/rules/NotificationRulesRepositoryManager.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.notification.rules
+
+import com.fsck.k9.Account
+import com.fsck.k9.mailstore.LocalStoreProvider
+
+class NotificationRulesRepositoryManager(private val localStoreProvider: LocalStoreProvider) {
+    fun getNotificationRulesRepository(account: Account) = NotificationRulesRepository(localStoreProvider, account)
+}

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.notification;
 
 
+import java.io.ByteArrayInputStream;
+
 import android.app.Notification;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -9,10 +11,12 @@ import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.controller.MessageReference;
+import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -272,6 +276,23 @@ public class NewMailNotificationsTest extends K9RobolectricTest {
 
         verify(notificationManager).cancel(notificationId);
         verify(notificationManager).cancel(NotificationIds.getNewMailSummaryNotificationId(account));
+    }
+
+    @Test
+    public void testMuteMailingLists() throws Exception {
+        final String MESSAGE = "From: lena@example.com\n"
+                + "List-Id: \"Lena's Personal Joke List\" <lenas-jokes.localhost>\n"
+                + "Date: Apr 1st Wed Apr  1 23:44:53 CEST 2020\n"
+                + "\n"
+                + "Hi!\n";
+
+        MimeMessage message = new MimeMessage();
+        message.parse(new ByteArrayInputStream(MESSAGE.getBytes()));
+
+        final Account account = new Account("uuid");
+        account.setMuteMailingLists(true);
+
+        assertTrue(account.isNotificationSuppressed(message));
     }
 
     private Account createAccount() {

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
@@ -17,6 +17,7 @@ import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -307,6 +308,36 @@ public class NewMailNotificationsTest extends K9RobolectricTest {
         account.setMutedSenders(BOB_ADDRESS);
 
         assertTrue(account.isNotificationSuppressed(message));
+    }
+
+    @Test
+    public void testMuteIfSentTo() throws Exception {
+        final String ALICE_ADDRESS = "alice@example.com";
+        final String LIST_ADDRESS = "list@example.com";
+        final String ME_ADDRESS = "me@example.com";
+        final String MESSAGE = "From: Alice <" + ALICE_ADDRESS + ">\n"
+                + "To: Myself <" + ME_ADDRESS + ">\n"
+                + "Cc: Somebody Else <someone@example.com>, The List <" + LIST_ADDRESS + ">\n"
+                + "Date: Apr 1st Wed Apr  1 23:44:53 CEST 2020\n"
+                + "\n"
+                + "Hi!\n";
+
+        MimeMessage message = new MimeMessage();
+        message.parse(new ByteArrayInputStream(MESSAGE.getBytes()));
+
+        final Account account = new Account("uuid");
+
+        account.setMuteIfSentTo(LIST_ADDRESS + ";" + ME_ADDRESS);
+        assertTrue(account.isNotificationSuppressed(message));
+
+        account.setMuteIfSentTo(ME_ADDRESS);
+        assertTrue(account.isNotificationSuppressed(message));
+
+        account.setMuteIfSentTo(LIST_ADDRESS);
+        assertTrue(account.isNotificationSuppressed(message));
+
+        account.setMuteIfSentTo(ALICE_ADDRESS);
+        assertFalse(account.isNotificationSuppressed(message));
     }
 
     private Account createAccount() {

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
@@ -11,6 +11,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.controller.MessageReference;
+import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
@@ -291,6 +292,19 @@ public class NewMailNotificationsTest extends K9RobolectricTest {
 
         final Account account = new Account("uuid");
         account.setMuteMailingLists(true);
+
+        assertTrue(account.isNotificationSuppressed(message));
+    }
+
+    @Test
+    public void testMutedSender() throws Exception {
+        final String BOB_ADDRESS = "bob@example.com";
+
+        LocalMessage message = createLocalMessage();
+        when(message.getSender()).thenReturn(new Address[] { new Address(BOB_ADDRESS) });
+
+        final Account account = new Account("uuid");
+        account.setMutedSenders(BOB_ADDRESS);
 
         assertTrue(account.isNotificationSuppressed(message));
     }

--- a/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
@@ -5,14 +5,16 @@ class TestNotificationResourceProvider : NotificationResourceProvider {
     override val iconMarkAsRead: Int = 2
     override val iconDelete: Int = 3
     override val iconReply: Int = 4
-    override val iconNewMail: Int = 5
-    override val iconSendingMail: Int = 6
-    override val iconCheckingMail: Int = 7
-    override val wearIconMarkAsRead: Int = 8
-    override val wearIconDelete: Int = 9
-    override val wearIconArchive: Int = 10
-    override val wearIconReplyAll: Int = 11
-    override val wearIconMarkAsSpam: Int = 12
+    override val iconMuteSender: Int = 5
+    override val iconNewMail: Int = 6
+    override val iconSendingMail: Int = 7
+    override val iconCheckingMail: Int = 8
+    override val wearIconMarkAsRead: Int = 9
+    override val wearIconDelete: Int = 10
+    override val wearIconArchive: Int = 11
+    override val wearIconReplyAll: Int = 12
+    override val wearIconMarkAsSpam: Int = 13
+    override val wearIconMuteSender: Int = 14
 
     override val messagesChannelName = "Messages"
     override val messagesChannelDescription = "Notifications related to messages"
@@ -77,4 +79,6 @@ class TestNotificationResourceProvider : NotificationResourceProvider {
     override fun actionArchiveAll(): String = "Archive All"
 
     override fun actionMarkAsSpam(): String = "Spam"
+
+    override fun actionMuteSender(): String = "Mute Sender"
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
+++ b/app/core/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
@@ -70,6 +70,9 @@ public class WearNotificationsTest extends RobolectricTest {
         PendingIntent markAsReadPendingIntent = createFakePendingIntent(2);
         when(actionCreator.createMarkMessageAsReadPendingIntent(messageReference, notificationId))
                 .thenReturn(markAsReadPendingIntent);
+        PendingIntent muteSenderPendingIntent = createFakePendingIntent(3);
+        when(actionCreator.createMuteSenderPendingIntent(messageReference, notificationId))
+                .thenReturn(muteSenderPendingIntent);
 
         Notification result = wearNotifications.buildStackedNotification(account, holder);
 
@@ -77,7 +80,8 @@ public class WearNotificationsTest extends RobolectricTest {
         verifyExtendWasOnlyCalledOnce();
         verifyAddAction(resourceProvider.getWearIconReplyAll(), "Reply", replyPendingIntent);
         verifyAddAction(resourceProvider.getWearIconMarkAsRead(), "Mark Read", markAsReadPendingIntent);
-        verifyNumberOfActions(2);
+        verifyAddAction(resourceProvider.getWearIconMuteSender(), "Mute Sender", muteSenderPendingIntent);
+        verifyNumberOfActions(3);
     }
 
     @Test

--- a/app/k9mail-jmap/src/main/AndroidManifest.xml
+++ b/app/k9mail-jmap/src/main/AndroidManifest.xml
@@ -138,6 +138,11 @@
             android:label="@string/account_setup_check_settings_title"/>
 
         <activity
+            android:name=".activity.EditEmailAddressList"
+            android:configChanges="locale"
+            android:label="@string/account_settings_edit_list_of_emails_title"/>
+
+        <activity
             android:name="com.fsck.k9.ui.endtoend.AutocryptKeyTransferActivity"
             android:configChanges="locale"
             android:label="@string/ac_transfer_title"

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -120,6 +120,13 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     }
 
     @Override
+    public PendingIntent createMuteSenderPendingIntent(MessageReference messageReference, int notificationId) {
+        Intent intent = NotificationActionService.createMuteSenderIntent(context, messageReference);
+
+        return PendingIntent.getService(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    @Override
     public PendingIntent getEditIncomingServerSettingsIntent(Account account) {
         Intent intent = AccountSetupIncoming.intentActionEditIncomingSettings(context, account);
 

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -8,6 +8,7 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override val iconMarkAsRead: Int = R.drawable.notification_action_mark_as_read
     override val iconDelete: Int = R.drawable.notification_action_delete
     override val iconReply: Int = R.drawable.notification_action_reply
+    override val iconMuteSender: Int = R.drawable.notification_action_mute_sender
     override val iconNewMail: Int = R.drawable.notification_icon_new_mail
     override val iconSendingMail: Int = R.drawable.notification_icon_check_mail
     override val iconCheckingMail: Int = R.drawable.notification_icon_check_mail
@@ -16,6 +17,7 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override val wearIconArchive: Int = R.drawable.notification_action_archive
     override val wearIconReplyAll: Int = R.drawable.notification_action_reply
     override val wearIconMarkAsSpam: Int = R.drawable.notification_action_mark_as_spam
+    override val wearIconMuteSender: Int = R.drawable.notification_action_mute_sender
 
     override val messagesChannelName: String
         get() = context.getString(R.string.notification_channel_messages_title)
@@ -91,4 +93,6 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun actionArchiveAll(): String = context.getString(R.string.notification_action_archive_all)
 
     override fun actionMarkAsSpam(): String = context.getString(R.string.notification_action_spam)
+
+    override fun actionMuteSender(): String = context.getString(R.string.notification_action_mute_sender)
 }

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -60,6 +60,9 @@ class K9NotificationStrategy(val contacts: Contacts) : NotificationStrategy {
             }
         }
 
+        if (account.isNotificationSuppressed(message))
+            return false
+
         // Don't notify if the sender address matches one of our identities and the user chose not
         // to be notified for such messages.
         return if (account.isAnIdentity(message.from) && !account.isNotifySelfNewMail) {

--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -164,6 +164,11 @@
             android:label="@string/account_setup_check_settings_title"/>
 
         <activity
+            android:name=".activity.EditEmailAddressList"
+            android:configChanges="locale"
+            android:label="@string/account_settings_edit_list_of_emails_title"/>
+
+        <activity
             android:name=".ui.endtoend.AutocryptKeyTransferActivity"
             android:configChanges="locale"
             android:label="@string/ac_transfer_title"

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -120,6 +120,13 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     }
 
     @Override
+    public PendingIntent createMuteSenderPendingIntent(MessageReference messageReference, int notificationId) {
+        Intent intent = NotificationActionService.createMuteSenderIntent(context, messageReference);
+
+        return PendingIntent.getService(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    @Override
     public PendingIntent getEditIncomingServerSettingsIntent(Account account) {
         Intent intent = AccountSetupIncoming.intentActionEditIncomingSettings(context, account);
 

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -8,6 +8,7 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override val iconMarkAsRead: Int = R.drawable.notification_action_mark_as_read
     override val iconDelete: Int = R.drawable.notification_action_delete
     override val iconReply: Int = R.drawable.notification_action_reply
+    override val iconMuteSender: Int = R.drawable.notification_action_mute_sender
     override val iconNewMail: Int = R.drawable.notification_icon_new_mail
     override val iconSendingMail: Int = R.drawable.notification_icon_check_mail
     override val iconCheckingMail: Int = R.drawable.notification_icon_check_mail
@@ -16,6 +17,7 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override val wearIconArchive: Int = R.drawable.notification_action_archive
     override val wearIconReplyAll: Int = R.drawable.notification_action_reply
     override val wearIconMarkAsSpam: Int = R.drawable.notification_action_mark_as_spam
+    override val wearIconMuteSender: Int = R.drawable.notification_action_mute_sender
 
     override val messagesChannelName: String
         get() = context.getString(R.string.notification_channel_messages_title)
@@ -77,6 +79,8 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
         context.getString(R.string.notification_bg_title_separator)
 
     override fun actionMarkAsRead(): String = context.getString(R.string.notification_action_mark_as_read)
+
+    override fun actionMuteSender(): String = context.getString(R.string.notification_action_mute_sender)
 
     override fun actionMarkAllAsRead(): String = context.getString(R.string.notification_action_mark_all_as_read)
 

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -90,6 +90,11 @@ class K9NotificationStrategy(private val contacts: Contacts) : NotificationStrat
             return false
         }
 
+        if (account.isNotificationSuppressed(message)) {
+            Timber.v("No notification: Message matches suppression pattern")
+            return false
+        }
+
         return true
     }
 }

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -227,6 +227,25 @@ class StoreSchemaDefinition implements SchemaDefinition {
         db.execSQL("CREATE TABLE pending_commands " +
                 "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
 
+        db.execSQL("DROP TABLE IF EXISTS notification_rule_clauses");
+        db.execSQL("CREATE TABLE notification_rule_clauses (" +
+                "id INTEGER PRIMARY KEY, " +
+                "notification_rule_id INTEGER NOT NULL, " +
+                "property TEXT NOT NULL, " +
+                "property_extra TEXT, " +
+                "match TEXT NOT NULL, " +
+                "match_extra TEXT " +
+                ")");
+
+        db.execSQL("DROP TABLE IF EXISTS notification_rules");
+        db.execSQL("CREATE TABLE notification_rules (" +
+                "id INTEGER PRIMARY KEY, " +
+                "description TEXT NOT NULL, " +
+                "enabled INTEGER DEFAULT 1," +
+                "action TEXT NOT NULL, " +
+                "action_extra TEXT NOT NULL " +
+                ")");
+
         db.execSQL("DROP TRIGGER IF EXISTS delete_folder");
         db.execSQL("CREATE TRIGGER delete_folder BEFORE DELETE ON folders BEGIN DELETE FROM messages WHERE old.id = folder_id; END;");
 
@@ -244,6 +263,13 @@ class StoreSchemaDefinition implements SchemaDefinition {
                 "DELETE FROM message_parts WHERE root = OLD.message_part_id; " +
                 "DELETE FROM messages_fulltext WHERE docid = OLD.id; " +
                 "DELETE FROM threads WHERE message_id = OLD.id; " +
+                "END");
+
+        db.execSQL("DROP TRIGGER IF EXISTS delete_notification_rule_clauses");
+        db.execSQL("CREATE TRIGGER delete_notification_rule_clauses " +
+                "BEFORE DELETE ON notification_rules " +
+                "BEGIN " +
+                "DELETE FROM notification_rule_clauses WHERE old.id = notification_rule_id; " +
                 "END");
 
         db.execSQL("DROP TABLE IF EXISTS messages_fulltext");

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo80.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo80.kt
@@ -1,0 +1,36 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+internal class MigrationTo80(private val db: SQLiteDatabase) {
+    fun addNotificationRuleTables() {
+        db.execSQL(
+            "CREATE TABLE notification_rule_clauses (" +
+                "id INTEGER PRIMARY KEY, " +
+                "notification_rule_id INTEGER NOT NULL, " +
+                "property TEXT NOT NULL, " +
+                "property_extra TEXT, " +
+                "match TEXT NOT NULL, " +
+                "match_extra TEXT " +
+                ")"
+        )
+
+        db.execSQL(
+            "CREATE TABLE notification_rules (" +
+                "id INTEGER PRIMARY KEY, " +
+                "description TEXT NOT NULL, " +
+                "enabled INTEGER DEFAULT 1," +
+                "action TEXT NOT NULL, " +
+                "action_extra TEXT NOT NULL " +
+                ")"
+        )
+
+        db.execSQL(
+            "CREATE TRIGGER delete_notification_rule_clauses " +
+                "BEFORE DELETE ON notification_rules " +
+                "BEGIN " +
+                "DELETE FROM notification_rule_clauses WHERE old.id = notification_rule_id; " +
+                "END"
+        )
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -25,5 +25,6 @@ object Migrations {
         // 77: No longer necessary
         if (oldVersion < 78) MigrationTo78(db).removeServerIdFromLocalFolders()
         if (oldVersion < 79) MigrationTo79(db).updateDeleteMessageTrigger()
+        if (oldVersion < 80) MigrationTo80(db).addNotificationRuleTables()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditEmailAddressList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditEmailAddressList.kt
@@ -1,0 +1,183 @@
+package com.fsck.k9.activity
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.AdapterView.OnItemClickListener
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import com.fsck.k9.Account
+import com.fsck.k9.Preferences
+import com.fsck.k9.ui.R
+
+interface EditEmailAddressListDialogListener {
+    fun onModifyEmail(oldEmail: String?, newEmail: String?)
+}
+
+class EditEmailAddressList : K9ListActivity(), OnItemClickListener, EditEmailAddressListDialogListener {
+    private lateinit var account: Account
+    private lateinit var arrayAdapter: ArrayAdapter<String>
+    private val emailAddresses = HashSet<String>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setLayout(R.layout.list_content_simple)
+
+        listView.isTextFilterEnabled = true
+        listView.itemsCanFocus = false
+        listView.choiceMode = ListView.CHOICE_MODE_NONE
+
+        val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT)
+        account = Preferences.getPreferences(this).getAccount(accountUuid)
+
+        arrayAdapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1)
+
+        setListAdapter(arrayAdapter)
+        setupClickListeners()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshView()
+    }
+
+    protected fun refreshView() {
+        arrayAdapter.setNotifyOnChange(false)
+        arrayAdapter.clear()
+        emailAddresses.clear()
+        for (emailAddress in account.mutedSenders) {
+            arrayAdapter.add(emailAddress)
+            emailAddresses.add(emailAddress)
+        }
+        arrayAdapter.add("+ Add to list")
+        arrayAdapter.notifyDataSetChanged()
+    }
+
+    override fun onModifyEmail(oldEmail: String?, newEmail: String?) {
+        if (oldEmail == newEmail)
+            return
+        if (oldEmail != null) {
+            arrayAdapter.remove(oldEmail)
+            emailAddresses.remove(oldEmail)
+        }
+        if (newEmail != null) {
+            arrayAdapter.add(newEmail)
+            emailAddresses.add(newEmail)
+        }
+        arrayAdapter.sort(
+            Comparator { o1, o2 ->
+                when {
+                    o1 == "+ Add to list" -> +1
+                    o2 == "+ Add to list" -> -1
+                    else -> o1.compareTo(o2)
+                }
+            }
+        )
+        arrayAdapter.notifyDataSetChanged()
+        saveEmailAddresses()
+    }
+
+    override fun onItemClick(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+        val originalEmail = when (position) {
+            arrayAdapter.count - 1 -> null
+            else -> arrayAdapter.getItem(position)
+        }
+        var dialogFragment = EditEmailAddressDialogFragment.create(originalEmail)
+        dialogFragment.show(supportFragmentManager, null)
+    }
+
+    protected fun setupClickListeners() {
+        this.listView.onItemClickListener = this
+    }
+
+    private fun saveEmailAddresses() {
+        account.setMutedSenders(emailAddresses)
+        Preferences.getPreferences(applicationContext).saveAccount(account)
+    }
+
+    override fun onBackPressed() {
+        saveEmailAddresses()
+        finish()
+        super.onBackPressed()
+    }
+
+    public override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+    }
+
+    public class EditEmailAddressDialogFragment : DialogFragment() {
+        private lateinit var listener: EditEmailAddressListDialogListener
+
+        override fun onAttach(context: Context) {
+            super.onAttach(context)
+            try {
+                listener = context as EditEmailAddressListDialogListener
+            } catch (e: ClassCastException) {
+                throw ClassCastException(
+                    context.toString() +
+                        " must implement EditEmailAddressListDialogListener"
+                )
+            }
+        }
+
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            val arguments = this.arguments ?: error("Fragment arguments missing")
+            val originalEmail = arguments.getString(EditEmailAddressDialogFragment.ARG_EMAIL_ADDRESS)
+
+            return activity?.let {
+                val builder = AlertDialog.Builder(it)
+                val inflater = requireActivity().layoutInflater
+
+                val view = inflater.inflate(R.layout.edit_email_address_dialog, null)
+                val editEmailAddress = view.findViewById<TextView>(R.id.edit_email_address)
+                if (originalEmail != null)
+                    editEmailAddress.setText(originalEmail)
+                builder.setView(view)
+                    .setPositiveButton(
+                        R.string.account_settings_edit_email_address_modify,
+                        DialogInterface.OnClickListener { dialog, id ->
+                            listener.onModifyEmail(originalEmail, editEmailAddress.text.toString())
+                        }
+                    )
+                    .setNegativeButton(
+                        R.string.account_settings_edit_email_address_remove,
+                        DialogInterface.OnClickListener { dialog, id ->
+                            listener.onModifyEmail(originalEmail, null)
+                        }
+                    )
+                builder.create()
+            } ?: throw IllegalStateException("Activity cannot be null")
+        }
+
+        companion object {
+            private const val ARG_EMAIL_ADDRESS = "accountUuid"
+
+            fun create(
+                originalEmail: String?
+            ) = EditEmailAddressDialogFragment().apply {
+                arguments = bundleOf(
+                    EditEmailAddressDialogFragment.ARG_EMAIL_ADDRESS to originalEmail,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun start(activity: Activity, accountUuid: String) {
+            val intent = Intent(activity, EditEmailAddressList::class.java)
+            intent.putExtra(EditEmailAddressList.EXTRA_ACCOUNT, accountUuid)
+            activity.startActivity(intent)
+        }
+
+        const val EXTRA_ACCOUNT = "com.fsck.k9.EditEmailAddressList_account"
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -33,6 +33,7 @@ class AccountSettingsDataStore(
             "account_led" -> account.notificationSetting.isLedEnabled
             "account_notify_sync" -> account.isNotifySync
             "notification_opens_unread" -> account.isGoToUnreadMessageSearch
+            "mute_mailing_lists" -> account.muteMailingLists
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
@@ -67,6 +68,7 @@ class AccountSettingsDataStore(
             "account_led" -> account.notificationSetting.setLed(value)
             "account_notify_sync" -> account.isNotifySync = value
             "notification_opens_unread" -> account.isGoToUnreadMessageSearch = value
+            "mute_mailing_lists" -> account.muteMailingLists = value
             "remote_search_enabled" -> account.isAllowRemoteSearch = value
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -12,6 +12,7 @@ import androidx.preference.Preference
 import androidx.preference.SwitchPreference
 import com.fsck.k9.Account
 import com.fsck.k9.account.BackgroundAccountRemover
+import com.fsck.k9.activity.EditEmailAddressList
 import com.fsck.k9.activity.ManageIdentities
 import com.fsck.k9.activity.setup.AccountSetupComposition
 import com.fsck.k9.activity.setup.AccountSetupIncoming
@@ -180,6 +181,10 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeNotifications() {
+        findPreference<Preference>(PREFERENCE_MUTED_SENDERS)?.onClick {
+            EditEmailAddressList.start(requireActivity(), accountUuid)
+        }
+
         findPreference<Preference>(PREFERENCE_OPEN_NOTIFICATION_SETTINGS)?.let {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference<Preference>(it).remove() }
@@ -377,6 +382,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         private const val PREFERENCE_SPAM_FOLDER = "spam_folder"
         private const val PREFERENCE_TRASH_FOLDER = "trash_folder"
         private const val PREFERENCE_OPEN_NOTIFICATION_SETTINGS = "open_notification_settings"
+        private const val PREFERENCE_MUTED_SENDERS = "muted_senders"
         private const val DELETE_POLICY_MARK_AS_READ = "MARK_AS_READ"
 
         private val PRE_SDK26_NOTIFICATION_PREFERENCES = arrayOf(

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -13,6 +13,7 @@ import androidx.preference.SwitchPreference
 import com.fsck.k9.Account
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.EditEmailAddressList
+import com.fsck.k9.activity.EmailAddressListType
 import com.fsck.k9.activity.ManageIdentities
 import com.fsck.k9.activity.setup.AccountSetupComposition
 import com.fsck.k9.activity.setup.AccountSetupIncoming
@@ -182,7 +183,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
 
     private fun initializeNotifications() {
         findPreference<Preference>(PREFERENCE_MUTED_SENDERS)?.onClick {
-            EditEmailAddressList.start(requireActivity(), accountUuid)
+            EditEmailAddressList.start(requireActivity(), accountUuid, EmailAddressListType.MUTED_SENDERS)
+        }
+
+        findPreference<Preference>(PREFERENCE_MUTE_IF_SENT_TO)?.onClick {
+            EditEmailAddressList.start(requireActivity(), accountUuid, EmailAddressListType.MUTE_IF_SENT_TO)
         }
 
         findPreference<Preference>(PREFERENCE_OPEN_NOTIFICATION_SETTINGS)?.let {
@@ -383,6 +388,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         private const val PREFERENCE_TRASH_FOLDER = "trash_folder"
         private const val PREFERENCE_OPEN_NOTIFICATION_SETTINGS = "open_notification_settings"
         private const val PREFERENCE_MUTED_SENDERS = "muted_senders"
+        private const val PREFERENCE_MUTE_IF_SENT_TO = "mute_if_sent_to"
         private const val DELETE_POLICY_MARK_AS_READ = "MARK_AS_READ"
 
         private val PRE_SDK26_NOTIFICATION_PREFERENCES = arrayOf(

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/EmailAddressListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/EmailAddressListFragment.kt
@@ -1,0 +1,17 @@
+package com.fsck.k9.ui.settings.account
+
+import android.os.Bundle
+import android.view.View
+import com.fsck.k9.ui.R
+import com.takisoft.preferencex.PreferenceFragmentCompat
+
+class EmailAddressListFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.empty_preferences, null)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/ui/legacy/src/main/res/drawable/notification_action_mute_sender.xml
+++ b/app/ui/legacy/src/main/res/drawable/notification_action_mute_sender.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:fillType="evenOdd"
+        android:pathData="M12,3c8,0 4,13 9,11v2h-18v-2c5,2 1,-11 9,-11ZM15,16a3,3 0 1,1 -6,0ZM17,1l2,2l-13,17l-2,-2Z" />
+</vector>

--- a/app/ui/legacy/src/main/res/layout/edit_email_address_dialog.xml
+++ b/app/ui/legacy/src/main/res/layout/edit_email_address_dialog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:orientation="vertical">
+
+    <TextView
+            android:id="@+id/edit_email_address_label"
+            android:layout_width="312dp"
+            android:layout_height="wrap_content"
+            android:text="Email address :"
+            android:layout_marginLeft="5dp"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <EditText
+            android:id="@+id/edit_email_address"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:layout_marginTop="10dp"
+            android:inputType="textEmailAddress">
+
+        <requestFocus />
+    </EditText>
+</LinearLayout>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -520,6 +520,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mark_message_as_read_on_delete_summary">Mark a message as read when it is deleted</string>
     <string name="account_settings_notification_open_system_notifications_label">Notification settings</string>
     <string name="account_settings_notification_open_system_notifications_summary">Open system notification settings</string>
+    <string name="account_settings_mute_mailing_lists_label">Mute mailing lists</string>
+    <string name="account_settings_mute_mailing_lists_summary">Suppress notifications for mails sent via mailing lists</string>
 
     <string name="account_settings_show_pictures_label">Always show images</string>
     <string name="account_settings_show_pictures_never">No</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="notification_action_archive">Archive</string>
     <string name="notification_action_archive_all">Archive All</string>
     <string name="notification_action_spam">Spam</string>
+    <string name="notification_action_mute_sender">Mute Sender</string>
     <string name="notification_certificate_error_title">Certificate error for <xliff:g id="account">%s</xliff:g></string>
     <string name="notification_certificate_error_text">Check your server settings</string>
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -518,6 +518,11 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
     <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>
     <string name="account_settings_mark_message_as_read_on_delete_summary">Mark a message as read when it is deleted</string>
+    <string name="account_settings_muted_senders_label">Muted senders</string>
+    <string name="account_settings_muted_senders_summary">Suppress notifications for mails from these senders</string>
+    <string name="account_settings_edit_list_of_emails_title">Edit list of emails</string>
+    <string name="account_settings_edit_email_address_modify">Modify</string>
+    <string name="account_settings_edit_email_address_remove">Remove</string>
     <string name="account_settings_notification_open_system_notifications_label">Notification settings</string>
     <string name="account_settings_notification_open_system_notifications_summary">Open system notification settings</string>
     <string name="account_settings_mute_mailing_lists_label">Mute mailing lists</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -520,6 +520,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mark_message_as_read_on_delete_summary">Mark a message as read when it is deleted</string>
     <string name="account_settings_muted_senders_label">Muted senders</string>
     <string name="account_settings_muted_senders_summary">Suppress notifications for mails from these senders</string>
+    <string name="account_settings_mute_if_sent_to_label">Mute for given recipients</string>
+    <string name="account_settings_mute_if_sent_to_summary">Suppress notifications for mails sent to these addresses</string>
     <string name="account_settings_edit_list_of_emails_title">Edit list of emails</string>
     <string name="account_settings_edit_email_address_modify">Modify</string>
     <string name="account_settings_edit_email_address_remove">Remove</string>

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -409,6 +409,13 @@
             android:title="@string/account_settings_muted_senders_label"
             android:fragment="com.fsck.k9.ui.settings.account.EmailAddressListFragment"/>
 
+        <Preference
+            android:key="mute_if_sent_to"
+            android:singleLine="false"
+            android:summary="@string/account_settings_mute_if_sent_to_summary"
+            android:title="@string/account_settings_mute_if_sent_to_label"
+            android:fragment="com.fsck.k9.ui.settings.account.EmailAddressListFragment"/>
+
         <com.fsck.k9.ui.settings.account.NotificationsPreference
             android:key="open_notification_settings"
             android:summary="@string/account_settings_notification_open_system_notifications_summary"

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -402,6 +402,13 @@
             android:summary="@string/account_settings_mute_mailing_lists_summary"
             android:title="@string/account_settings_mute_mailing_lists_label" />
 
+        <Preference
+            android:key="muted_senders"
+            android:singleLine="false"
+            android:summary="@string/account_settings_muted_senders_summary"
+            android:title="@string/account_settings_muted_senders_label"
+            android:fragment="com.fsck.k9.ui.settings.account.EmailAddressListFragment"/>
+
         <com.fsck.k9.ui.settings.account.NotificationsPreference
             android:key="open_notification_settings"
             android:summary="@string/account_settings_notification_open_system_notifications_summary"

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -396,6 +396,12 @@
             android:summary="@string/account_settings_notification_opens_unread_summary"
             android:title="@string/account_settings_notification_opens_unread_label" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="mute_mailing_lists"
+            android:summary="@string/account_settings_mute_mailing_lists_summary"
+            android:title="@string/account_settings_mute_mailing_lists_label" />
+
         <com.fsck.k9.ui.settings.account.NotificationsPreference
             android:key="open_notification_settings"
             android:summary="@string/account_settings_notification_open_system_notifications_summary"


### PR DESCRIPTION
This PR offers a few options to suppress notifications, and is a continuation of https://github.com/k9mail/k-9/pull/5064. Concretely, it adds three new items to each account's "Notifications" preferences:

![image](https://user-images.githubusercontent.com/127790/106401494-af71c080-6424-11eb-863c-01744ebfafe2.png)

- "Mute mailing lists" will suppress notifications for mails that were sent via mailing lists (as identified by the `List-Id` header).
- "Muted senders" will suppress notifications when they were sent from given email addresses (see below for the UI behind that button).
- "Mute for given recipients" is a bit more complicated: certain mailing lists have a reply-to-all policy, therefore one might receive duplicate mails for them, one version with the `List-Id` header mentioned above, one without. To catch the latter, this option allows to suppress mail notifications if any recipient matches any entry in the provided list (common use case: add the mailing list address).

Here is a screenshot of the list shown when clicking on the "Muted senders" button (or the "Mute for given recipients" one):

![image](https://user-images.githubusercontent.com/127790/106401608-48084080-6425-11eb-8f6e-a387045662a4.png)

To make the "Mute senders" feature easier to use, notifications will now also show a "Mute Sender" action (which will add the sender email address to the list of "Muted senders"). Example:

![image](https://user-images.githubusercontent.com/127790/106401727-f4e2bd80-6425-11eb-8843-ab4afca525c2.png)

This PR is related to https://github.com/k9mail/k-9/issues/3675, focusing on my personal use case. It does leave the door wide open for interested contributors to extend the feature to e.g. suppress notifications on certain days.