### PR TITLE
Fix search view in message list

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -101,6 +101,9 @@ open class MessageList :
 
     private lateinit var actionBar: ActionBar
     private lateinit var searchView: SearchView
+    private var initialSearchViewQuery: String? = null
+    private var initialSearchViewIconified: Boolean = true
+
     private var drawer: K9Drawer? = null
     private var openFolderTransaction: FragmentTransaction? = null
     private var progressBar: ProgressBar? = null
@@ -574,6 +577,8 @@ open class MessageList :
         outState.putSerializable(STATE_DISPLAY_MODE, displayMode)
         outState.putBoolean(STATE_MESSAGE_VIEW_ONLY, messageViewOnly)
         outState.putBoolean(STATE_MESSAGE_LIST_WAS_DISPLAYED, messageListWasDisplayed)
+        outState.putBoolean(STATE_SEARCH_VIEW_ICONIFIED, searchView.isIconified)
+        outState.putString(STATE_SEARCH_VIEW_QUERY, searchView.query?.toString())
     }
 
     public override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -581,6 +586,8 @@ open class MessageList :
 
         messageViewOnly = savedInstanceState.getBoolean(STATE_MESSAGE_VIEW_ONLY)
         messageListWasDisplayed = savedInstanceState.getBoolean(STATE_MESSAGE_LIST_WAS_DISPLAYED)
+        initialSearchViewIconified = savedInstanceState.getBoolean(STATE_SEARCH_VIEW_ICONIFIED)
+        initialSearchViewQuery = savedInstanceState.getString(STATE_SEARCH_VIEW_QUERY)
     }
 
     private fun initializeActionBar() {
@@ -966,6 +973,9 @@ open class MessageList :
                 return false
             }
         })
+
+        searchView.isIconified = initialSearchViewIconified
+        searchView.setQuery(initialSearchViewQuery, false)
     }
 
     private fun collapseSearchView() {
@@ -1415,6 +1425,8 @@ open class MessageList :
         private const val STATE_DISPLAY_MODE = "displayMode"
         private const val STATE_MESSAGE_VIEW_ONLY = "messageViewOnly"
         private const val STATE_MESSAGE_LIST_WAS_DISPLAYED = "messageListWasDisplayed"
+        private const val STATE_SEARCH_VIEW_ICONIFIED = "searchViewIconified"
+        private const val STATE_SEARCH_VIEW_QUERY = "searchViewQuery"
 
         private const val FIRST_FRAGMENT_TRANSACTION = "first"
         private const val FRAGMENT_TAG_MESSAGE_VIEW_CONTAINER = "MessageViewContainerFragment"

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -17,7 +17,6 @@ import android.widget.AdapterView.OnItemLongClickListener
 import android.widget.ListView
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -1534,8 +1533,7 @@ class MessageListFragment :
     }
 
     private fun startAndPrepareActionMode() {
-        val activity = requireActivity() as AppCompatActivity
-        actionMode = activity.startSupportActionMode(actionModeCallback)
+        actionMode = fragmentListener.startSupportActionMode(actionModeCallback)
         actionMode?.invalidate()
     }
 
@@ -2003,6 +2001,7 @@ class MessageListFragment :
         fun setMessageListTitle(title: String, subtitle: String?)
         fun onCompose(account: Account?)
         fun startSearch(query: String, account: Account?, folderId: Long?): Boolean
+        fun startSupportActionMode(callback: ActionMode.Callback): ActionMode?
         fun goBack()
         fun onFolderNotFoundError()
 


### PR DESCRIPTION
We now reuse the previous `SearchView` instance when the toolbar menu is recreated. And we restore the previous state when the activity is recreated.

Fixes #5967