### PR TITLE
Remove volume key navigation for list views

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -189,9 +189,6 @@ object K9 : EarlyInit {
     var isUseVolumeKeysForNavigation = false
 
     @JvmStatic
-    var isUseVolumeKeysForListNavigation = false
-
-    @JvmStatic
     var isShowUnifiedInbox = true
 
     @JvmStatic
@@ -298,7 +295,6 @@ object K9 : EarlyInit {
         isSensitiveDebugLoggingEnabled = storage.getBoolean("enableSensitiveLogging", false)
         isShowAnimations = storage.getBoolean("animations", true)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
-        isUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false)
         isShowUnifiedInbox = storage.getBoolean("showUnifiedInbox", true)
         isShowStarredCount = storage.getBoolean("showStarredCount", false)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
@@ -370,7 +366,6 @@ object K9 : EarlyInit {
         editor.putEnum("backgroundOperations", backgroundOps)
         editor.putBoolean("animations", isShowAnimations)
         editor.putBoolean("useVolumeKeysForNavigation", isUseVolumeKeysForNavigation)
-        editor.putBoolean("useVolumeKeysForListNavigation", isUseVolumeKeysForListNavigation)
         editor.putBoolean("autofitWidth", isAutoFitWidth)
         editor.putBoolean("quietTimeEnabled", isQuietTimeEnabled)
         editor.putBoolean("notificationDuringQuietTimeEnabled", isNotificationDuringQuietTimeEnabled)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -184,9 +184,6 @@ public class GeneralSettingsDescriptions {
                 new V(16, new LegacyThemeSetting(AppTheme.LIGHT)),
                 new V(24, new SubThemeSetting(SubTheme.USE_GLOBAL))
         ));
-        s.put("useVolumeKeysForListNavigation", Settings.versions(
-                new V(1, new BooleanSetting(false))
-        ));
         s.put("useVolumeKeysForNavigation", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 81;
+    public static final int VERSION = 82;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_general_settings_values.xml
@@ -210,9 +210,4 @@
         <item>spam</item>
     </string-array>
 
-    <string-array name="volume_navigation_values" translatable="false">
-        <item>message</item>
-        <item>list</item>
-    </string-array>
-
 </resources>

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/K9ListActivity.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/K9ListActivity.java
@@ -1,58 +1,16 @@
 package com.fsck.k9.activity;
 
 
-import android.view.KeyEvent;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 
-import com.fsck.k9.K9;
 import com.fsck.k9.ui.base.K9Activity;
 
 
 public abstract class K9ListActivity extends K9Activity {
     protected ListAdapter adapter;
     protected ListView list;
-
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // Shortcuts that work no matter what is selected
-        if (K9.isUseVolumeKeysForListNavigation() &&
-                (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
-                        keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
-
-            final ListView listView = getListView();
-
-            int currentPosition = listView.getSelectedItemPosition();
-            if (currentPosition == AdapterView.INVALID_POSITION || listView.isInTouchMode()) {
-                currentPosition = listView.getFirstVisiblePosition();
-            }
-
-            if (keyCode == KeyEvent.KEYCODE_VOLUME_UP && currentPosition > 0) {
-                listView.setSelection(currentPosition - 1);
-            } else if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN &&
-                    currentPosition < listView.getCount()) {
-                listView.setSelection(currentPosition + 1);
-            }
-
-            return true;
-        }
-
-        return super.onKeyDown(keyCode, event);
-    }
-
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        // Swallow these events too to avoid the audible notification of a volume change
-        if (K9.isUseVolumeKeysForListNavigation() &&
-                (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
-                keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
-            return true;
-        }
-
-        return super.onKeyUp(keyCode, event);
-    }
 
     protected ListView getListView() {
         if (list == null) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -759,9 +759,6 @@ open class MessageList :
                 ) {
                     showPreviousMessage()
                     return true
-                } else if (displayMode != DisplayMode.MESSAGE_VIEW && K9.isUseVolumeKeysForListNavigation) {
-                    messageListFragment!!.onMoveUp()
-                    return true
                 }
             }
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
@@ -769,9 +766,6 @@ open class MessageList :
                     K9.isUseVolumeKeysForNavigation
                 ) {
                     showNextMessage()
-                    return true
-                } else if (displayMode != DisplayMode.MESSAGE_VIEW && K9.isUseVolumeKeysForListNavigation) {
-                    messageListFragment!!.onMoveDown()
                     return true
                 }
             }
@@ -910,7 +904,7 @@ open class MessageList :
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         // Swallow these events too to avoid the audible notification of a volume change
-        if (K9.isUseVolumeKeysForListNavigation) {
+        if (K9.isUseVolumeKeysForNavigation) {
             if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
                 Timber.v("Swallowed key up.")
                 return true

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -1123,14 +1123,6 @@ class MessageListFragment :
         super.onStop()
     }
 
-    fun onMoveUp() {
-        // FIXME
-    }
-
-    fun onMoveDown() {
-        // FIXME
-    }
-
     fun openMessage(messageReference: MessageReference) {
         fragmentListener.openMessage(messageReference)
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -41,6 +41,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_timezone" -> K9.isHideTimeZone
             "debug_logging" -> K9.isDebugLoggingEnabled
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled
+            "volume_navigation" -> K9.isUseVolumeKeysForNavigation
             else -> defValue
         }
     }
@@ -70,6 +71,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_timezone" -> K9.isHideTimeZone = value
             "debug_logging" -> K9.isDebugLoggingEnabled = value
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled = value
+            "volume_navigation" -> K9.isUseVolumeKeysForNavigation = value
             else -> return
         }
 
@@ -189,12 +191,6 @@ class GeneralSettingsDataStore(
                     if (K9.isMessageViewSpamActionVisible) add("spam")
                 }
             }
-            "volume_navigation" -> {
-                mutableSetOf<String>().apply {
-                    if (K9.isUseVolumeKeysForNavigation) add("message")
-                    if (K9.isUseVolumeKeysForListNavigation) add("list")
-                }
-            }
             else -> defValues
         }
     }
@@ -216,10 +212,6 @@ class GeneralSettingsDataStore(
                 K9.isMessageViewMoveActionVisible = "move" in checkedValues
                 K9.isMessageViewCopyActionVisible = "copy" in checkedValues
                 K9.isMessageViewSpamActionVisible = "spam" in checkedValues
-            }
-            "volume_navigation" -> {
-                K9.isUseVolumeKeysForNavigation = "message" in checkedValues
-                K9.isUseVolumeKeysForListNavigation = "list" in checkedValues
             }
             else -> return
         }

--- a/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -157,9 +157,4 @@
         <item>@string/spam_action</item>
     </string-array>
 
-    <string-array name="volume_navigation_entries">
-        <item>@string/volume_navigation_message</item>
-        <item>@string/volume_navigation_list</item>
-    </string-array>
-
 </resources>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -817,9 +817,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="animations_title">Animation</string>
     <string name="animations_summary">Use gaudy visual effects</string>
 
-    <string name="volume_navigation_title">Volume key navigation</string>
-    <string name="volume_navigation_message">In message views</string>
-    <string name="volume_navigation_list">In list views</string>
+    <string name="volume_navigation_title">Volume key navigation in message view</string>
 
     <string name="show_unified_inbox_title">Show Unified Inbox</string>
     <string name="show_starred_count_title">Show starred count</string>

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -358,10 +358,7 @@
         android:title="@string/interaction_preferences"
         search:ignore="true">
 
-        <MultiSelectListPreference
-            android:dialogTitle="@string/volume_navigation_title"
-            android:entries="@array/volume_navigation_entries"
-            android:entryValues="@array/volume_navigation_values"
+        <CheckBoxPreference
             android:key="volume_navigation"
             android:title="@string/volume_navigation_title" />
 


### PR DESCRIPTION
In list views the volume key navigation is only really useful if you have a hardware keyboard to trigger further actions on the selected list item. But when using a keyboard, you can use the cursor keys to navigate list items.

Mainly we're removing this feature because it would be extra effort to make it work with `RecyclerView`.