### PR TITLE
Fix action mode when switching from split view to message view

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -338,6 +338,7 @@ open class MessageList :
             }
             DisplayMode.SPLIT_VIEW -> {
                 messageListWasDisplayed = true
+                messageListFragment?.onListVisible()
                 if (messageViewFragment == null) {
                     showMessageViewPlaceHolder()
                 } else {
@@ -1469,6 +1470,7 @@ open class MessageList :
         displayMode = DisplayMode.MESSAGE_LIST
         viewSwitcher!!.showFirstView()
 
+        messageListFragment!!.onListVisible()
         messageListFragment!!.setActiveMessage(null)
 
         setDrawerLockState()
@@ -1491,6 +1493,7 @@ open class MessageList :
 
     private fun showMessageView() {
         displayMode = DisplayMode.MESSAGE_VIEW
+        messageListFragment?.onListHidden()
 
         if (!messageListWasDisplayed) {
             viewSwitcher!!.animateFirstView = false

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -133,6 +133,8 @@ class MessageListFragment :
     var isInitialized = false
         private set
 
+    private var isListVisible = false
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
@@ -1508,8 +1510,11 @@ class MessageListFragment :
     }
 
     private fun resetActionMode() {
-        if (selected.isEmpty()) {
+        if (!isResumed) return
+
+        if (!isListVisible || selected.isEmpty()) {
             actionMode?.finish()
+            actionMode = null
             return
         }
 
@@ -1573,6 +1578,16 @@ class MessageListFragment :
         if (isMarkAllAsReadSupported) {
             messagingController.markAllMessagesRead(account, currentFolder!!.databaseId)
         }
+    }
+
+    fun onListVisible() {
+        isListVisible = true
+        resetActionMode()
+    }
+
+    fun onListHidden() {
+        isListVisible = false
+        resetActionMode()
     }
 
     val isCheckMailSupported: Boolean


### PR DESCRIPTION
This hides the contextual action bar when only the message view is displayed. However, selected messages are remembered and the contextual action bar will be restored when the message list is displayed (either in split view mode or when returning from the message view to the message list screen).

This behavior will be useful once we add support for 
- #3555

Fixes #6141