### PR TITLE
Message View Redesign - Optional account chip

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -139,6 +139,9 @@ open class MessageList :
     private var viewSwitcher: ViewSwitcher? = null
     private lateinit var recentChangesSnackbar: Snackbar
 
+    private val isShowAccountChip: Boolean
+        get() = messageListFragment?.isShowAccountChip ?: true
+
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -1018,7 +1021,7 @@ open class MessageList :
         if (draftsFolderId != null && folderId == draftsFolderId) {
             MessageActions.actionEditDraft(this, messageReference)
         } else {
-            val fragment = MessageViewContainerFragment.newInstance(messageReference)
+            val fragment = MessageViewContainerFragment.newInstance(messageReference, isShowAccountChip)
             supportFragmentManager.commitNow {
                 replace(R.id.message_view_container, fragment, FRAGMENT_TAG_MESSAGE_VIEW_CONTAINER)
             }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -143,6 +143,9 @@ class MessageListFragment :
             invalidateMenu()
         }
 
+    val isShowAccountChip: Boolean
+        get() = !isSingleAccountMode
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
@@ -475,7 +478,7 @@ class MessageListFragment :
             showContactPicture = K9.isShowContactPicture,
             showingThreadedList = showingThreadedList,
             backGroundAsReadIndicator = K9.isUseBackgroundAsUnreadIndicator,
-            showAccountChip = !isSingleAccountMode
+            showAccountChip = isShowAccountChip
         )
 
     private fun getFolderInfoHolder(folderId: Long, account: Account): FolderInfoHolder {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -55,6 +55,8 @@ public class MessageTopView extends LinearLayout {
     private boolean isShowingProgress;
     private boolean showPicturesButtonClicked;
 
+    private boolean showAccountChip;
+
     private MessageCryptoPresenter messageCryptoPresenter;
 
 
@@ -82,6 +84,10 @@ public class MessageTopView extends LinearLayout {
         containerView = findViewById(R.id.message_container);
 
         hideHeaderView();
+    }
+
+    public void setShowAccountChip(boolean showAccountChip) {
+        this.showAccountChip = showAccountChip;
     }
 
     private void setShowPicturesButtonListener() {
@@ -208,7 +214,7 @@ public class MessageTopView extends LinearLayout {
     }
 
     public void setHeaders(Message message, Account account, boolean showStar) {
-        mHeaderContainer.populate(message, account, showStar);
+        mHeaderContainer.populate(message, account, showStar, showAccountChip);
         mHeaderContainer.setVisibility(View.VISIBLE);
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -29,6 +29,8 @@ class MessageViewContainerFragment : Fragment() {
             setMenuVisibility(value)
         }
 
+    private var showAccountChip: Boolean = true
+
     lateinit var messageReference: MessageReference
         private set
 
@@ -72,7 +74,9 @@ class MessageViewContainerFragment : Fragment() {
             lastDirection = savedInstanceState.getSerializable(STATE_LAST_DIRECTION) as Direction?
         }
 
-        adapter = MessageViewContainerAdapter(this)
+        showAccountChip = arguments?.getBoolean(ARG_SHOW_ACCOUNT_CHIP) ?: showAccountChip
+
+        adapter = MessageViewContainerAdapter(this, showAccountChip)
     }
 
     override fun onAttach(context: Context) {
@@ -234,7 +238,11 @@ class MessageViewContainerFragment : Fragment() {
         findMessageViewFragment().onPendingIntentResult(requestCode, resultCode, data)
     }
 
-    private class MessageViewContainerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+    private class MessageViewContainerAdapter(
+        fragment: Fragment,
+        private val showAccountChip: Boolean
+    ) : FragmentStateAdapter(fragment) {
+
         var messageList: List<MessageListItem> = emptyList()
             set(value) {
                 val diffResult = DiffUtil.calculateDiff(
@@ -262,7 +270,7 @@ class MessageViewContainerFragment : Fragment() {
             check(position in messageList.indices)
 
             val messageReference = messageList[position].messageReference
-            return MessageViewFragment.newInstance(messageReference)
+            return MessageViewFragment.newInstance(messageReference, showAccountChip)
         }
 
         fun getMessageReference(position: Int): MessageReference {
@@ -305,13 +313,15 @@ class MessageViewContainerFragment : Fragment() {
 
     companion object {
         private const val ARG_REFERENCE = "reference"
+        private const val ARG_SHOW_ACCOUNT_CHIP = "showAccountChip"
 
         private const val STATE_MESSAGE_REFERENCE = "messageReference"
         private const val STATE_LAST_DIRECTION = "lastDirection"
 
-        fun newInstance(reference: MessageReference): MessageViewContainerFragment {
+        fun newInstance(reference: MessageReference, showAccountChip: Boolean): MessageViewContainerFragment {
             return MessageViewContainerFragment().withArguments(
-                ARG_REFERENCE to reference.toIdentityString()
+                ARG_REFERENCE to reference.toIdentityString(),
+                ARG_SHOW_ACCOUNT_CHIP to showAccountChip
             )
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -86,6 +86,7 @@ class MessageViewFragment :
 
     private lateinit var account: Account
     lateinit var messageReference: MessageReference
+    private var showAccountChip: Boolean = true
 
     private var currentAttachmentViewInfo: AttachmentViewInfo? = null
     private var isDeleteMenuItemDisabled: Boolean = false
@@ -108,6 +109,9 @@ class MessageViewFragment :
 
         messageReference = MessageReference.parse(arguments?.getString(ARG_REFERENCE))
             ?: error("Invalid argument '$ARG_REFERENCE'")
+
+        showAccountChip = arguments?.getBoolean(ARG_SHOW_ACCOUNT_CHIP)
+            ?: error("Missing argument: '$ARG_SHOW_ACCOUNT_CHIP'")
 
         if (savedInstanceState != null) {
             wasMessageMarkedAsOpened = savedInstanceState.getBoolean(STATE_WAS_MESSAGE_MARKED_AS_OPENED)
@@ -136,6 +140,8 @@ class MessageViewFragment :
     }
 
     private fun initializeMessageTopView(messageTopView: MessageTopView) {
+        messageTopView.setShowAccountChip(showAccountChip)
+
         messageTopView.setAttachmentCallback(this)
         messageTopView.setMessageCryptoPresenter(messageCryptoPresenter)
 
@@ -940,6 +946,7 @@ class MessageViewFragment :
         const val PROGRESS_THRESHOLD_MILLIS = 500 * 1000
 
         private const val ARG_REFERENCE = "reference"
+        private const val ARG_SHOW_ACCOUNT_CHIP = "showAccountChip"
 
         private const val STATE_WAS_MESSAGE_MARKED_AS_OPENED = "wasMessageMarkedAsOpened"
 
@@ -947,9 +954,10 @@ class MessageViewFragment :
         private const val ACTIVITY_CHOOSE_FOLDER_COPY = 2
         private const val REQUEST_CODE_CREATE_DOCUMENT = 3
 
-        fun newInstance(reference: MessageReference): MessageViewFragment {
+        fun newInstance(reference: MessageReference, showAccountChip: Boolean): MessageViewFragment {
             return MessageViewFragment().withArguments(
-                ARG_REFERENCE to reference.toIdentityString()
+                ARG_REFERENCE to reference.toIdentityString(),
+                ARG_SHOW_ACCOUNT_CHIP to showAccountChip
             )
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -128,9 +128,14 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         starView.setOnClickListener(listener);
     }
 
-    public void populate(final Message message, final Account account, boolean showStar) {
-        accountChip.setText(account.getDisplayName());
-        accountChip.setChipBackgroundColor(ColorStateList.valueOf(account.getChipColor()));
+    public void populate(final Message message, final Account account, boolean showStar, boolean showAccountChip) {
+        if (showAccountChip) {
+            accountChip.setVisibility(View.VISIBLE);
+            accountChip.setText(account.getDisplayName());
+            accountChip.setChipBackgroundColor(ColorStateList.valueOf(account.getChipColor()));
+        } else {
+            accountChip.setVisibility(View.GONE);
+        }
 
         Address fromAddress = null;
         Address[] fromAddresses = message.getFrom();

--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -11,6 +11,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <Space
+            android:id="@+id/margin_top"
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.google.android.material.chip.Chip
             android:id="@+id/chip"
             android:layout_width="wrap_content"
@@ -25,6 +31,13 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:chipBackgroundColor="#1976D2"
             tools:text="Account name" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/top_margin_barrier"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="chip,margin_top" />
 
         <com.fsck.k9.ui.helper.BottomBaselineTextView
             android:id="@+id/subject"
@@ -41,6 +54,8 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/flagged"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/top_margin_barrier"
+            app:layout_constraintVertical_bias="0.0"
             tools:text="Message subject" />
 
         <ImageView


### PR DESCRIPTION
Only show account chip in message view when the associated message list contains messages from more than one account.

### When coming from the Unified Inbox (with more than one account) or a search over multiple accounts
<img src="https://user-images.githubusercontent.com/218061/191245676-2d709b3a-a81e-455e-881c-d42dc1e31555.png" alt="image" width=300> 

### When coming from a message list only displaying messages from one account
<img src="https://user-images.githubusercontent.com/218061/191245765-632949c7-2562-48c6-abf4-ec5d0274313d.png" alt="image" width=300>
