### PR TITLE
Clear `folder_extra_values` when using "clear local messages"

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -925,6 +925,7 @@ public class LocalFolder {
                 db.execSQL("DELETE FROM threads WHERE message_id IN " +
                         "(SELECT id FROM messages WHERE folder_id = ?)", folderIdArg);
                 db.execSQL("DELETE FROM messages WHERE folder_id = ?", folderIdArg);
+                db.execSQL("DELETE FROM folder_extra_values WHERE folder_id = ?", folderIdArg);
 
                 setMoreMessages(MoreMessages.UNKNOWN);
                 resetLastChecked(db);


### PR DESCRIPTION
Make it easier to fix issues like the one described here: https://forum.k9mail.app/t/android-10-notification-issues/50/31