### PR TITLE
Change the separator between message view pages

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -8,8 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.MarginPageTransformer
 import androidx.viewpager2.widget.ViewPager2
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.ui.R
@@ -88,10 +88,13 @@ class MessageViewContainerFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.message_view_container, container, false)
 
+        val resources = inflater.context.resources
+        val pageMargin = resources.getDimension(R.dimen.message_view_pager_page_margin).toInt()
+
         viewPager = view.findViewById(R.id.message_viewpager)
         viewPager.isUserInputEnabled = true
         viewPager.offscreenPageLimit = ViewPager2.OFFSCREEN_PAGE_LIMIT_DEFAULT
-        viewPager.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.HORIZONTAL))
+        viewPager.setPageTransformer(MarginPageTransformer(pageMargin))
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             // The message list is updated each time the active message is changed. To avoid message list updates
             // during the animation, we only set the active message after the animation has finished.

--- a/app/ui/legacy/src/main/res/values/dimensions.xml
+++ b/app/ui/legacy/src/main/res/values/dimensions.xml
@@ -7,4 +7,6 @@
     <dimen name="input_label_vertical_spacing">8dp</dimen>
     <dimen name="input_label_horizontal_spacing">4dp</dimen>
     <dimen name="account_setup_margin_between_items_incoming_and_outgoing">12dp</dimen>
+
+    <dimen name="message_view_pager_page_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
To me, more space between pages looks better. It also solves the problem of the `DividerItemDecoration` showing at the right edge of the screen.


https://user-images.githubusercontent.com/218061/189532726-7fd5671a-69ff-4416-b6e8-5a34485941fc.mp4

