### PR TITLE
Change message list divider to follow the views opacity

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -16,7 +16,6 @@ import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DefaultItemAnimator
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -50,6 +49,7 @@ import com.fsck.k9.ui.messagelist.MessageListAppearance
 import com.fsck.k9.ui.messagelist.MessageListConfig
 import com.fsck.k9.ui.messagelist.MessageListInfo
 import com.fsck.k9.ui.messagelist.MessageListItem
+import com.fsck.k9.ui.messagelist.MessageListItemDecoration
 import com.fsck.k9.ui.messagelist.MessageListViewModel
 import com.fsck.k9.ui.messagelist.MessageSortOverride
 import java.util.concurrent.Future
@@ -237,7 +237,7 @@ class MessageListFragment :
     private fun initializeRecyclerView(view: View) {
         recyclerView = view.findViewById(R.id.message_list)
 
-        val itemDecoration = DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
+        val itemDecoration = MessageListItemDecoration(requireContext())
         recyclerView.addItemDecoration(itemDecoration)
         recyclerView.itemAnimator = DefaultItemAnimator().apply {
             supportsChangeAnimations = false

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemDecoration.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemDecoration.kt
@@ -1,0 +1,52 @@
+package com.fsck.k9.ui.messagelist
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.view.View
+import androidx.core.graphics.withSave
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ItemDecoration
+import com.fsck.k9.ui.resolveDrawableAttribute
+import kotlin.math.roundToInt
+
+/**
+ * An [ItemDecoration] that uses the alpha and visibility values of a view when drawing the divider.
+ *
+ * Based on [androidx.recyclerview.widget.DividerItemDecoration].
+ */
+class MessageListItemDecoration(context: Context) : ItemDecoration() {
+    private val divider: Drawable = context.theme.resolveDrawableAttribute(android.R.attr.listDivider)
+    private val bounds = Rect()
+
+    override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        if (parent.layoutManager == null) return
+
+        canvas.withSave {
+            val childCount = parent.childCount
+            for (i in 0 until childCount) {
+                val child = parent.getChildAt(i)
+                if (!child.isVisible) {
+                    continue
+                }
+
+                parent.getDecoratedBoundsWithMargins(child, bounds)
+
+                val left = 0
+                val right = parent.width
+                val bottom = bounds.bottom + child.translationY.roundToInt()
+                val top = bottom - divider.intrinsicHeight
+
+                divider.setBounds(left, top, right, bottom)
+                divider.alpha = (child.alpha * 255).toInt()
+                divider.draw(canvas)
+            }
+        }
+    }
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        outRect.set(0, 0, 0, divider.intrinsicHeight)
+    }
+}


### PR DESCRIPTION
This makes some animations look a bit nicer.

For example removing messages (animations slowed down 10x):

### Before
https://user-images.githubusercontent.com/218061/193320773-735ab98d-534a-496f-94b3-1f3dd26bbec0.mp4

### After
https://user-images.githubusercontent.com/218061/193320795-e8f114b1-2fee-4e44-87ed-c054912f6008.mp4


