### PR TITLE
Remove `trimIndent()` from production code

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
@@ -70,30 +70,30 @@ internal class CopyMessageOperations(
     private fun copyMessageParts(database: SQLiteDatabase, messageId: Long): Long {
         return database.rawQuery(
             """
-            SELECT                 
-                message_parts.id,
-                message_parts.type,
-                message_parts.root,
-                message_parts.parent,
-                message_parts.seq,
-                message_parts.mime_type,
-                message_parts.decoded_body_size,
-                message_parts.display_name,
-                message_parts.header,
-                message_parts.encoding,
-                message_parts.charset,
-                message_parts.data_location,
-                message_parts.data,
-                message_parts.preamble,
-                message_parts.epilogue,
-                message_parts.boundary,
-                message_parts.content_id,
-                message_parts.server_extra 
-            FROM messages 
-            JOIN message_parts ON (message_parts.root = messages.message_part_id) 
-            WHERE messages.id = ? 
-            ORDER BY message_parts.seq
-            """.trimIndent(),
+SELECT
+  message_parts.id,
+  message_parts.type,
+  message_parts.root,
+  message_parts.parent,
+  message_parts.seq,
+  message_parts.mime_type,
+  message_parts.decoded_body_size,
+  message_parts.display_name,
+  message_parts.header,
+  message_parts.encoding,
+  message_parts.charset,
+  message_parts.data_location,
+  message_parts.data,
+  message_parts.preamble,
+  message_parts.epilogue,
+  message_parts.boundary,
+  message_parts.content_id,
+  message_parts.server_extra 
+FROM messages 
+JOIN message_parts ON (message_parts.root = messages.message_part_id) 
+WHERE messages.id = ? 
+ORDER BY message_parts.seq
+            """,
             arrayOf(messageId.toString())
         ).use { cursor ->
             if (!cursor.moveToNext()) error("No message part found for message with ID $messageId")
@@ -201,10 +201,8 @@ internal class CopyMessageOperations(
 
     private fun copyFulltextEntry(database: SQLiteDatabase, newMessageId: Long, messageId: Long) {
         database.execSQL(
-            """
-            INSERT OR REPLACE INTO messages_fulltext (docid, fulltext)
-              SELECT ?, fulltext FROM messages_fulltext WHERE docid = ?
-            """.trimIndent(),
+            "INSERT OR REPLACE INTO messages_fulltext (docid, fulltext) " +
+                "SELECT ?, fulltext FROM messages_fulltext WHERE docid = ?",
             arrayOf(newMessageId.toString(), messageId.toString())
         )
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/DeleteFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/DeleteFolderOperations.kt
@@ -19,16 +19,16 @@ internal class DeleteFolderOperations(
     private fun SQLiteDatabase.deleteMessagePartFiles(folderServerId: String) {
         rawQuery(
             """
-            SELECT message_parts.id 
-            FROM folders 
-            JOIN messages ON (messages.folder_id = folders.id) 
-            JOIN message_parts ON (
-                message_parts.root = messages.message_part_id 
-                AND 
-                message_parts.data_location = $DATA_LOCATION_ON_DISK
-            ) 
-            WHERE folders.server_id = ?
-            """.trimIndent(),
+SELECT message_parts.id 
+FROM folders 
+JOIN messages ON (messages.folder_id = folders.id) 
+JOIN message_parts ON (
+  message_parts.root = messages.message_part_id 
+  AND 
+  message_parts.data_location = $DATA_LOCATION_ON_DISK
+) 
+WHERE folders.server_id = ?
+            """,
             arrayOf(folderServerId)
         ).use { cursor ->
             while (cursor.moveToNext()) {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/DeleteMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/DeleteMessageOperations.kt
@@ -38,12 +38,12 @@ internal class DeleteMessageOperations(
         return lockableDatabase.execute(false) { database ->
             database.rawQuery(
                 """
-                SELECT messages.id, messages.message_part_id, COUNT(threads2.id) 
-                FROM messages 
-                LEFT JOIN threads threads1 ON (threads1.message_id = messages.id)  
-                LEFT JOIN threads threads2 ON (threads2.parent = threads1.id) 
-                WHERE folder_id = ? AND uid = ?
-                """.trimIndent(),
+SELECT messages.id, messages.message_part_id, COUNT(threads2.id) 
+FROM messages 
+LEFT JOIN threads threads1 ON (threads1.message_id = messages.id)  
+LEFT JOIN threads threads2 ON (threads2.parent = threads1.id) 
+WHERE folder_id = ? AND uid = ?
+                """,
                 arrayOf(folderId.toString(), messageServerId)
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
@@ -128,12 +128,12 @@ internal class DeleteMessageOperations(
     private fun SQLiteDatabase.getEmptyThreadParent(messageId: Long): Long? {
         return rawQuery(
             """
-            SELECT messages.id 
-            FROM threads threads1 
-            JOIN threads threads2 ON (threads1.parent = threads2.id) 
-            JOIN messages ON (threads2.message_id = messages.id AND messages.empty = 1) 
-            WHERE threads1.message_id = ?
-            """.trimIndent(),
+SELECT messages.id 
+FROM threads threads1 
+JOIN threads threads2 ON (threads1.parent = threads2.id) 
+JOIN messages ON (threads2.message_id = messages.id AND messages.empty = 1) 
+WHERE threads1.message_id = ?
+            """,
             arrayOf(messageId.toString())
         ).use { cursor ->
             if (cursor.moveToFirst() && !cursor.isNull(0)) {
@@ -151,11 +151,11 @@ internal class DeleteMessageOperations(
     private fun SQLiteDatabase.hasThreadChildren(messageId: Long): Boolean {
         return rawQuery(
             """
-            SELECT COUNT(threads2.id) 
-            FROM threads threads1 
-            JOIN threads threads2 ON (threads2.parent = threads1.id) 
-            WHERE threads1.message_id = ?
-            """.trimIndent(),
+SELECT COUNT(threads2.id) 
+FROM threads threads1 
+JOIN threads threads2 ON (threads2.parent = threads1.id) 
+WHERE threads1.message_id = ?
+            """,
             arrayOf(messageId.toString())
         ).use { cursor ->
             cursor.moveToFirst() && !cursor.isNull(0) && cursor.getLong(0) > 0L

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
@@ -70,22 +70,22 @@ internal class RetrieveFolderOperations(private val lockableDatabase: LockableDa
 
             val query =
                 """
-                SELECT ${FOLDER_COLUMNS.joinToString()}, (
-                    SELECT COUNT(messages.id) 
-                    FROM messages 
-                    WHERE messages.folder_id = folders.id 
-                      AND messages.empty = 0 AND messages.deleted = 0 
-                      AND (messages.read = 0 OR folders.id = ?)
-                ), (
-                    SELECT COUNT(messages.id) 
-                    FROM messages 
-                    WHERE messages.folder_id = folders.id 
-                      AND messages.empty = 0 AND messages.deleted = 0 
-                      AND messages.flagged = 1
-                )
-                FROM folders
-                $displayModeSelection
-                """.trimIndent()
+SELECT ${FOLDER_COLUMNS.joinToString()}, (
+  SELECT COUNT(messages.id) 
+  FROM messages 
+  WHERE messages.folder_id = folders.id 
+    AND messages.empty = 0 AND messages.deleted = 0 
+    AND (messages.read = 0 OR folders.id = ?)
+), (
+  SELECT COUNT(messages.id) 
+  FROM messages 
+  WHERE messages.folder_id = folders.id 
+    AND messages.empty = 0 AND messages.deleted = 0 
+    AND messages.flagged = 1
+)
+FROM folders
+$displayModeSelection
+                """
 
             db.rawQuery(query, arrayOf(outboxFolderIdOrZero.toString())).use { cursor ->
                 val cursorFolderAccessor = CursorFolderAccessor(cursor)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
@@ -20,32 +20,32 @@ internal class RetrieveMessageListOperations(private val lockableDatabase: Locka
         return lockableDatabase.execute(false) { database ->
             database.rawQuery(
                 """
-                SELECT 
-                    messages.id AS id, 
-                    uid, 
-                    folder_id, 
-                    sender_list, 
-                    to_list, 
-                    cc_list, 
-                    date, 
-                    internal_date, 
-                    subject, 
-                    preview_type,
-                    preview, 
-                    read, 
-                    flagged, 
-                    answered, 
-                    forwarded, 
-                    attachment_count, 
-                    root
-                FROM messages
-                JOIN threads ON (threads.message_id = messages.id)
-                LEFT JOIN FOLDERS ON (folders.id = messages.folder_id)
-                WHERE
-                    ($selection)
-                    AND empty = 0 AND deleted = 0
-                ORDER BY $sortOrder
-                """.trimIndent(),
+SELECT 
+  messages.id AS id, 
+  uid, 
+  folder_id, 
+  sender_list, 
+  to_list, 
+  cc_list, 
+  date, 
+  internal_date, 
+  subject, 
+  preview_type,
+  preview, 
+  read, 
+  flagged, 
+  answered, 
+  forwarded, 
+  attachment_count, 
+  root
+FROM messages
+JOIN threads ON (threads.message_id = messages.id)
+LEFT JOIN FOLDERS ON (folders.id = messages.folder_id)
+WHERE
+  ($selection)
+  AND empty = 0 AND deleted = 0
+ORDER BY $sortOrder
+                """,
                 selectionArgs,
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = false)
@@ -72,60 +72,60 @@ internal class RetrieveMessageListOperations(private val lockableDatabase: Locka
         return lockableDatabase.execute(false) { database ->
             database.rawQuery(
                 """
-                SELECT 
-                    messages.id AS id, 
-                    uid, 
-                    folder_id, 
-                    sender_list, 
-                    to_list, 
-                    cc_list, 
-                    aggregated.date AS date, 
-                    aggregated.internal_date AS internal_date, 
-                    subject, 
-                    preview_type,
-                    preview, 
-                    aggregated.read AS read, 
-                    aggregated.flagged AS flagged, 
-                    aggregated.answered AS answered, 
-                    aggregated.forwarded AS forwarded, 
-                    aggregated.attachment_count AS attachment_count, 
-                    root, 
-                    aggregated.thread_count AS thread_count
-                FROM (
-                    SELECT 
-                        threads.root AS thread_root,
-                        MAX(date) AS date,
-                        MAX(internal_date) AS internal_date,
-                        MIN(read) AS read,
-                        MAX(flagged) AS flagged,
-                        MIN(answered) AS answered,
-                        MIN(forwarded) AS forwarded,
-                        SUM(attachment_count) AS attachment_count,
-                        COUNT(threads.root) AS thread_count                        
-                    FROM messages
-                    JOIN threads ON (threads.message_id = messages.id)
-                    JOIN folders ON (folders.id = messages.folder_id)
-                    WHERE
-                        threads.root IN (
-                            SELECT threads.root 
-                            FROM messages
-                            JOIN threads ON (threads.message_id = messages.id)
-                            WHERE messages.empty = 0 AND messages.deleted = 0
-                        )
-                        AND ($selection)
-                        AND messages.empty = 0 AND messages.deleted = 0
-                    GROUP BY threads.root
-                ) aggregated
-                JOIN threads ON (threads.root = aggregated.thread_root)
-                JOIN messages ON (
-                    messages.id = threads.message_id
-                    AND messages.empty = 0 AND messages.deleted = 0
-                    AND messages.date = aggregated.date
-                )
-                JOIN folders ON (folders.id = messages.folder_id)
-                GROUP BY threads.root
-                ORDER BY $orderBy
-                """.trimIndent(),
+SELECT 
+  messages.id AS id, 
+  uid, 
+  folder_id, 
+  sender_list, 
+  to_list, 
+  cc_list, 
+  aggregated.date AS date, 
+  aggregated.internal_date AS internal_date, 
+  subject, 
+  preview_type,
+  preview, 
+  aggregated.read AS read, 
+  aggregated.flagged AS flagged, 
+  aggregated.answered AS answered, 
+  aggregated.forwarded AS forwarded, 
+  aggregated.attachment_count AS attachment_count, 
+  root, 
+  aggregated.thread_count AS thread_count
+FROM (
+  SELECT 
+    threads.root AS thread_root,
+    MAX(date) AS date,
+    MAX(internal_date) AS internal_date,
+    MIN(read) AS read,
+    MAX(flagged) AS flagged,
+    MIN(answered) AS answered,
+    MIN(forwarded) AS forwarded,
+    SUM(attachment_count) AS attachment_count,
+    COUNT(threads.root) AS thread_count                        
+  FROM messages
+  JOIN threads ON (threads.message_id = messages.id)
+  JOIN folders ON (folders.id = messages.folder_id)
+  WHERE
+    threads.root IN (
+      SELECT threads.root 
+      FROM messages
+      JOIN threads ON (threads.message_id = messages.id)
+      WHERE messages.empty = 0 AND messages.deleted = 0
+    )
+    AND ($selection)
+    AND messages.empty = 0 AND messages.deleted = 0
+  GROUP BY threads.root
+) aggregated
+JOIN threads ON (threads.root = aggregated.thread_root)
+JOIN messages ON (
+  messages.id = threads.message_id
+  AND messages.empty = 0 AND messages.deleted = 0
+  AND messages.date = aggregated.date
+)
+JOIN folders ON (folders.id = messages.folder_id)
+GROUP BY threads.root
+ORDER BY $orderBy
+                """,
                 selectionArgs,
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = true)
@@ -145,32 +145,32 @@ internal class RetrieveMessageListOperations(private val lockableDatabase: Locka
         return lockableDatabase.execute(false) { database ->
             database.rawQuery(
                 """
-                SELECT 
-                    messages.id AS id, 
-                    uid, 
-                    folder_id, 
-                    sender_list, 
-                    to_list, 
-                    cc_list, 
-                    date, 
-                    internal_date, 
-                    subject, 
-                    preview_type,
-                    preview, 
-                    read, 
-                    flagged, 
-                    answered, 
-                    forwarded, 
-                    attachment_count, 
-                    root
-                FROM threads 
-                JOIN messages ON (messages.id = threads.message_id)
-                LEFT JOIN FOLDERS ON (folders.id = messages.folder_id)
-                WHERE
-                    root = ?
-                    AND empty = 0 AND deleted = 0
-                ORDER BY $sortOrder
-                """.trimIndent(),
+SELECT 
+  messages.id AS id, 
+  uid, 
+  folder_id, 
+  sender_list, 
+  to_list, 
+  cc_list, 
+  date, 
+  internal_date, 
+  subject, 
+  preview_type,
+  preview, 
+  read, 
+  flagged, 
+  answered, 
+  forwarded, 
+  attachment_count, 
+  root
+FROM threads 
+JOIN messages ON (messages.id = threads.message_id)
+LEFT JOIN FOLDERS ON (folders.id = messages.folder_id)
+WHERE
+  root = ?
+  AND empty = 0 AND deleted = 0
+ORDER BY $sortOrder
+                """,
                 arrayOf(threadId.toString()),
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = false)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
@@ -20,11 +20,11 @@ internal class ThreadMessageOperations {
     fun getMessageThreadHeaders(database: SQLiteDatabase, messageId: Long): ThreadHeaders {
         return database.rawQuery(
             """
-            SELECT messages.message_id, message_parts.header 
-            FROM messages 
-            LEFT JOIN message_parts ON (messages.message_part_id = message_parts.id) 
-            WHERE messages.id = ?
-            """.trimIndent(),
+SELECT messages.message_id, message_parts.header 
+FROM messages 
+LEFT JOIN message_parts ON (messages.message_part_id = message_parts.id) 
+WHERE messages.id = ?
+            """,
             arrayOf(messageId.toString()),
         ).use { cursor ->
             if (!cursor.moveToFirst()) error("Message not found: $messageId")
@@ -157,14 +157,14 @@ internal class ThreadMessageOperations {
 
         return db.rawQuery(
             """
-            SELECT t.id, t.message_id, t.root, t.parent 
-            FROM messages m 
-            LEFT JOIN threads t ON (t.message_id = m.id) 
-            WHERE m.folder_id = ? AND m.message_id = ? 
-            ${if (onlyEmpty) "AND m.empty = 1 " else ""}
-            ORDER BY m.id 
-            LIMIT 1
-            """.trimIndent(),
+SELECT t.id, t.message_id, t.root, t.parent 
+FROM messages m 
+LEFT JOIN threads t ON (t.message_id = m.id) 
+WHERE m.folder_id = ? AND m.message_id = ? 
+${if (onlyEmpty) "AND m.empty = 1 " else ""}
+ORDER BY m.id 
+LIMIT 1
+            """,
             arrayOf(folderId.toString(), messageIdHeader)
         ).use { cursor ->
             if (cursor.moveToFirst()) {


### PR DESCRIPTION
Unfortunately, the `trimIndent()` operation isn't performed at compile time. Until that is the case we should avoid it in production code. It's creating unnecessary work for the garbage collector.