### PR TITLE
Update GitHub URLs to new location

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ submitting a new issue.
 
 * The issue tracker is solely for bug reports and feature/enhancement requests. If you have a question of any kind,
 please use the [support forum](https://forum.k9mail.app/c/support) instead.
-* Search the [existing issues](https://github.com/k9mail/k-9/issues?q=) first to make sure your issue hasn't been
+* Search the [existing issues](https://github.com/thundernest/k-9/issues?q=) first to make sure your issue hasn't been
 reported before.
 
 
@@ -22,8 +22,8 @@ We're using [Transifex](https://www.transifex.com/k-9/k9mail/) to manage transla
 
 ## Contributing code
 
-We love [pull requests](https://github.com/k9mail/k-9/pulls) from everyone!
+We love [pull requests](https://github.com/thundernest/k-9/pulls) from everyone!
 
 Any contributions, large or small, major features, bug fixes, unit/integration tests are welcomed and appreciated
 but will be thoroughly reviewed and discussed.
-Please make sure you read the [Code Style Guidelines](https://github.com/k9mail/k-9/wiki/CodeStyle).
+Please make sure you read the [Code Style Guidelines](https://github.com/thundernest/k-9/wiki/CodeStyle).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,6 +72,6 @@ body:
     attributes:
       label: Logs
       description: |
-        Please take some time to [retrieve logs](https://github.com/k9mail/k-9/wiki/LoggingErrors) and attach them here.
+        Please take some time to [retrieve logs](https://github.com/thundernest/k-9/wiki/LoggingErrors) and attach them here.
 
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.kt
@@ -388,7 +388,7 @@ class AccountSetupCheckSettings : K9Activity(), ConfirmationDialogFragmentListen
 
     /**
      * FIXME: Don't use an AsyncTask to perform network operations.
-     * See also discussion in https://github.com/k9mail/k-9/pull/560
+     * See also discussion in https://github.com/thundernest/k-9/pull/560
      */
     private inner class CheckAccountTask(private val account: Account) : AsyncTask<CheckDirection, Int, Unit>() {
         override fun doInBackground(vararg params: CheckDirection) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -619,7 +619,7 @@ public class MessageCryptoHelper {
 
     private void onCryptoOperationCanceled() {
         // there are weird states that get us here when we're not actually processing any part. just skip in that case
-        // see https://github.com/k9mail/k-9/issues/1878
+        // see https://github.com/thundernest/k-9/issues/1878
         if (currentCryptoPart != null) {
             CryptoResultAnnotation errorPart = CryptoResultAnnotation.createOpenPgpCanceledAnnotation();
             addCryptoResultAnnotationToMessage(errorPart);

--- a/app/ui/legacy/src/main/res/values/constants.xml
+++ b/app/ui/legacy/src/main/res/values/constants.xml
@@ -4,8 +4,8 @@
     <string name="user_manual_url" translatable="false">https://docs.k9mail.app/</string>
     <string name="user_forum_url" translatable="false">https://forum.k9mail.app/</string>
     <string name="message_header_mua" translatable="false">K-9 Mail for Android</string>
-    <string name="app_authors_url" translatable="false">https://github.com/k9mail/k-9/graphs/contributors</string>
-    <string name="app_source_url" translatable="false">https://github.com/k9mail/k-9</string>
+    <string name="app_authors_url" translatable="false">https://github.com/thundernest/k-9/graphs/contributors</string>
+    <string name="app_source_url" translatable="false">https://github.com/thundernest/k-9</string>
     <string name="app_license_url" translatable="false">https://www.apache.org/licenses/LICENSE-2.0</string>
     <string name="fediverse_handle" translatable="false">\@k9mail@fosstodon.org</string>
     <string name="fediverse_url" translatable="false">https://fosstodon.org/@k9mail</string>

--- a/docs/google-play/full_description.txt
+++ b/docs/google-play/full_description.txt
@@ -4,10 +4,10 @@ K-9 supports IMAP, POP3 and Exchange 2003/2007 (with WebDAV).
 
 Install the app "OpenKeychain: Easy PGP" to encrypt/decrypt your emails using OpenPGP.
 
-K-9 is a community developed project.  If you're interested in helping to make the most popular open source email client on Android even better, please join us!  You can find our bug tracker, source code, mailing list and wiki at https://github.com/k9mail/k-9
+K-9 is a community developed project.  If you're interested in helping to make the most popular open source email client on Android even better, please join us!  You can find our bug tracker, source code, mailing list and wiki at https://github.com/thundernest/k-9
 We're always happy to welcome new developers, designers, documenters, bug triagers and friends. 
 
-If you're having trouble with K-9, please report a bug at https://github.com/k9mail/k-9 rather than just leaving a one-star review. We don't mind you telling the world that you're frustrated, but if you use our bug tracker, we have a better chance of fixing whatever's giving you a hard time.
+If you're having trouble with K-9, please report a bug at https://github.com/thundernest/k-9 rather than just leaving a one-star review. We don't mind you telling the world that you're frustrated, but if you use our bug tracker, we have a better chance of fixing whatever's giving you a hard time.
 
 You can find K-9's release notes at: https://bit.ly/new-k9
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -20,5 +20,5 @@ If you're having trouble with K-9 Mail, ask for help in our <a href="https://for
 <b>Want to help?</b>
 
 K-9 Mail is a community developed project. If you're interested in helping to improve the app, please join us!
-You can find our bug tracker, source code, and wiki at <a href="https://github.com/k9mail/k-9">https://github.com/k9mail/k-9</a>.
+You can find our bug tracker, source code, and wiki at <a href="https://github.com/thundernest/k-9">https://github.com/thundernest/k-9</a>.
 We're always happy to welcome new developers, designers, documenters, translators, bug triagers and friends.

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -277,7 +277,7 @@ class SmtpTransport(
     private fun buildHostnameToReport(): String {
         val localAddress = socket!!.localAddress
 
-        // We use local IP statically for privacy reasons, see https://github.com/k9mail/k-9/pull/3798
+        // We use local IP statically for privacy reasons, see https://github.com/thundernest/k-9/pull/3798
         return if (localAddress is Inet6Address) {
             "[IPv6:::1]"
         } else {


### PR DESCRIPTION
This pull request updates some URLs that are pointing to the old location of this code repository.

There are more in `app/ui/legacy/src/main/res/values-.../strings.xml`, but I think those are auto-imported from the translations and I'm not sure what/where it should be changed first in a way that it gets picked up by the translation system.
