### PR TITLE
Fix swipe between messages

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -352,8 +352,6 @@ open class MessageList :
                         showMessageViewPlaceHolder()
                     } else {
                         messageViewContainerFragment.isActive = true
-                        val activeMessage = messageViewContainerFragment.messageReference
-                        messageListFragment.setActiveMessage(activeMessage)
                     }
                 }
 
@@ -985,10 +983,6 @@ open class MessageList :
         if (draftsFolderId != null && folderId == draftsFolderId) {
             MessageActions.actionEditDraft(this, messageReference)
         } else {
-            if (messageListFragment != null) {
-                messageListFragment!!.setActiveMessage(messageReference)
-            }
-
             val fragment = MessageViewContainerFragment.newInstance(messageReference)
             supportFragmentManager.commitNow {
                 replace(R.id.message_view_container, fragment, FRAGMENT_TAG_MESSAGE_VIEW_CONTAINER)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListConfig.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListConfig.kt
@@ -10,5 +10,11 @@ data class MessageListConfig(
     val sortType: SortType,
     val sortAscending: Boolean,
     val sortDateAscending: Boolean,
-    val activeMessage: MessageReference?
+    val activeMessage: MessageReference?,
+    val sortOverrides: Map<MessageReference, MessageSortOverride>
+)
+
+data class MessageSortOverride(
+    val isRead: Boolean,
+    val isStarred: Boolean
 )

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.ui.messagelist
 
 import com.fsck.k9.Account
+import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.mail.Address
 
 data class MessageListItem(
@@ -25,4 +26,7 @@ data class MessageListItem(
     val messageUid: String,
     val databaseId: Long,
     val threadRoot: Long
-)
+) {
+    val messageReference: MessageReference
+        get() = MessageReference(account.uuid, folderId, messageUid)
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -136,12 +136,14 @@ class MessageListLoader(
                     .thenByDate(config)
             }
             SortType.SORT_UNREAD -> {
-                compareBy<MessageListItem>(config.sortAscending) { it.isRead }
-                    .thenByDate(config)
+                compareBy<MessageListItem>(config.sortAscending) {
+                    config.sortOverrides[it.messageReference]?.isRead ?: it.isRead
+                }.thenByDate(config)
             }
             SortType.SORT_FLAGGED -> {
-                compareBy<MessageListItem>(!config.sortAscending) { it.isStarred }
-                    .thenByDate(config)
+                compareBy<MessageListItem>(!config.sortAscending) {
+                    config.sortOverrides[it.messageReference]?.isStarred ?: it.isStarred
+                }.thenByDate(config)
             }
             SortType.SORT_ATTACHMENT -> {
                 compareBy<MessageListItem>(!config.sortAscending) { it.hasAttachments }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
@@ -4,10 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fsck.k9.controller.MessageReference
+import java.util.LinkedList
 
 class MessageListViewModel(private val messageListLiveDataFactory: MessageListLiveDataFactory) : ViewModel() {
     private var currentMessageListLiveData: MessageListLiveData? = null
     private val messageListLiveData = MediatorLiveData<MessageListInfo>()
+
+    val messageSortOverrides = LinkedList<Pair<MessageReference, MessageSortOverride>>()
 
     fun getMessageListLiveData(): LiveData<MessageListInfo> {
         return messageListLiveData

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -32,6 +32,8 @@ class MessageViewContainerFragment : Fragment() {
     lateinit var messageReference: MessageReference
         private set
 
+    private var activeMessageReference: MessageReference? = null
+
     var lastDirection: Direction? = null
         private set
 
@@ -140,22 +142,23 @@ class MessageViewContainerFragment : Fragment() {
     }
 
     private fun setActiveMessage(position: Int) {
-        rememberNavigationDirection(position, messageReference)
-
-        messageReference = adapter.getMessageReference(position)
-
-        fragmentListener.setActiveMessage(messageReference)
-    }
-
-    private fun rememberNavigationDirection(newPosition: Int, currentMessageReference: MessageReference) {
-        // When messages are added or removed from the list, the current position will change even though we're still
-        // displaying the same message. In those cases we don't want to update `lastDirection`.
-        val newMessageReference = adapter.getMessageReference(newPosition)
-        if (newMessageReference == currentMessageReference) {
-            currentPosition = newPosition
+        // If the position of current message changes (e.g. because messages were added or removed from the list), we
+        // keep track of the new position but otherwise ignore the event.
+        val newMessageReference = adapter.getMessageReference(position)
+        if (newMessageReference == activeMessageReference) {
+            currentPosition = position
             return
         }
 
+        rememberNavigationDirection(position)
+
+        messageReference = adapter.getMessageReference(position)
+
+        activeMessageReference = messageReference
+        fragmentListener.setActiveMessage(messageReference)
+    }
+
+    private fun rememberNavigationDirection(newPosition: Int) {
         currentPosition?.let { currentPosition ->
             lastDirection = if (newPosition < currentPosition) Direction.PREVIOUS else Direction.NEXT
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -313,6 +313,3 @@ class MessageViewContainerFragment : Fragment() {
         }
     }
 }
-
-private val MessageListItem.messageReference: MessageReference
-    get() = MessageReference(account.uuid, folderId, messageUid)


### PR DESCRIPTION
For the last 3 displayed messages we remember the original 'read' and 'starred' state of the messages. We pass this information to `MessageListLoader` so messages can be sorted according to these remembered values and not the current state. This way messages, that are marked as read/unread or starred/not starred while being displayed, won't immediately change position in the message list if the list is sorted by these fields.
The main benefit is that the swipe to next/previous message feature will work in a less surprising way.

Fixes #6246

This should also make #6239 much less of an issue.