### PR TITLE
Change the OAuth client ID used for Microsoft accounts

### DIFF
--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -79,7 +79,7 @@ android {
             buildConfigField "String", "OAUTH_GMAIL_CLIENT_ID", "\"262622259280-hhmh92rhklkg2k1tjil69epo0o9a12jm.apps.googleusercontent.com\""
             buildConfigField "String", "OAUTH_YAHOO_CLIENT_ID", "\"dj0yJmk9aHNUb3d2MW5TQnpRJmQ9WVdrOWVYbHpaRWM0YkdnbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PWIz\""
             buildConfigField "String", "OAUTH_AOL_CLIENT_ID", "\"dj0yJmk9dUNqYXZhYWxOYkdRJmQ9WVdrOU1YQnZVRFZoY1ZrbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PWIw\""
-            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"62b5988d-b86f-48e1-aba4-5e71d36c5b6a\""
+            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"e647013a-ada4-4114-b419-e43d250f99c5\""
             buildConfigField "String", "OAUTH_MICROSOFT_REDIRECT_URI", "\"msauth://com.fsck.k9/Dx8yUsuhyU3dYYba1aA16Wxu5eM%3D\""
 
             manifestPlaceholders = ['appAuthRedirectScheme': 'com.fsck.k9']
@@ -94,7 +94,7 @@ android {
             buildConfigField "String", "OAUTH_GMAIL_CLIENT_ID", "\"262622259280-5qb3vtj68d5dtudmaif4g9vd3cpar8r3.apps.googleusercontent.com\""
             buildConfigField "String", "OAUTH_YAHOO_CLIENT_ID", "\"dj0yJmk9ejRCRU1ybmZjQlVBJmQ9WVdrOVVrZEViak4xYmxZbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTZj\""
             buildConfigField "String", "OAUTH_AOL_CLIENT_ID", "\"dj0yJmk9cHYydkJkTUxHcXlYJmQ9WVdrOWVHZHhVVXN4VVV3bWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTdm\""
-            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"62b5988d-b86f-48e1-aba4-5e71d36c5b6a\""
+            buildConfigField "String", "OAUTH_MICROSOFT_CLIENT_ID", "\"e647013a-ada4-4114-b419-e43d250f99c5\""
             buildConfigField "String", "OAUTH_MICROSOFT_REDIRECT_URI", "\"msauth://com.fsck.k9.debug/VZF2DYuLYAu4TurFd6usQB2JPts%3D\""
 
             manifestPlaceholders = ['appAuthRedirectScheme': 'com.fsck.k9.debug']


### PR DESCRIPTION
New client ID because things are complicated with Microsoft. This client ID belongs to a "verified publisher". So users should be able to use OAuth 2.0 with Office365 accounts.

@blino: Can you please check if this works with an Office365 account? I currently don't have access to a working test account.