### PR TITLE
Display an error notification when creating a notification fails

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -18,7 +18,9 @@ val coreNotificationModule = module {
         )
     }
     single { NotificationManagerCompat.from(get()) }
-    single { NotificationHelper(context = get(), notificationManager = get(), channelUtils = get()) }
+    single {
+        NotificationHelper(context = get(), notificationManager = get(), notificationChannelManager = get(), resourceProvider = get())
+    }
     single {
         NotificationChannelManager(
             preferences = get(),
@@ -82,8 +84,7 @@ val coreNotificationModule = module {
             notificationHelper = get(),
             actionCreator = get(),
             resourceProvider = get(),
-            lockScreenNotificationCreator = get(),
-            notificationManager = get()
+            lockScreenNotificationCreator = get()
         )
     }
     factory {
@@ -92,8 +93,7 @@ val coreNotificationModule = module {
             actionCreator = get(),
             lockScreenNotificationCreator = get(),
             singleMessageNotificationCreator = get(),
-            resourceProvider = get(),
-            notificationManager = get()
+            resourceProvider = get()
         )
     }
     factory { LockScreenNotificationCreator(notificationHelper = get(), resourceProvider = get()) }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
@@ -1,17 +1,25 @@
 package com.fsck.k9.notification
 
+import android.app.Notification
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
 import com.fsck.k9.K9
+import com.fsck.k9.helper.PendingIntentCompat
+import com.fsck.k9.notification.NotificationChannelManager.ChannelType
+import timber.log.Timber
 
 class NotificationHelper(
     private val context: Context,
     private val notificationManager: NotificationManagerCompat,
-    private val channelUtils: NotificationChannelManager
+    private val notificationChannelManager: NotificationChannelManager,
+    private val resourceProvider: NotificationResourceProvider
 ) {
     fun getContext(): Context {
         return context
@@ -21,14 +29,59 @@ class NotificationHelper(
         return notificationManager
     }
 
-    fun createNotificationBuilder(
-        account: Account,
-        channelType: NotificationChannelManager.ChannelType
-    ): NotificationCompat.Builder {
-        return NotificationCompat.Builder(
-            context,
-            channelUtils.getChannelIdFor(account, channelType)
-        )
+    fun createNotificationBuilder(account: Account, channelType: ChannelType): NotificationCompat.Builder {
+        val notificationChannel = notificationChannelManager.getChannelIdFor(account, channelType)
+        return NotificationCompat.Builder(context, notificationChannel)
+    }
+
+    fun notify(account: Account, notificationId: Int, notification: Notification) {
+        try {
+            notificationManager.notify(notificationId, notification)
+        } catch (e: SecurityException) {
+            // When importing settings from another device, we could end up with a NotificationChannel that references a
+            // non-existing notification sound. In that case, we end up with a SecurityException with a message similar
+            // to this:
+            // UID 123 does not have permission to content://media/external_primary/audio/media/42?title=Coins&canonical=1 [user 0]
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                e.message?.contains("does not have permission to") == true
+            ) {
+                Timber.e(e, "Failed to create a notification for a new message")
+                showNotifyErrorNotification(account)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun showNotifyErrorNotification(account: Account) {
+        val title = resourceProvider.notifyErrorTitle()
+        val text = resourceProvider.notifyErrorText()
+
+        val messagesNotificationChannelId = notificationChannelManager.getChannelIdFor(account, ChannelType.MESSAGES)
+        val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_CHANNEL_ID, messagesNotificationChannelId)
+            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        }
+
+        val notificationSettingsPendingIntent =
+            PendingIntent.getActivity(context, account.accountNumber, intent, PendingIntentCompat.FLAG_IMMUTABLE)
+
+        val notification = createNotificationBuilder(account, ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconWarning)
+            .setColor(account.chipColor)
+            .setWhen(System.currentTimeMillis())
+            .setAutoCancel(true)
+            .setTicker(title)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setContentIntent(notificationSettingsPendingIntent)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .setErrorAppearance()
+            .build()
+
+        val notificationId = NotificationIds.getNewMailSummaryNotificationId(account)
+        notificationManager.notify(notificationId, notification)
     }
 
     companion object {

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
@@ -24,6 +24,9 @@ interface NotificationResourceProvider {
     fun authenticationErrorTitle(): String
     fun authenticationErrorBody(accountName: String): String
 
+    fun notifyErrorTitle(): String
+    fun notifyErrorText(): String
+
     fun certificateErrorTitle(): String
     fun certificateErrorTitle(accountName: String): String
     fun certificateErrorBody(): String

--- a/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
-import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
 import timber.log.Timber
 import androidx.core.app.NotificationCompat.Builder as NotificationBuilder
@@ -12,8 +11,7 @@ internal class SingleMessageNotificationCreator(
     private val notificationHelper: NotificationHelper,
     private val actionCreator: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
-    private val lockScreenNotificationCreator: LockScreenNotificationCreator,
-    private val notificationManager: NotificationManagerCompat
+    private val lockScreenNotificationCreator: LockScreenNotificationCreator
 ) {
     fun createSingleNotification(
         baseNotificationData: BaseNotificationData,
@@ -52,7 +50,7 @@ internal class SingleMessageNotificationCreator(
                 notification
             )
         }
-        notificationManager.notify(notificationId, notification)
+        notificationHelper.notify(account, notificationId, notification)
     }
 
     private fun NotificationBuilder.setBigText(text: CharSequence) = apply {

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
-import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
 import com.fsck.k9.notification.NotificationIds.getNewMailSummaryNotificationId
@@ -15,8 +14,7 @@ internal class SummaryNotificationCreator(
     private val actionCreator: NotificationActionCreator,
     private val lockScreenNotificationCreator: LockScreenNotificationCreator,
     private val singleMessageNotificationCreator: SingleMessageNotificationCreator,
-    private val resourceProvider: NotificationResourceProvider,
-    private val notificationManager: NotificationManagerCompat
+    private val resourceProvider: NotificationResourceProvider
 ) {
     fun createSummaryNotification(
         baseNotificationData: BaseNotificationData,
@@ -75,7 +73,7 @@ internal class SummaryNotificationCreator(
             .build()
 
         Timber.v("Creating inbox-style summary notification (silent=%b): %s", notificationData.isSilent, notification)
-        notificationManager.notify(notificationData.notificationId, notification)
+        notificationHelper.notify(account, notificationData.notificationId, notification)
     }
 
     private fun buildInboxSummaryText(accountName: String, notificationData: SummaryInboxNotificationData): String {

--- a/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
@@ -26,6 +26,15 @@ class TestNotificationResourceProvider : NotificationResourceProvider {
     override fun authenticationErrorBody(accountName: String): String =
         "Authentication failed for $accountName. Update your server settings."
 
+    override fun notifyErrorTitle(): String = "Notification error"
+
+    override fun notifyErrorText(): String {
+        return "An error has occurred while trying to create a system notification for a new message. " +
+            "The reason is most likely a missing notification sound.\n" +
+            "\n" +
+            "Tap to open notification settings."
+    }
+
     override fun certificateErrorTitle(): String = "Certificate error"
 
     override fun certificateErrorTitle(accountName: String): String = "Certificate error for $accountName"

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -36,6 +36,10 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun authenticationErrorBody(accountName: String): String =
         context.getString(R.string.notification_authentication_error_text, accountName)
 
+    override fun notifyErrorTitle(): String = context.getString(R.string.notification_notify_error_title)
+
+    override fun notifyErrorText(): String = context.getString(R.string.notification_notify_error_text)
+
     override fun certificateErrorTitle(): String = context.getString(R.string.notification_certificate_error_public)
 
     override fun certificateErrorTitle(accountName: String): String =

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -200,6 +200,11 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="notification_authentication_error_title">Authentication failed</string>
     <string name="notification_authentication_error_text">Authentication failed for <xliff:g id="account">%s</xliff:g>. Update your server settings.</string>
 
+    <!-- Title of an error notification that is displayed when creating a notification for a new message has failed -->
+    <string name="notification_notify_error_title">Notification error</string>
+    <!-- Body of an error notification that is displayed when creating a notification for a new message has failed -->
+    <string name="notification_notify_error_text">An error has occurred while trying to create a system notification for a new message. The reason is most likely a missing notification sound.\n\nTap to open notification settings.</string>
+
     <string name="notification_bg_sync_ticker">Checking mail: <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g></string>
     <string name="notification_bg_sync_title">Checking mail</string>
     <string name="notification_bg_send_ticker">Sending mail: <xliff:g id="account">%s</xliff:g></string>


### PR DESCRIPTION
When importing settings from another device, we could end up with a notification channel that references a non-existing notification sound. In that case creating a notification for a new message will lead to a `SecurityException`. We catch this case and display an error notification instead. This is fine because we create the "Miscellaneous" notification channel without a notification sound. And if the user configured a notification sound that is later no longer available/accessible, the framework doesn't throw. See [NotificationRecord.java](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/notification/NotificationRecord.java;l=1364;drc=4e3be6801933f38c64aea1bcdb7906488380ad21).

<img src="https://user-images.githubusercontent.com/218061/178308622-82389c18-edb4-4778-afa1-6398260644f2.png" alt="image" width=300>

Fixes #6009