### PR TITLE
Set the User-Agent to just "K-9 Mail"

### DIFF
--- a/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -20,7 +20,7 @@ class TestCoreResourceProvider : CoreResourceProvider {
 
     override fun noSubject() = "(No subject)"
 
-    override fun userAgent(): String = "K-9 Mail for Android"
+    override fun userAgent(): String = "K-9 Mail"
     override fun encryptedSubject(): String = "Encrypted message"
 
     override fun replyHeader(sender: String) = "$sender wrote:"

--- a/app/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -78,7 +78,7 @@ public class MessageBuilderTest extends RobolectricTest {
             "CC: cc recip <cc@example.org>\r\n" +
             "BCC: bcc recip <bcc@example.org>\r\n" +
             "Subject: test_subject\r\n" +
-            "User-Agent: K-9 Mail for Android\r\n" +
+            "User-Agent: K-9 Mail\r\n" +
             "Reply-to: reply 1 <reply-to1@example.org>, reply 2 <reply-to2@example.org>\r\n" +
             "In-Reply-To: inreplyto\r\n" +
             "References: references\r\n" +

--- a/app/ui/legacy/src/main/res/values/constants.xml
+++ b/app/ui/legacy/src/main/res/values/constants.xml
@@ -3,7 +3,7 @@
     <string name="app_webpage_url" translatable="false">https://k9mail.app/</string>
     <string name="user_manual_url" translatable="false">https://docs.k9mail.app/</string>
     <string name="user_forum_url" translatable="false">https://forum.k9mail.app/</string>
-    <string name="message_header_mua" translatable="false">K-9 Mail for Android</string>
+    <string name="message_header_mua" translatable="false">K-9 Mail</string>
     <string name="app_authors_url" translatable="false">https://github.com/k9mail/k-9/graphs/contributors</string>
     <string name="app_source_url" translatable="false">https://github.com/k9mail/k-9</string>
     <string name="app_license_url" translatable="false">https://www.apache.org/licenses/LICENSE-2.0</string>

--- a/app/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -20,7 +20,7 @@ class TestCoreResourceProvider : CoreResourceProvider {
 
     override fun noSubject() = throw UnsupportedOperationException("not implemented")
 
-    override fun userAgent(): String = "K-9 Mail for Android"
+    override fun userAgent(): String = "K-9 Mail"
     override fun encryptedSubject(): String = "Encrypted message"
 
     override fun replyHeader(sender: String) = throw UnsupportedOperationException("not implemented")


### PR DESCRIPTION
The original `User-Agent` value, "K-9 Mail for Android", appeared in the source code around commit c25769d90606e4cacad1de0212121bb199d678a6, in October 2008. Back then, Android was quite a new thing, so there could be some sense in advertising K-9 as a MUA for the new mobile platform.

These days Android phones are relatively common, no longer the new thing, so there could be some sense in simplifying the `User-Agent` by no longer advertising the operating system and focusing just on the application name.