### PR TITLE
Add ability to switch between text/plain and text/html

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -126,6 +126,9 @@ object K9 : EarlyInit {
     var backgroundOps = BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC
 
     @JvmStatic
+    var preferredContentType = PREF_CONT_TYPE.TEXT_HTML
+
+    @JvmStatic
     var isShowAnimations = true
 
     @JvmStatic
@@ -350,6 +353,8 @@ object K9 : EarlyInit {
 
         backgroundOps = storage.getEnum("backgroundOperations", BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC)
 
+        preferredContentType = storage.getEnum("preferredContentTypeK9", PREF_CONT_TYPE.TEXT_HTML)
+
         isColorizeMissingContactPictures = storage.getBoolean("colorizeMissingContactPictures", true)
 
         isMessageViewArchiveActionVisible = storage.getBoolean("messageViewArchiveActionVisible", false)
@@ -368,6 +373,7 @@ object K9 : EarlyInit {
         editor.putBoolean("enableDebugLogging", isDebugLoggingEnabled)
         editor.putBoolean("enableSensitiveLogging", isSensitiveDebugLoggingEnabled)
         editor.putEnum("backgroundOperations", backgroundOps)
+        editor.putEnum("preferredContentTypeK9", preferredContentType)
         editor.putBoolean("animations", isShowAnimations)
         editor.putBoolean("useVolumeKeysForNavigation", isUseVolumeKeysForNavigation)
         editor.putBoolean("useVolumeKeysForListNavigation", isUseVolumeKeysForListNavigation)
@@ -486,6 +492,11 @@ object K9 : EarlyInit {
 
     enum class BACKGROUND_OPS {
         ALWAYS, NEVER, WHEN_CHECKED_AUTO_SYNC
+    }
+
+    enum class PREF_CONT_TYPE {
+        TEXT_HTML,
+        TEXT_PLAIN
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -21,6 +21,7 @@ public class MessageViewInfo {
     public final boolean isSubjectEncrypted;
     public final AttachmentResolver attachmentResolver;
     public final String text;
+    public final String textPlainFormatted;
     public final CryptoResultAnnotation cryptoResultAnnotation;
     public final List<AttachmentViewInfo> attachments;
     public final String extraText;
@@ -31,7 +32,7 @@ public class MessageViewInfo {
     public MessageViewInfo(
             Message message, boolean isMessageIncomplete, Part rootPart,
             String subject, boolean isSubjectEncrypted,
-            String text, List<AttachmentViewInfo> attachments,
+            String text, String textPlainFormatted, List<AttachmentViewInfo> attachments,
             CryptoResultAnnotation cryptoResultAnnotation,
             AttachmentResolver attachmentResolver,
             String extraText, List<AttachmentViewInfo> extraAttachments,
@@ -42,6 +43,7 @@ public class MessageViewInfo {
         this.subject = subject;
         this.isSubjectEncrypted = isSubjectEncrypted;
         this.text = text;
+        this.textPlainFormatted = textPlainFormatted;
         this.cryptoResultAnnotation = cryptoResultAnnotation;
         this.attachmentResolver = attachmentResolver;
         this.attachments = attachments;
@@ -51,10 +53,10 @@ public class MessageViewInfo {
     }
 
     static MessageViewInfo createWithExtractedContent(Message message, Part rootPart, boolean isMessageIncomplete,
-            String text, List<AttachmentViewInfo> attachments, AttachmentResolver attachmentResolver,
+            String text, String textPlainFormatted, List<AttachmentViewInfo> attachments, AttachmentResolver attachmentResolver,
             UnsubscribeUri preferredUnsubscribeUri) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, null, false, text, attachments, null, attachmentResolver, null,
+                message, isMessageIncomplete, rootPart, null, false, text, textPlainFormatted, attachments, null, attachmentResolver, null,
                 Collections.<AttachmentViewInfo>emptyList(), preferredUnsubscribeUri);
     }
 
@@ -63,7 +65,7 @@ public class MessageViewInfo {
             Body emptyBody = new TextBody("");
             Part emptyPart = new MimeBodyPart(emptyBody, "text/plain");
             String subject = message.getSubject();
-            return new MessageViewInfo(message, isMessageIncomplete, emptyPart, subject, false, null, null, null, null,
+            return new MessageViewInfo(message, isMessageIncomplete, emptyPart, subject, false, null, null, null, null, null,
                     null, null, null);
         } catch (MessagingException e) {
             throw new AssertionError(e);
@@ -72,13 +74,14 @@ public class MessageViewInfo {
 
     public static MessageViewInfo createForMetadataOnly(Message message, boolean isMessageIncomplete) {
         String subject = message.getSubject();
-        return new MessageViewInfo(message, isMessageIncomplete, null, subject, false, null, null, null, null, null, null, null);
+        return new MessageViewInfo(message, isMessageIncomplete, null, subject, false, null, null, null, null, null, null, null, null);
     }
 
     MessageViewInfo withCryptoData(CryptoResultAnnotation rootPartAnnotation, String extraViewableText,
             List<AttachmentViewInfo> extraAttachmentInfos) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, attachments,
+                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, textPlainFormatted,
+                attachments,
                 rootPartAnnotation,
                 attachmentResolver,
                 extraViewableText, extraAttachmentInfos,
@@ -88,7 +91,7 @@ public class MessageViewInfo {
 
     MessageViewInfo withSubject(String subject, boolean isSubjectEncrypted) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, attachments,
+                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, textPlainFormatted, attachments,
                 cryptoResultAnnotation, attachmentResolver, extraText, extraAttachments, preferredUnsubscribeUri
         );
     }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -149,7 +149,7 @@ public class MessageViewInfoExtractor {
         UnsubscribeUri preferredUnsubscribeUri = ListUnsubscribeHelper.INSTANCE.getPreferredListUnsubscribeUri(message);
 
         return MessageViewInfo.createWithExtractedContent(
-                message, contentPart, isMessageIncomplete, viewable.html, attachmentInfos, attachmentResolver,
+                message, contentPart, isMessageIncomplete, viewable.html, HtmlConverter.textToHtml(viewable.text), attachmentInfos, attachmentResolver,
                 preferredUnsubscribeUri);
     }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettings.kt
@@ -13,6 +13,7 @@ package com.fsck.k9.preferences
 data class GeneralSettings(
     val backgroundSync: BackgroundSync,
     val showRecentChanges: Boolean,
+    val preferredContentType: PrefContentType,
     val appTheme: AppTheme,
     val messageViewTheme: SubTheme,
     val messageComposeTheme: SubTheme,
@@ -23,6 +24,11 @@ enum class BackgroundSync {
     ALWAYS,
     NEVER,
     FOLLOW_SYSTEM_AUTO_SYNC
+}
+
+enum class PrefContentType {
+    TEXT_HTML,
+    TEXT_PLAIN
 }
 
 enum class AppTheme {

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -278,6 +278,9 @@ public class GeneralSettingsDescriptions {
         s.put("showStarredCount", Settings.versions(
                 new V(75, new BooleanSetting(false))
         ));
+        s.put("preferredContentTypeK9", Settings.versions(
+                new V(82, new EnumSetting<>(K9.PREF_CONT_TYPE.class, K9.PREF_CONT_TYPE.TEXT_HTML))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
@@ -68,7 +68,8 @@ internal class RealGeneralSettingsManager(
     @Synchronized
     private fun updateGeneralSettingsWithStateFromK9(): GeneralSettings {
         return getSettings().copy(
-            backgroundSync = K9.backgroundOps.toBackgroundSync()
+            backgroundSync = K9.backgroundOps.toBackgroundSync(),
+            preferredContentType = K9.preferredContentType.toPrefContentType()
         ).also { generalSettings ->
             this.generalSettings = generalSettings
         }
@@ -134,6 +135,7 @@ internal class RealGeneralSettingsManager(
         val settings = GeneralSettings(
             backgroundSync = K9.backgroundOps.toBackgroundSync(),
             showRecentChanges = storage.getBoolean("showRecentChanges", true),
+            preferredContentType = K9.preferredContentType.toPrefContentType(),
             appTheme = storage.getEnum("theme", AppTheme.FOLLOW_SYSTEM),
             messageViewTheme = storage.getEnum("messageViewTheme", SubTheme.USE_GLOBAL),
             messageComposeTheme = storage.getEnum("messageComposeTheme", SubTheme.USE_GLOBAL),
@@ -151,6 +153,13 @@ private fun K9.BACKGROUND_OPS.toBackgroundSync(): BackgroundSync {
         K9.BACKGROUND_OPS.ALWAYS -> BackgroundSync.ALWAYS
         K9.BACKGROUND_OPS.NEVER -> BackgroundSync.NEVER
         K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC -> BackgroundSync.FOLLOW_SYSTEM_AUTO_SYNC
+    }
+}
+
+private fun K9.PREF_CONT_TYPE.toPrefContentType(): PrefContentType {
+    return when (this) {
+        K9.PREF_CONT_TYPE.TEXT_HTML -> PrefContentType.TEXT_HTML
+        K9.PREF_CONT_TYPE.TEXT_PLAIN -> PrefContentType.TEXT_PLAIN
     }
 }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 81;
+    public static final int VERSION = 82;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_general_settings_values.xml
@@ -208,6 +208,11 @@
         <item>spam</item>
     </string-array>
 
+    <string-array name="messageview_preferred_content_type_values" translatable="false">
+        <item>TEXT_HTML</item>
+        <item>TEXT_PLAIN</item>
+    </string-array>
+
     <string-array name="volume_navigation_values" translatable="false">
         <item>message</item>
         <item>list</item>

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1007,15 +1007,11 @@ open class MessageList :
             startActivity(MessageSourceActivity.createLaunchIntent(this, messageViewFragment!!.messageReference))
             return true
         } else if (id == R.id.set_format_plain) {
-            messageViewFragment!!.setRenderPlainFormat(true);
-            messageViewFragment!!.asyncReloadMessage(); /* call refresh */
-            updateMenu();
-            return true;
+            messageViewFragment!!.onDisplayPlainText()
+            return true
         } else if (id == R.id.set_format_html) {
-            messageViewFragment!!.setRenderPlainFormat(false);
-            messageViewFragment!!.asyncReloadMessage(); /* call refresh */
-            updateMenu();
-            return true;
+            messageViewFragment!!.onDisplayHTML()
+            return true
         }
 
         if (!singleFolderMode) {
@@ -1110,8 +1106,8 @@ open class MessageList :
             menu.findItem(R.id.toggle_message_view_theme).isVisible = false
             menu.findItem(R.id.unsubscribe).isVisible = false
             menu.findItem(R.id.show_headers).isVisible = false
-            menu.findItem(R.id.set_format_html).isVisible = false;
-            menu.findItem(R.id.set_format_plain).isVisible = false;
+            menu.findItem(R.id.set_format_html).isVisible = false
+            menu.findItem(R.id.set_format_plain).isVisible = false
         } else {
             // hide prev/next buttons in split mode
             if (displayMode != DisplayMode.MESSAGE_VIEW) {
@@ -1190,10 +1186,10 @@ open class MessageList :
                 menu.findItem(R.id.refile).isVisible = false
             }
 
-            if (messageViewFragment!!.getRenderPlainFormat()) {
-                menu.findItem(R.id.set_format_plain).isVisible = false;
+            if (messageViewFragment!!.isRenderPlainFormat) {
+                menu.findItem(R.id.set_format_plain).isVisible = false
             } else {
-                menu.findItem(R.id.set_format_html).isVisible = false;
+                menu.findItem(R.id.set_format_html).isVisible = false
             }
 
             if (messageViewFragment!!.isOutbox) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1006,6 +1006,16 @@ open class MessageList :
         } else if (id == R.id.show_headers) {
             startActivity(MessageSourceActivity.createLaunchIntent(this, messageViewFragment!!.messageReference))
             return true
+        } else if (id == R.id.set_format_plain) {
+            messageViewFragment!!.setRenderPlainFormat(true);
+            messageViewFragment!!.asyncReloadMessage(); /* call refresh */
+            updateMenu();
+            return true;
+        } else if (id == R.id.set_format_html) {
+            messageViewFragment!!.setRenderPlainFormat(false);
+            messageViewFragment!!.asyncReloadMessage(); /* call refresh */
+            updateMenu();
+            return true;
         }
 
         if (!singleFolderMode) {
@@ -1100,6 +1110,8 @@ open class MessageList :
             menu.findItem(R.id.toggle_message_view_theme).isVisible = false
             menu.findItem(R.id.unsubscribe).isVisible = false
             menu.findItem(R.id.show_headers).isVisible = false
+            menu.findItem(R.id.set_format_html).isVisible = false;
+            menu.findItem(R.id.set_format_plain).isVisible = false;
         } else {
             // hide prev/next buttons in split mode
             if (displayMode != DisplayMode.MESSAGE_VIEW) {
@@ -1176,6 +1188,12 @@ open class MessageList :
                 menu.findItem(R.id.spam).isVisible = false
 
                 menu.findItem(R.id.refile).isVisible = false
+            }
+
+            if (messageViewFragment!!.getRenderPlainFormat()) {
+                menu.findItem(R.id.set_format_plain).isVisible = false;
+            } else {
+                menu.findItem(R.id.set_format_html).isVisible = false;
             }
 
             if (messageViewFragment!!.isOutbox) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -82,7 +82,7 @@ public class MessageContainerView extends LinearLayout implements OnCreateContex
     private AttachmentViewCallback attachmentCallback;
     private Map<AttachmentViewInfo, AttachmentView> attachmentViewMap = new HashMap<>();
     private Map<Uri, AttachmentViewInfo> attachments = new HashMap<>();
-    private boolean hasHiddenExternalImages;
+    private boolean hasHiddenExternalImages = false;
 
     private String currentHtmlText;
     private AttachmentResolver currentAttachmentResolver;
@@ -401,7 +401,8 @@ public class MessageContainerView extends LinearLayout implements OnCreateContex
     }
 
     public void displayMessageViewContainer(MessageViewInfo messageViewInfo,
-            final OnRenderingFinishedListener onRenderingFinishedListener, boolean loadPictures,
+            final boolean renderPlainFormat, final OnRenderingFinishedListener onRenderingFinishedListener,
+            boolean loadPictures,
             boolean hideUnsignedTextDivider, AttachmentViewCallback attachmentCallback) {
 
         this.attachmentCallback = attachmentCallback;
@@ -410,15 +411,22 @@ public class MessageContainerView extends LinearLayout implements OnCreateContex
 
         renderAttachments(messageViewInfo);
 
-        String textToDisplay = messageViewInfo.text;
-        if (textToDisplay != null && !isShowingPictures()) {
-            if (Utility.hasExternalImages(textToDisplay)) {
-                if (loadPictures) {
-                    setLoadPictures(true);
-                } else {
-                    hasHiddenExternalImages = true;
+        String textToDisplay;
+        hasHiddenExternalImages = false;
+        if (!renderPlainFormat) {
+            textToDisplay = messageViewInfo.text;
+
+            if (textToDisplay != null && !isShowingPictures()) {
+                if (Utility.hasExternalImages(textToDisplay)) {
+                    if (loadPictures) {
+                        setLoadPictures(true);
+                    } else {
+                        hasHiddenExternalImages = true;
+                    }
                 }
             }
+        } else {
+            textToDisplay = displayHtml.wrapMessageContent(messageViewInfo.textPlainFormatted);
         }
 
         if (textToDisplay == null) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -22,6 +22,7 @@ import android.widget.TextView;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.ShowPictures;
+import com.fsck.k9.K9;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.helper.Contacts;
@@ -54,7 +55,7 @@ public class MessageTopView extends LinearLayout {
     private Button showPicturesButton;
     private boolean isShowingProgress;
     private boolean showPicturesButtonClicked;
-    private boolean renderPlainFormat = false;
+    private boolean renderPlainFormat;
 
     private MessageCryptoPresenter messageCryptoPresenter;
 
@@ -81,6 +82,8 @@ public class MessageTopView extends LinearLayout {
         setShowPicturesButtonListener();
 
         containerView = findViewById(R.id.message_container);
+
+        renderPlainFormat = (K9.getPreferredContentType() == K9.PREF_CONT_TYPE.TEXT_PLAIN);
 
         hideHeaderView();
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -54,6 +54,7 @@ public class MessageTopView extends LinearLayout {
     private Button showPicturesButton;
     private boolean isShowingProgress;
     private boolean showPicturesButtonClicked;
+    private boolean renderPlainFormat = false;
 
     private MessageCryptoPresenter messageCryptoPresenter;
 
@@ -120,7 +121,7 @@ public class MessageTopView extends LinearLayout {
         containerView.addView(view);
 
         boolean hideUnsignedTextDivider = account.isOpenPgpHideSignOnly();
-        view.displayMessageViewContainer(messageViewInfo, new OnRenderingFinishedListener() {
+        view.displayMessageViewContainer(messageViewInfo, renderPlainFormat, new OnRenderingFinishedListener() {
             @Override
             public void onLoadFinished() {
                 displayViewOnLoadFinished(true);
@@ -129,6 +130,8 @@ public class MessageTopView extends LinearLayout {
 
         if (view.hasHiddenExternalImages() && !showPicturesButtonClicked) {
             showShowPicturesButton();
+        } else {
+            hideShowPicturesButton();
         }
     }
 
@@ -354,6 +357,14 @@ public class MessageTopView extends LinearLayout {
         if (messageContainerViewCandidate instanceof MessageContainerView) {
             ((MessageContainerView) messageContainerViewCandidate).refreshAttachmentThumbnail(attachment);
         }
+    }
+
+    public void setRenderPlainFormat(final boolean b) {
+        renderPlainFormat = b;
+    }
+
+    public boolean getRenderPlainFormat() {
+        return renderPlainFormat;
     }
 
     private static class SavedState extends BaseSavedState {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -764,6 +764,18 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         messageCryptoPresenter.onClickShowCryptoKey();
     }
 
+    public void asyncReloadMessage() {
+        messageLoaderHelper.asyncReloadMessage();
+    }
+
+    public void setRenderPlainFormat(final boolean b) {
+        mMessageView.setRenderPlainFormat(b);
+    }
+
+    public boolean getRenderPlainFormat() {
+        return mMessageView.getRenderPlainFormat();
+    }
+
     public interface MessageViewFragmentListener {
         void onForward(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);
         void onForwardAsAttachment(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -99,6 +99,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private MessageLoaderHelper messageLoaderHelper;
     private MessageCryptoPresenter messageCryptoPresenter;
     private Long showProgressThreshold;
+    MessageViewInfo mMessageViewInfo;
     private UnsubscribeUri preferredUnsubscribeUri;
 
     /**
@@ -301,6 +302,18 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         } else {
             delete();
         }
+    }
+
+    public void onDisplayPlainText() {
+        mMessageView.setRenderPlainFormat(true);
+        showMessage(mMessageViewInfo);
+        mFragmentListener.updateMenu();
+    }
+
+    public void onDisplayHTML() {
+        mMessageView.setRenderPlainFormat(false);
+        showMessage(mMessageViewInfo);
+        mFragmentListener.updateMenu();
     }
 
     private void delete() {
@@ -764,15 +777,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         messageCryptoPresenter.onClickShowCryptoKey();
     }
 
-    public void asyncReloadMessage() {
-        messageLoaderHelper.asyncReloadMessage();
-    }
 
-    public void setRenderPlainFormat(final boolean b) {
-        mMessageView.setRenderPlainFormat(b);
-    }
-
-    public boolean getRenderPlainFormat() {
+    public boolean isRenderPlainFormat() {
         return mMessageView.getRenderPlainFormat();
     }
 
@@ -811,6 +817,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         @Override
         public void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo) {
+            mMessageViewInfo = messageViewInfo;
             showMessage(messageViewInfo);
             preferredUnsubscribeUri = messageViewInfo.preferredUnsubscribeUri;
             showProgressThreshold = null;

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -105,6 +105,7 @@ class GeneralSettingsDataStore(
             "notification_quick_delete" -> K9.notificationQuickDeleteBehaviour.name
             "lock_screen_notification_visibility" -> K9.lockScreenNotificationVisibility.name
             "background_ops" -> K9.backgroundOps.name
+            "messageview_preferred_content_type" -> K9.preferredContentType.name
             "quiet_time_starts" -> K9.quietTimeStarts
             "quiet_time_ends" -> K9.quietTimeEnds
             "account_name_font" -> K9.fontSizes.accountName.toString()
@@ -144,6 +145,7 @@ class GeneralSettingsDataStore(
                 K9.lockScreenNotificationVisibility = K9.LockScreenNotificationVisibility.valueOf(value)
             }
             "background_ops" -> setBackgroundOps(value)
+            "messageview_preferred_content_type" -> setContentType(value)
             "quiet_time_starts" -> K9.quietTimeStarts = value
             "quiet_time_ends" -> K9.quietTimeEnds = value
             "account_name_font" -> K9.fontSizes.accountName = value.toInt()
@@ -286,6 +288,13 @@ class GeneralSettingsDataStore(
         if (newBackgroundOps != K9.backgroundOps) {
             K9.backgroundOps = newBackgroundOps
             jobManager.scheduleAllMailJobs()
+        }
+    }
+
+    private fun setContentType(value: String) {
+        val newContentType = K9.PREF_CONT_TYPE.valueOf(value)
+        if (newContentType != K9.preferredContentType) {
+            K9.preferredContentType = newContentType
         }
     }
 }

--- a/app/ui/legacy/src/main/res/menu/message_list_option.xml
+++ b/app/ui/legacy/src/main/res/menu/message_list_option.xml
@@ -155,6 +155,18 @@
           app:showAsAction="never"
           android:title="@string/show_headers_action"/>
 
+    <item
+        android:id="@+id/set_format_html"
+        android:title="@string/set_format_html_action"
+        android:titleCondensed="@string/set_format_html_condensed_action"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/set_format_plain"
+        android:title="@string/set_format_plain_action"
+        android:titleCondensed="@string/set_format_plain_condensed_action"
+        app:showAsAction="never" />
+
     <!-- always -->
     <item
         android:id="@+id/compose"

--- a/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -156,6 +156,11 @@
         <item>@string/spam_action</item>
     </string-array>
 
+    <string-array name="messageview_preferred_content_type_entries">
+        <item>@string/global_settings_messageview_preferred_content_type_text_html</item>
+        <item>@string/global_settings_messageview_preferred_content_type_text_plain</item>
+    </string-array>
+
     <string-array name="volume_navigation_entries">
         <item>@string/volume_navigation_message</item>
         <item>@string/volume_navigation_list</item>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -141,6 +141,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="copy_action">Copy</string>
     <string name="unsubscribe_action">Unsubscribe</string>
     <string name="show_headers_action">Show headers</string>
+    <string name="set_format_html_action">Use original formatting</string>
+    <string name="set_format_html_condensed_action">Show formatted</string>
+    <string name="set_format_plain_action">Show unformatted message</string>
+    <string name="set_format_plain_condensed_action">Show unformatted</string>
     <plurals name="copy_address_to_clipboard">
         <item quantity="one">Address copied to clipboard</item>
         <item quantity="other">Addresses copied to clipboard</item>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -298,6 +298,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_messageview_fixedwidth_summary">Use a fixed-width font when showing plain-text messages</string>
     <string name="global_settings_messageview_autofit_width_label">Auto-fit messages</string>
     <string name="global_settings_messageview_autofit_width_summary">Shrink messages to fit the screen</string>
+    <string name="global_settings_messageview_preferred_content_type_title">Preferred Content-Type</string>
+    <string name="global_settings_messageview_preferred_content_type_text_html">HTML (text/html)</string>
+    <string name="global_settings_messageview_preferred_content_type_text_plain">Plain text (text/plain)</string>
+
     <string name="global_settings_messageview_return_to_list_label">Return to list after delete</string>
     <string name="global_settings_messageview_return_to_list_summary">Return to message list after message deletion</string>
     <string name="global_settings_messageview_show_next_label">Show next message after delete</string>

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -348,6 +348,13 @@
                 android:summary="@string/global_settings_messageview_autofit_width_summary"
                 android:title="@string/global_settings_messageview_autofit_width_label" />
 
+            <ListPreference
+                android:dialogTitle="@string/global_settings_messageview_preferred_content_type_title"
+                android:entries="@array/messageview_preferred_content_type_entries"
+                android:entryValues="@array/messageview_preferred_content_type_values"
+                android:key="messageview_preferred_content_type"
+                app:useSimpleSummaryProvider="true"
+                android:title="@string/global_settings_messageview_preferred_content_type_title" />
         </PreferenceCategory>
 
     </PreferenceScreen>


### PR DESCRIPTION
This PR follows https://github.com/k9mail/k-9/pull/3936 which has not been updated for a while.

It:
- contains the same changes except I fixed it to work with current code
- adds a setting to choose the default content-type.

With them, the user can:
- set the default way to display messages (either plain text or HTML)
- on a "per demand" basis switch from one to another for the currently displayed message.

Related feature requests: https://github.com/k9mail/k-9/issues/906 https://github.com/k9mail/k-9/issues/1397

In case you or anyone is interested, the PR is also available for 5.8 in this branch https://github.com/tenzap/k-9/tree/f/5.8-MAINT/plain_text

Screenshot for the setting is below, other screenshots for per-message basis are in the original PR #3936
![Screenshot_1631201917_256p](https://user-images.githubusercontent.com/46226844/132722259-b0010d62-5ff6-4e51-ac7f-7f013b5c5c8f.png)
