### PR TITLE
Add monochrome icon

### DIFF
--- a/app/ui/legacy/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/ui/legacy/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,70 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="m33.37,60.39l0,3.87l8.26,12.25c0.67,1.16 1.91,1.93 3.35,1.93l18.05,0c1.44,0 2.68,-0.78 3.35,-1.93l0,0L74.63,64.26l0,-3.87z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M43.68,32.02l2.58,0l0,5.16l-2.58,0z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.46"
+      android:fillColor="#000000"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M61.74,32.02l2.58,0l0,5.16l-2.58,0z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.46"
+      android:fillColor="#000000"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M48.84,27.51L48.84,30.09A1.93,1.93 0,0 1,46.91 32.02L39.17,32.02A1.93,1.93 0,0 1,37.24 30.09L37.24,27.51A1.93,1.93 0,0 1,39.17 25.57L46.91,25.57A1.93,1.93 0,0 1,48.84 27.51z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M70.76,27.51L70.76,30.09A1.93,1.93 0,0 1,68.83 32.02L61.09,32.02A1.93,1.93 0,0 1,59.16 30.09L59.16,27.51A1.93,1.93 0,0 1,61.09 25.57L68.83,25.57A1.93,1.93 0,0 1,70.76 27.51z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M33.37,34.6C31.23,34.6 29.5,36.33 29.5,38.47L29.5,60.39C29.5,62.53 31.23,64.26 33.37,64.26L74.63,64.26C76.77,64.26 78.5,62.53 78.5,60.39L78.5,38.47C78.5,36.33 76.77,34.6 74.63,34.6L33.37,34.6zM34.38,38.83A0.97,0.97 82.66,0 1,35.11 38.91L54,48.98L72.89,38.91A0.97,0.97 124.49,0 1,74.2 39.3A0.97,0.97 60.28,0 1,73.8 40.61L54,51.17L34.2,40.61A0.97,0.97 0,0 1,33.8 39.3A0.97,0.97 65.26,0 1,34.38 38.83z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="0.11"
+      android:fillColor="#000000"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M57.87,73.93L57.87,77.8A1.93,1.93 0,0 1,55.93 79.73L52.07,79.73A1.93,1.93 125.04,0 1,50.13 77.8L50.13,73.93A1.93,1.93 87.01,0 1,52.07 72L55.93,72A1.93,1.93 0,0 1,57.87 73.93z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="0.11"
+      android:fillColor="#000000"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M54,78.44m-3.87,0a3.87,3.87 134.88,1 1,7.74 0a3.87,3.87 45.24,1 1,-7.74 0"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="2.9"
+      android:fillColor="#000000"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/ui/legacy/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/ui/legacy/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -4,4 +4,5 @@
     <foreground>
         <inset android:drawable="@mipmap/icon" android:inset="23%"/>
     </foreground>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/images/drawable-src/ic_launcher_monochrome.svg
+++ b/images/drawable-src/ic_launcher_monochrome.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="108"
+   height="108"
+   viewBox="0 0 108 108"
+   version="1.1"
+   id="svg9113"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="ic_launcher_monochrome.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs9107" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="8.6620581"
+     inkscape:cy="61.076348"
+     inkscape:document-units="px"
+     inkscape:current-layer="g405"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1058"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     units="px"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata9110">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-266.85715,-437.94824)">
+    <g
+       id="g405"
+       transform="matrix(0.85234502,0,0,0.85234502,47.376157,72.63861)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.72243641;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-dasharray:none"
+         d="m 32,116 v 12 l 25.607422,38 c 2.069825,3.58859 5.935831,6 10.392578,6 h 56 c 4.45675,0 8.32275,-2.41141 10.39258,-6 h 0.0117 L 160,128 v -12 z"
+         transform="matrix(0.37821481,0,0,0.37821481,284.54852,455.57305)"
+         id="path12541" />
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.71542;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect11626"
+         width="3.0257185"
+         height="6.0514183"
+         x="308.75427"
+         y="466.16309" />
+      <rect
+         y="466.16309"
+         x="329.9343"
+         height="6.0514183"
+         width="3.0257185"
+         id="rect12099"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.71542;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         ry="2.2692893"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.40788058;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect11624"
+         width="7.5642939"
+         height="13.615733"
+         x="458.59879"
+         y="-314.80569"
+         rx="2.2692893"
+         transform="rotate(90)" />
+      <rect
+         transform="rotate(90)"
+         rx="2.2692893"
+         y="-340.52432"
+         x="458.59879"
+         height="13.615733"
+         width="7.5642939"
+         id="rect12097"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.40788058;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         ry="2.2692893" />
+      <path
+         id="rect11599"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.340162;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="M 176.30146 -32.002467 C 176.30146 -25.354473 181.6496 -20.000276 188.2976 -20.000276 L 256.29992 -20.000276 C 262.94791 -20.000276 268.30211 -25.354473 268.30211 -32.002467 L 268.30211 -159.99757 C 268.30211 -166.64557 262.94791 -171.99976 256.29992 -171.99976 L 188.2976 -171.99976 C 181.6496 -171.99976 176.30146 -166.64557 176.30146 -159.99757 L 176.30146 -32.002467 z M 189.43056 -35.128732 A 3 3 0 0 1 189.65473 -37.412844 L 220.89921 -96.000019 L 189.65473 -154.58719 A 3 3 0 0 1 190.8907 -158.64649 A 3 3 0 0 1 194.95 -157.41053 L 227.69702 -96.000019 L 194.95 -34.589512 A 3 3 0 0 1 190.8907 -33.353547 A 3 3 0 0 1 189.43056 -35.128732 z "
+         transform="matrix(0,0.37821481,-0.37821481,0,284.54852,402.50951)" />
+      <g
+         transform="matrix(0.37821481,0,0,0.37821481,284.54852,402.50951)"
+         id="g13464">
+        <rect
+           ry="6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.340162;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect11618"
+           width="24.000019"
+           height="23.999996"
+           x="292.29999"
+           y="-108"
+           rx="6"
+           transform="rotate(90)" />
+        <circle
+           r="11.999994"
+           cy="312.29999"
+           cx="96"
+           id="path11616"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Added monochrome icon for Material You "Themed icons" support.

before:
![SS_20220918_234051](https://user-images.githubusercontent.com/26635624/190927614-239ccb11-d484-47a8-a204-bf92bcc45aa5.png)

after:
![SS_20220918_232458](https://user-images.githubusercontent.com/26635624/190927619-87ae023a-4090-4115-9702-28841fad93e4.png)
