### PR TITLE
Close ActionMode when rotating to portrait while a message has opened…

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -436,6 +436,11 @@ class MessageListFragment :
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
+        if (K9.splitViewMode == K9.SplitViewMode.WHEN_IN_LANDSCAPE)
+            activeMessage?.let {
+                actionMode?.finish()
+            }
+
         saveListState(outState)
         outState.putLongArray(STATE_SELECTED_MESSAGES, selected.toLongArray())
         outState.putBoolean(STATE_REMOTE_SEARCH_PERFORMED, isRemoteSearch)


### PR DESCRIPTION
Fixes #6141
I CLosed ActionMode when we had opened a message in landscape split view mode and then rotated the device to portrait.
In this situation, we see opened message and its toolbar.
We don't do this when the user sets Show Split View to Always. Because in that case, the user sees the list in portrait too. So we shouldn't close ActionMode or unselect list items.