### PR TITLE
Another attempt at fixing the ghost message list

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -23,6 +23,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout.DrawerListener
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
 import androidx.lifecycle.Observer
 import com.fsck.k9.Account
 import com.fsck.k9.Account.SortType
@@ -1307,14 +1308,16 @@ open class MessageList :
     }
 
     private fun addMessageListFragment(fragment: MessageListFragment) {
-        val fragmentTransaction = supportFragmentManager.beginTransaction()
+        supportFragmentManager.commit {
+            replace(R.id.message_list_container, fragment)
 
-        fragmentTransaction.replace(R.id.message_list_container, fragment)
-        fragmentTransaction.setReorderingAllowed(true)
-        if (supportFragmentManager.backStackEntryCount == 0) {
-            fragmentTransaction.addToBackStack(FIRST_FRAGMENT_TRANSACTION)
-        } else {
-            fragmentTransaction.addToBackStack(null)
+            setReorderingAllowed(true)
+
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                addToBackStack(FIRST_FRAGMENT_TRANSACTION)
+            } else {
+                addToBackStack(null)
+            }
         }
 
         messageListFragment = fragment
@@ -1322,8 +1325,6 @@ open class MessageList :
         if (isDrawerEnabled) {
             lockDrawer()
         }
-
-        fragmentTransaction.commit()
     }
 
     override fun startSearch(query: String, account: Account?, folderId: Long?): Boolean {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1311,13 +1311,11 @@ open class MessageList :
         configureMenu(menu)
     }
 
-    private fun addMessageListFragment(fragment: MessageListFragment, addToBackStack: Boolean) {
+    private fun addMessageListFragment(fragment: MessageListFragment) {
         val fragmentTransaction = supportFragmentManager.beginTransaction()
 
         fragmentTransaction.replace(R.id.message_list_container, fragment)
-        if (addToBackStack) {
-            fragmentTransaction.addToBackStack(null)
-        }
+        fragmentTransaction.addToBackStack(null)
 
         messageListFragment = fragment
 
@@ -1364,7 +1362,7 @@ open class MessageList :
         initializeFromLocalSearch(tmpSearch)
 
         val fragment = MessageListFragment.newInstance(tmpSearch, true, false)
-        addMessageListFragment(fragment, true)
+        addMessageListFragment(fragment)
     }
 
     private fun showMessageViewPlaceHolder() {


### PR DESCRIPTION
We never updated/cleared `firstBackStackId` when the user manually popped the initial transaction. This new approach should be less prone to errors.

Fixes #4452