### PR TITLE
Darken msg list view when in dark mode back as before 2edf42f9f8179d248feef3609fa16f946eabade3

### DIFF
--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -200,7 +200,7 @@
         <item name="messageListSelectedBackgroundColor">#ff347489</item>
         <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
         <item name="messageListReadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListUnreadItemBackgroundColor">#ff505050</item>
+        <item name="messageListUnreadItemBackgroundColor">#ff303030</item>
         <item name="messageListThreadCountForegroundColor">?android:attr/colorBackground</item>
         <item name="messageListThreadCountBackground">@drawable/thread_count_box_dark</item>
         <item name="messageListActiveItemBackgroundColor">#ff33b5e5</item>


### PR DESCRIPTION
Since 2edf42f9f8179d248feef3609fa16f946eabade3 merge in september, list view of msg in dark mode are super white for some reason, this MR is to go back to a better darken color more in phase with other part of the interface.

Before:
![Light](https://user-images.githubusercontent.com/56130419/192159719-b9cb3f61-9091-421d-b651-203f22eb2a06.jpg)


After:
![Dark](https://user-images.githubusercontent.com/56130419/192159726-953ac48c-9bf7-4dcf-ba39-f4466eeac50c.jpg)

