### PR TITLE
Restore previous logic to select the next message after deleting the current one

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1198,9 +1198,15 @@ open class MessageList :
     }
 
     private fun showLogicalNextMessage(): Boolean {
-        return when (lastDirection) {
+        val couldMoveInLastDirection = when (lastDirection) {
             Direction.NEXT -> showNextMessage()
             Direction.PREVIOUS -> showPreviousMessage()
+        }
+
+        return if (couldMoveInLastDirection) {
+            true
+        } else {
+            showNextMessage() || showPreviousMessage()
         }
     }
 


### PR DESCRIPTION
This got lost when we added swiping between messages.

Fixes #6315