### PR TITLE
Fix attachment file name may fail to parse

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -889,7 +889,7 @@ internal class RealImapFolder(
                 for (i in bodyParams.indices step 2) {
                     val paramName = bodyParams.getString(i)
                     val paramValue = bodyParams.getString(i + 1)
-                    contentType.append(String.format(";\r\n %s=\"%s\"", paramName, paramValue))
+                    contentType.append(String.format(";\r\n %s=%s", paramName, paramValue))
                 }
             }
 
@@ -915,7 +915,7 @@ internal class RealImapFolder(
                     for (i in bodyDispositionParams.indices step 2) {
                         val paramName = bodyDispositionParams.getString(i).lowercase()
                         val paramValue = bodyDispositionParams.getString(i + 1)
-                        contentDisposition.append(String.format(";\r\n %s=\"%s\"", paramName, paramValue))
+                        contentDisposition.append(String.format(";\r\n %s=%s", paramName, paramValue))
                     }
                 }
             }


### PR DESCRIPTION
Extra double quotes can cause this attachment name parsing to fail
attachment; filename*=utf-8''file_name_url_encoded

my imap server is [mailu](https://github.com/Mailu/Mailu) 1.7
The double quotes here cause the utf8-encoded attachment name parsing to fail