### PR TITLE
Add OAuth support for Microsoft accounts

### DIFF
--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -96,22 +96,6 @@
         <incoming uri="imap+ssl+://imap.comcast.net" username="$email" />
         <outgoing uri="smtp+tls+://smtp.comcast.net" username="$email" />
     </provider>
-    <provider id="live" label="Windows Live Hotmail" domain="live.com">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
-    <provider id="hotmail" label="Hotmail" domain="hotmail.com">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
-    <provider id="outlook" label="Outlook.com" domain="outlook.com">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
-    <provider id="msn" label="MSN" domain="msn.com">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
     <provider id="montclair.edu" label="MSU" domain="montclair.edu">
         <incoming uri="imap+ssl+://mail.montclair.edu" username="$user" />
         <outgoing uri="smtp+tls+://smtp.montclair.edu" username="$user" />
@@ -253,15 +237,6 @@
         <outgoing uri="smtp+ssl+://mail.messagingengine.com" username="$email" />
     </provider>
 
-   <!-- UK -->
-    <provider id="live-uk" label="Windows Live Hotmail" domain="live.co.uk">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
-    <provider id="hotmail-uk" label="Hotmail" domain="hotmail.co.uk">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
     <!-- Virgin Media variants -->
     <provider id="virginmedia.com" label="Virgin Media" domain="virginmedia.com">
         <incoming uri="imap+ssl+://imap.virginmedia.com" username="$email" />
@@ -644,11 +619,7 @@
         <incoming uri="imap+ssl+://imap.azet.sk" username="$email" />
         <outgoing uri="smtp+ssl+://smtp.azet.sk" username="$email" />
     </provider>
-    <provider id="outlook.sk" label="Outlook.sk" domain="outlook.sk">
-        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
-        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
-    </provider>
-    
+
     <!-- The Netherlands -->
     <!-- Ziggo variants -->
     <provider id="casema.nl" label="Ziggo" domain="casema.nl">
@@ -769,4 +740,35 @@
         <incoming uri="imap+ssl+://imap.aol.com" username="$email" />
         <outgoing uri="smtp+ssl+://smtp.aol.com" username="$email" />
     </provider>
+
+    <!-- Microsoft variants -->
+    <provider domain="outlook.com">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="hotmail.com">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="msn.com">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="live.com">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="live.co.uk">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="hotmail.co.uk">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+    <provider domain="outlook.sk">
+        <incoming uri="imap+ssl+://outlook.office365.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.office365.com" username="$email" />
+    </provider>
+
 </providers>

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -85,6 +85,8 @@ android {
             buildConfigField "String", "OAUTH_GMAIL_CLIENT_ID", "\"262622259280-hhmh92rhklkg2k1tjil69epo0o9a12jm.apps.googleusercontent.com\""
             buildConfigField "String", "OAUTH_YAHOO_CLIENT_ID", "\"dj0yJmk9aHNUb3d2MW5TQnpRJmQ9WVdrOWVYbHpaRWM0YkdnbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PWIz\""
             buildConfigField "String", "OAUTH_AOL_CLIENT_ID", "\"dj0yJmk9dUNqYXZhYWxOYkdRJmQ9WVdrOU1YQnZVRFZoY1ZrbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PWIw\""
+            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"62b5988d-b86f-48e1-aba4-5e71d36c5b6a\""
+            buildConfigField "String", "OAUTH_MICROSOFT_REDIRECT_URI", "\"msauth://com.fsck.k9/Dx8yUsuhyU3dYYba1aA16Wxu5eM%3D\""
 
             manifestPlaceholders = ['appAuthRedirectScheme': 'com.fsck.k9']
         }
@@ -100,6 +102,8 @@ android {
             buildConfigField "String", "OAUTH_GMAIL_CLIENT_ID", "\"262622259280-5qb3vtj68d5dtudmaif4g9vd3cpar8r3.apps.googleusercontent.com\""
             buildConfigField "String", "OAUTH_YAHOO_CLIENT_ID", "\"dj0yJmk9ejRCRU1ybmZjQlVBJmQ9WVdrOVVrZEViak4xYmxZbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTZj\""
             buildConfigField "String", "OAUTH_AOL_CLIENT_ID", "\"dj0yJmk9cHYydkJkTUxHcXlYJmQ9WVdrOWVHZHhVVXN4VVV3bWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTdm\""
+            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"62b5988d-b86f-48e1-aba4-5e71d36c5b6a\""
+            buildConfigField "String", "OAUTH_MICROSOFT_REDIRECT_URI", "\"msauth://com.fsck.k9.debug/VZF2DYuLYAu4TurFd6usQB2JPts%3D\""
 
             manifestPlaceholders = ['appAuthRedirectScheme': 'com.fsck.k9.debug']
         }

--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -428,5 +428,20 @@
                 android:resource="@xml/temp_file_provider_paths" />
         </provider>
 
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Microsoft uses a special redirect URI format for Android apps -->
+                <data android:scheme="msauth" android:host="${applicationId}"/>
+            </intent-filter>
+        </activity>
+
     </application>
 </manifest>

--- a/app/k9mail/src/main/java/com/fsck/k9/auth/OAuthConfigurations.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/auth/OAuthConfigurations.kt
@@ -33,6 +33,13 @@ fun createOAuthConfigurationProvider(): OAuthConfigurationProvider {
                 tokenEndpoint = "https://api.login.aol.com/oauth2/get_token",
                 redirectUri = redirectUriDoubleSlash
             ),
+            listOf("outlook.office365.com", "smtp.office365.com") to OAuthConfiguration(
+                clientId = BuildConfig.OAUTH_MICROSOFT_CLIENT_ID,
+                scopes = listOf("https://outlook.office.com/IMAP.AccessAsUser.All", "https://outlook.office.com/SMTP.Send", "offline_access"),
+                authorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+                tokenEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+                redirectUri = BuildConfig.OAUTH_MICROSOFT_REDIRECT_URI
+            ),
         ),
         googleConfiguration = googleConfig
     )


### PR DESCRIPTION
This should work for both personal (Outlook, Hotmail, etc) and Office365 accounts. Currently we aren't verified by Microsoft yet. So Office365 users won't be able to grant access to K-9 Mail yet.

Replaces #6094
Closes #1753