### PR TITLE
Show small line next to attachment button

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_view_attachment.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_attachment.xml
@@ -16,7 +16,7 @@
         android:orientation="vertical"
         android:foreground="?attr/selectableItemBackground"
         app:cardBackgroundColor="?attr/attachmentCardBackground"
-        app:cardCornerRadius="2dp"
+        app:cardCornerRadius="4dp"
         app:cardElevation="1dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -82,18 +82,25 @@
                 app:layout_constraintVertical_bias="0.0"
                 tools:text="99 KB" />
 
+            <View
+                android:layout_width="2dp"
+                android:layout_height="0dp"
+                android:background="?attr/messageViewBackgroundColor"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/save_button"
+                app:layout_constraintTop_toTopOf="parent" />
+
             <ImageButton
                 android:id="@+id/save_button"
                 android:layout_width="42dp"
-                android:layout_height="42dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:layout_height="0dp"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackground"
                 android:contentDescription="@string/remove_attachment_action"
                 app:srcCompat="?attr/iconActionSaveAttachment"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/attachment_preview" />
+                app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Apparently, people have difficulties with the attachment box. This adds a small line to separate the two buttons. While I was at it, I changed the corners to be a bit more round.

https://forum.k9mail.app/t/default-folder-for-attachments/3931
https://forum.k9mail.app/t/concerning-attachments-embedded-media/359

Before:
<img width="300" src="https://user-images.githubusercontent.com/5811634/179372089-5be0302d-8e73-4251-a2c2-21099b8d6d72.png" />

After:
<img width="300" src="https://user-images.githubusercontent.com/5811634/179372095-cb647363-8a36-41d1-80dc-b376468db629.png" />
