### PR TITLE
Fix leading space disappears when sending an email

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
@@ -62,6 +62,7 @@ class TextToHtml private constructor(private val text: CharSequence, private val
 
     internal fun appendHtmlEncoded(ch: Char) {
         when (ch) {
+            ' ' -> html.append("&nbsp;")
             '&' -> html.append("&amp;")
             '<' -> html.append("&lt;")
             '>' -> html.append("&gt;")


### PR DESCRIPTION
Fix the problem that the space at the beginning of the line disappears when sending an email,

send mail like this,
```
 0
1
 2
  3
```
receive html like this,
```html
<!DOCTYPE html><html><body> 0<br>1<br> 2<br>  3</body></html>
```
space at the beginning of the line will not be displayed,
it will look like this,
```
0
1
2
3
```

change the space to `&nbsp;` will display normally
```html
<!DOCTYPE html><html><body>&nbsp;0<br>1<br>&nbsp;2<br>&nbsp;&nbsp;3</body></html>
```