### PR TITLE
Use fixed font for composing new message as well (not only for reading messages)

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.content.pm.ActivityInfo;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -461,6 +462,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         recipientMvpView.setFontSizes(K9.getFontSizes(), fontSize);
         quotedMessageMvpView.setFontSizes(K9.getFontSizes(), fontSize);
         K9.getFontSizes().setViewTextSize(subjectView, fontSize);
+        if(K9.isUseMessageViewFixedWidthFont()) {
+            messageContentView.setTypeface(Typeface.MONOSPACE);
+        }
         K9.getFontSizes().setViewTextSize(messageContentView, fontSize);
         K9.getFontSizes().setViewTextSize(signatureView, fontSize);
 


### PR DESCRIPTION
Hi,

Fixes #907

This pulls request fixes issue 907 (https://github.com/k9mail/k-9/issues/907,  "Add option to use fixed-width font when composing messages #907")

Now, if the user has chosen to use fixed-fonts in their settings, this not only applies to viewing messages, but also to composing new messages.

Thanks for applying.