### PR TITLE
Display "authentication failed" notification when OAuth sign-in is required

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -8,6 +8,7 @@ import com.fsck.k9.Account
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.mail.AuthType
 import timber.log.Timber
 
 class MailSyncWorker(
@@ -41,6 +42,11 @@ class MailSyncWorker(
 
         if (account.incomingServerSettings.isMissingCredentials) {
             Timber.d("Password for this account is missing. Skipping mail sync.")
+            return Result.success()
+        }
+
+        if (account.incomingServerSettings.authenticationType == AuthType.XOAUTH2 && account.oAuthState == null) {
+            Timber.d("Account requires sign-in. Skipping mail sync.")
             return Result.success()
         }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
@@ -42,7 +42,10 @@ class RealOAuth2TokenProvider(
 
         latch.await(timeoutMillis, TimeUnit.MILLISECONDS)
 
-        if (exception != null || token != oldAccessToken) {
+        if (exception != null) {
+            account.oAuthState = null
+            accountManager.saveAccount(account)
+        } else if (token != oldAccessToken) {
             requestFreshToken = false
             account.oAuthState = authState.jsonSerializeString()
             accountManager.saveAccount(account)


### PR DESCRIPTION
Treat missing authorization (OAuth) like a missing password.