### PR TITLE
Fix bug when tapping a single message notification

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
@@ -5,54 +5,35 @@ import com.fsck.k9.Account
 import com.fsck.k9.controller.MessageReference
 
 interface NotificationActionCreator {
-    fun createViewMessagePendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createViewMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createViewFolderPendingIntent(account: Account, folderId: Long, notificationId: Int): PendingIntent
+    fun createViewFolderPendingIntent(account: Account, folderId: Long): PendingIntent
 
-    fun createViewMessagesPendingIntent(
-        account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
-    ): PendingIntent
+    fun createViewMessagesPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
 
-    fun createViewFolderListPendingIntent(account: Account, notificationId: Int): PendingIntent
+    fun createViewFolderListPendingIntent(account: Account): PendingIntent
 
-    fun createDismissAllMessagesPendingIntent(account: Account, notificationId: Int): PendingIntent
+    fun createDismissAllMessagesPendingIntent(account: Account): PendingIntent
 
-    fun createDismissMessagePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent
+    fun createDismissMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createReplyPendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createReplyPendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createMarkMessageAsReadPendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createMarkMessageAsReadPendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createMarkAllAsReadPendingIntent(
-        account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
-    ): PendingIntent
+    fun createMarkAllAsReadPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
 
     fun getEditIncomingServerSettingsIntent(account: Account): PendingIntent
 
     fun getEditOutgoingServerSettingsIntent(account: Account): PendingIntent
 
-    fun createDeleteMessagePendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createDeleteMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createDeleteAllPendingIntent(
-        account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
-    ): PendingIntent
+    fun createDeleteAllPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
 
-    fun createArchiveMessagePendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createArchiveMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createArchiveAllPendingIntent(
-        account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
-    ): PendingIntent
+    fun createArchiveAllPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
 
-    fun createMarkMessageAsSpamPendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent
+    fun createMarkMessageAsSpamPendingIntent(messageReference: MessageReference): PendingIntent
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -19,13 +19,9 @@ internal class SendFailedNotificationController(
 
         val pendingIntent = account.outboxFolderId.let { outboxFolderId ->
             if (outboxFolderId != null) {
-                actionBuilder.createViewFolderPendingIntent(
-                    account, outboxFolderId, notificationId
-                )
+                actionBuilder.createViewFolderPendingIntent(account, outboxFolderId)
             } else {
-                actionBuilder.createViewFolderListPendingIntent(
-                    account, notificationId
-                )
+                actionBuilder.createViewFolderListPendingIntent(account)
             }
         }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.notification
 
-import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
@@ -35,8 +34,8 @@ internal class SingleMessageNotificationCreator(
             .setContentText(content.subject)
             .setSubText(baseNotificationData.accountName)
             .setBigText(content.preview)
-            .setContentIntent(createViewIntent(content, notificationId))
-            .setDeleteIntent(createDismissIntent(content, notificationId))
+            .setContentIntent(actionCreator.createViewMessagePendingIntent(content.messageReference))
+            .setDeleteIntent(actionCreator.createDismissMessagePendingIntent(content.messageReference))
             .setDeviceActions(singleNotificationData)
             .setWearActions(singleNotificationData)
             .setAppearance(singleNotificationData.isSilent, baseNotificationData.appearance)
@@ -57,14 +56,6 @@ internal class SingleMessageNotificationCreator(
         setStyle(NotificationCompat.BigTextStyle().bigText(text))
     }
 
-    private fun createViewIntent(content: NotificationContent, notificationId: Int): PendingIntent {
-        return actionCreator.createViewMessagePendingIntent(content.messageReference, notificationId)
-    }
-
-    private fun createDismissIntent(content: NotificationContent, notificationId: Int): PendingIntent {
-        return actionCreator.createDismissMessagePendingIntent(content.messageReference, notificationId)
-    }
-
     private fun NotificationBuilder.setDeviceActions(notificationData: SingleNotificationData) = apply {
         val actions = notificationData.actions
         for (action in actions) {
@@ -81,8 +72,7 @@ internal class SingleMessageNotificationCreator(
         val title = resourceProvider.actionReply()
         val content = notificationData.content
         val messageReference = content.messageReference
-        val replyToMessagePendingIntent =
-            actionCreator.createReplyPendingIntent(messageReference, notificationData.notificationId)
+        val replyToMessagePendingIntent = actionCreator.createReplyPendingIntent(messageReference)
 
         addAction(icon, title, replyToMessagePendingIntent)
     }
@@ -91,9 +81,8 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.iconMarkAsRead
         val title = resourceProvider.actionMarkAsRead()
         val content = notificationData.content
-        val notificationId = notificationData.notificationId
         val messageReference = content.messageReference
-        val action = actionCreator.createMarkMessageAsReadPendingIntent(messageReference, notificationId)
+        val action = actionCreator.createMarkMessageAsReadPendingIntent(messageReference)
 
         addAction(icon, title, action)
     }
@@ -102,9 +91,8 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.iconDelete
         val title = resourceProvider.actionDelete()
         val content = notificationData.content
-        val notificationId = notificationData.notificationId
         val messageReference = content.messageReference
-        val action = actionCreator.createDeleteMessagePendingIntent(messageReference, notificationId)
+        val action = actionCreator.createDeleteMessagePendingIntent(messageReference)
 
         addAction(icon, title, action)
     }
@@ -129,8 +117,7 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.wearIconReplyAll
         val title = resourceProvider.actionReply()
         val messageReference = notificationData.content.messageReference
-        val notificationId = notificationData.notificationId
-        val action = actionCreator.createReplyPendingIntent(messageReference, notificationId)
+        val action = actionCreator.createReplyPendingIntent(messageReference)
         val replyAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(replyAction)
@@ -140,8 +127,7 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.wearIconMarkAsRead
         val title = resourceProvider.actionMarkAsRead()
         val messageReference = notificationData.content.messageReference
-        val notificationId = notificationData.notificationId
-        val action = actionCreator.createMarkMessageAsReadPendingIntent(messageReference, notificationId)
+        val action = actionCreator.createMarkMessageAsReadPendingIntent(messageReference)
         val markAsReadAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(markAsReadAction)
@@ -151,8 +137,7 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.wearIconDelete
         val title = resourceProvider.actionDelete()
         val messageReference = notificationData.content.messageReference
-        val notificationId = notificationData.notificationId
-        val action = actionCreator.createDeleteMessagePendingIntent(messageReference, notificationId)
+        val action = actionCreator.createDeleteMessagePendingIntent(messageReference)
         val deleteAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(deleteAction)
@@ -162,8 +147,7 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.wearIconArchive
         val title = resourceProvider.actionArchive()
         val messageReference = notificationData.content.messageReference
-        val notificationId = notificationData.notificationId
-        val action = actionCreator.createArchiveMessagePendingIntent(messageReference, notificationId)
+        val action = actionCreator.createArchiveMessagePendingIntent(messageReference)
         val archiveAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(archiveAction)
@@ -173,8 +157,7 @@ internal class SingleMessageNotificationCreator(
         val icon = resourceProvider.wearIconMarkAsSpam
         val title = resourceProvider.actionMarkAsSpam()
         val messageReference = notificationData.content.messageReference
-        val notificationId = notificationData.notificationId
-        val action = actionCreator.createMarkMessageAsSpamPendingIntent(messageReference, notificationId)
+        val action = actionCreator.createMarkMessageAsSpamPendingIntent(messageReference)
         val spamAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(spamAction)

--- a/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
@@ -23,7 +23,6 @@ internal class SingleMessageNotificationCreator(
 
         val notification = notificationHelper.createNotificationBuilder(account, ChannelType.MESSAGES)
             .setCategory(NotificationCompat.CATEGORY_EMAIL)
-            .setAutoCancel(true)
             .setGroup(baseNotificationData.groupKey)
             .setGroupSummary(isGroupSummary)
             .setSmallIcon(resourceProvider.iconNewMail)

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -52,7 +52,6 @@ internal class SummaryNotificationCreator(
 
         val notification = notificationHelper.createNotificationBuilder(account, ChannelType.MESSAGES)
             .setCategory(NotificationCompat.CATEGORY_EMAIL)
-            .setAutoCancel(true)
             .setGroup(baseNotificationData.groupKey)
             .setGroupSummary(true)
             .setSmallIcon(resourceProvider.iconNewMail)

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -5,7 +5,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
 import com.fsck.k9.Account
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
-import com.fsck.k9.notification.NotificationIds.getNewMailSummaryNotificationId
 import timber.log.Timber
 import androidx.core.app.NotificationCompat.Builder as NotificationBuilder
 
@@ -65,7 +64,7 @@ internal class SummaryNotificationCreator(
             .setSubText(accountName)
             .setInboxStyle(title, summary, notificationData.content)
             .setContentIntent(createViewIntent(account, notificationData))
-            .setDeleteIntent(createDismissIntent(account, notificationData.notificationId))
+            .setDeleteIntent(actionCreator.createDismissAllMessagesPendingIntent(account))
             .setDeviceActions(account, notificationData)
             .setWearActions(account, notificationData)
             .setAppearance(notificationData.isSilent, baseNotificationData.appearance)
@@ -101,15 +100,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun createViewIntent(account: Account, notificationData: SummaryInboxNotificationData): PendingIntent {
-        return actionCreator.createViewMessagesPendingIntent(
-            account = account,
-            messageReferences = notificationData.messageReferences,
-            notificationId = notificationData.notificationId
-        )
-    }
-
-    private fun createDismissIntent(account: Account, notificationId: Int): PendingIntent {
-        return actionCreator.createDismissAllMessagesPendingIntent(account, notificationId)
+        return actionCreator.createViewMessagesPendingIntent(account, notificationData.messageReferences)
     }
 
     private fun NotificationBuilder.setDeviceActions(
@@ -131,9 +122,7 @@ internal class SummaryNotificationCreator(
         val icon = resourceProvider.iconMarkAsRead
         val title = resourceProvider.actionMarkAsRead()
         val messageReferences = notificationData.messageReferences
-        val notificationId = notificationData.notificationId
-        val markAllAsReadPendingIntent =
-            actionCreator.createMarkAllAsReadPendingIntent(account, messageReferences, notificationId)
+        val markAllAsReadPendingIntent = actionCreator.createMarkAllAsReadPendingIntent(account, messageReferences)
 
         addAction(icon, title, markAllAsReadPendingIntent)
     }
@@ -144,9 +133,8 @@ internal class SummaryNotificationCreator(
     ) {
         val icon = resourceProvider.iconDelete
         val title = resourceProvider.actionDelete()
-        val notificationId = getNewMailSummaryNotificationId(account)
         val messageReferences = notificationData.messageReferences
-        val action = actionCreator.createDeleteAllPendingIntent(account, messageReferences, notificationId)
+        val action = actionCreator.createDeleteAllPendingIntent(account, messageReferences)
 
         addAction(icon, title, action)
     }
@@ -175,8 +163,7 @@ internal class SummaryNotificationCreator(
         val icon = resourceProvider.wearIconMarkAsRead
         val title = resourceProvider.actionMarkAllAsRead()
         val messageReferences = notificationData.messageReferences
-        val notificationId = getNewMailSummaryNotificationId(account)
-        val action = actionCreator.createMarkAllAsReadPendingIntent(account, messageReferences, notificationId)
+        val action = actionCreator.createMarkAllAsReadPendingIntent(account, messageReferences)
         val markAsReadAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(markAsReadAction)
@@ -186,8 +173,7 @@ internal class SummaryNotificationCreator(
         val icon = resourceProvider.wearIconDelete
         val title = resourceProvider.actionDeleteAll()
         val messageReferences = notificationData.messageReferences
-        val notificationId = getNewMailSummaryNotificationId(account)
-        val action = actionCreator.createDeleteAllPendingIntent(account, messageReferences, notificationId)
+        val action = actionCreator.createDeleteAllPendingIntent(account, messageReferences)
         val deleteAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(deleteAction)
@@ -197,8 +183,7 @@ internal class SummaryNotificationCreator(
         val icon = resourceProvider.wearIconArchive
         val title = resourceProvider.actionArchiveAll()
         val messageReferences = notificationData.messageReferences
-        val notificationId = getNewMailSummaryNotificationId(account)
-        val action = actionCreator.createArchiveAllPendingIntent(account, messageReferences, notificationId)
+        val action = actionCreator.createArchiveAllPendingIntent(account, messageReferences)
         val archiveAction = NotificationCompat.Action.Builder(icon, title, action).build()
 
         addAction(archiveAction)

--- a/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
@@ -18,9 +18,7 @@ internal class SyncNotificationController(
 
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         val outboxFolderId = account.outboxFolderId ?: error("Outbox folder not configured")
-        val showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(
-            account, outboxFolderId, notificationId
-        )
+        val showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(account, outboxFolderId)
 
         val notificationBuilder = notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
@@ -53,9 +51,7 @@ internal class SyncNotificationController(
         val text = accountName + resourceProvider.checkingMailSeparator() + folderName
 
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
-        val showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(
-            account, folderId, notificationId
-        )
+        val showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(account, folderId)
 
         val notificationBuilder = notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)

--- a/app/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
@@ -9,7 +9,6 @@ import com.fsck.k9.Account
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
@@ -88,8 +87,8 @@ class SendFailedNotificationControllerTest : RobolectricTest() {
 
     private fun createActionBuilder(contentIntent: PendingIntent): NotificationActionCreator {
         return mock {
-            on { createViewFolderListPendingIntent(any(), anyInt()) } doReturn contentIntent
-            on { createViewFolderPendingIntent(any(), anyLong(), anyInt()) } doReturn contentIntent
+            on { createViewFolderListPendingIntent(any()) } doReturn contentIntent
+            on { createViewFolderPendingIntent(any(), anyLong()) } doReturn contentIntent
         }
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
@@ -11,7 +11,6 @@ import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.notification.NotificationIds.getFetchingMailNotificationId
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
@@ -140,7 +139,7 @@ class SyncNotificationControllerTest : RobolectricTest() {
 
     private fun createActionBuilder(contentIntent: PendingIntent): NotificationActionCreator {
         return mock {
-            on { createViewFolderPendingIntent(eq(account), anyLong(), anyInt()) } doReturn contentIntent
+            on { createViewFolderPendingIntent(eq(account), anyLong()) } doReturn contentIntent
         }
     }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
@@ -37,25 +37,21 @@ internal class K9NotificationActionCreator(
     private val messageStoreManager: MessageStoreManager
 ) : NotificationActionCreator {
 
-    override fun createViewMessagePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createViewMessagePendingIntent(messageReference: MessageReference): PendingIntent {
         val openInUnifiedInbox = K9.isShowUnifiedInbox && isIncludedInUnifiedInbox(messageReference)
         val intent = createMessageViewIntent(messageReference, openInUnifiedInbox)
 
         return PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createViewFolderPendingIntent(account: Account, folderId: Long, notificationId: Int): PendingIntent {
+    override fun createViewFolderPendingIntent(account: Account, folderId: Long): PendingIntent {
         val intent = createMessageListIntent(account, folderId)
         return PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
     override fun createViewMessagesPendingIntent(
         account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
+        messageReferences: List<MessageReference>
     ): PendingIntent {
         val folderIds = extractFolderIds(messageReferences)
 
@@ -70,39 +66,33 @@ internal class K9NotificationActionCreator(
         return PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createViewFolderListPendingIntent(account: Account, notificationId: Int): PendingIntent {
+    override fun createViewFolderListPendingIntent(account: Account): PendingIntent {
         val intent = createMessageListIntent(account)
         return PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createDismissAllMessagesPendingIntent(account: Account, notificationId: Int): PendingIntent {
+    override fun createDismissAllMessagesPendingIntent(account: Account): PendingIntent {
         val intent = NotificationActionService.createDismissAllMessagesIntent(context, account).apply {
             data = Uri.parse("data:,dismissAll/${account.uuid}/${System.currentTimeMillis()}")
         }
         return PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createDismissMessagePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createDismissMessagePendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = NotificationActionService.createDismissMessageIntent(context, messageReference).apply {
             data = Uri.parse("data:,dismiss/${messageReference.toIdentityString()}")
         }
         return PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createReplyPendingIntent(messageReference: MessageReference, notificationId: Int): PendingIntent {
+    override fun createReplyPendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = MessageActions.getActionReplyIntent(context, messageReference).apply {
             data = Uri.parse("data:,reply/${messageReference.toIdentityString()}")
         }
         return PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createMarkMessageAsReadPendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createMarkMessageAsReadPendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = NotificationActionService.createMarkMessageAsReadIntent(context, messageReference).apply {
             data = Uri.parse("data:,markAsRead/${messageReference.toIdentityString()}")
         }
@@ -111,8 +101,7 @@ internal class K9NotificationActionCreator(
 
     override fun createMarkAllAsReadPendingIntent(
         account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
+        messageReferences: List<MessageReference>
     ): PendingIntent {
         val accountUuid = account.uuid
         val intent = NotificationActionService.createMarkAllAsReadIntent(context, accountUuid, messageReferences).apply {
@@ -131,31 +120,22 @@ internal class K9NotificationActionCreator(
         return PendingIntent.getActivity(context, account.accountNumber, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createDeleteMessagePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createDeleteMessagePendingIntent(messageReference: MessageReference): PendingIntent {
         return if (K9.isConfirmDeleteFromNotification) {
-            createDeleteConfirmationPendingIntent(messageReference, 0)
+            createDeleteConfirmationPendingIntent(messageReference)
         } else {
-            createDeleteServicePendingIntent(messageReference, 0)
+            createDeleteServicePendingIntent(messageReference)
         }
     }
 
-    private fun createDeleteServicePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    private fun createDeleteServicePendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = NotificationActionService.createDeleteMessageIntent(context, messageReference).apply {
             data = Uri.parse("data:,delete/${messageReference.toIdentityString()}")
         }
         return PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    private fun createDeleteConfirmationPendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    private fun createDeleteConfirmationPendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = DeleteConfirmationActivity.getIntent(context, messageReference).apply {
             data = Uri.parse("data:,deleteConfirmation/${messageReference.toIdentityString()}")
         }
@@ -164,20 +144,16 @@ internal class K9NotificationActionCreator(
 
     override fun createDeleteAllPendingIntent(
         account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
+        messageReferences: List<MessageReference>
     ): PendingIntent {
         return if (K9.isConfirmDeleteFromNotification) {
-            getDeleteAllConfirmationPendingIntent(messageReferences, 0)
+            getDeleteAllConfirmationPendingIntent(messageReferences)
         } else {
-            getDeleteAllServicePendingIntent(account, messageReferences, 0)
+            getDeleteAllServicePendingIntent(account, messageReferences)
         }
     }
 
-    private fun getDeleteAllConfirmationPendingIntent(
-        messageReferences: List<MessageReference>,
-        notificationId: Int
-    ): PendingIntent {
+    private fun getDeleteAllConfirmationPendingIntent(messageReferences: List<MessageReference>): PendingIntent {
         val intent = DeleteConfirmationActivity.getIntent(context, messageReferences).apply {
             data = Uri.parse("data:,deleteAllConfirmation/${System.currentTimeMillis()}")
         }
@@ -186,8 +162,7 @@ internal class K9NotificationActionCreator(
 
     private fun getDeleteAllServicePendingIntent(
         account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
+        messageReferences: List<MessageReference>
     ): PendingIntent {
         val accountUuid = account.uuid
         val intent = NotificationActionService.createDeleteAllMessagesIntent(context, accountUuid, messageReferences).apply {
@@ -196,10 +171,7 @@ internal class K9NotificationActionCreator(
         return PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createArchiveMessagePendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createArchiveMessagePendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = NotificationActionService.createArchiveMessageIntent(context, messageReference).apply {
             data = Uri.parse("data:,archive/${messageReference.toIdentityString()}")
         }
@@ -208,8 +180,7 @@ internal class K9NotificationActionCreator(
 
     override fun createArchiveAllPendingIntent(
         account: Account,
-        messageReferences: List<MessageReference>,
-        notificationId: Int
+        messageReferences: List<MessageReference>
     ): PendingIntent {
         val intent = NotificationActionService.createArchiveAllIntent(context, account, messageReferences).apply {
             data = Uri.parse("data:,archiveAll/${account.uuid}/${System.currentTimeMillis()}")
@@ -217,10 +188,7 @@ internal class K9NotificationActionCreator(
         return PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE)
     }
 
-    override fun createMarkMessageAsSpamPendingIntent(
-        messageReference: MessageReference,
-        notificationId: Int
-    ): PendingIntent {
+    override fun createMarkMessageAsSpamPendingIntent(messageReference: MessageReference): PendingIntent {
         val intent = NotificationActionService.createMarkMessageAsSpamIntent(context, messageReference).apply {
             data = Uri.parse("data:,spam/${messageReference.toIdentityString()}")
         }


### PR DESCRIPTION
On one of my test devices (Android 12), tapping a single message notification opens the message view, which leads to the notification being removed. If there's an inactive notification it will be promoted to an active notification and use the notification ID of the notification that was just removed. Due to auto-cancel being used, the delete intent of the first notification is then triggered. However, the system seems to use the notification ID to retrieve the delete intent. Because it will fetch the delete intent from the new notification, not the old one. (I made sure to check that it's not a `PendingIntent` reuse issue)

Since we remove the notification ourselves, we can simply stop using the auto-cancel mechanism.