### PR TITLE
Fix crash/undefined behvior when clicking on 2 messages at the same time

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -388,6 +388,10 @@ class MessageListFragment :
     }
 
     override fun onMessageClicked(messageListItem: MessageListItem) {
+        if(!isActive){
+            return
+        }
+        isActive = false
         if (adapter.selectedCount > 0) {
             toggleMessageSelect(messageListItem)
         } else {


### PR DESCRIPTION
I don't know if that fix is sufficient, but it works on my device.

To reproduce it, juts click on the same message (not a thread, from the same account) and if you get lucky the app will crash. 
Original trace:
```
10-03 19:18:26.293 25972 25972 D AndroidRuntime: Shutting down VM
10-03 19:18:26.299 25972 25972 E AndroidRuntime: FATAL EXCEPTION: main
10-03 19:18:26.299 25972 25972 E AndroidRuntime: Process: com.fsck.k9, PID: 25972
10-03 19:18:26.299 25972 25972 E AndroidRuntime: java.lang.IllegalStateException: Fragment MessageListFragment{2188141} (19c7d5bd-e2ff-4463-bef0-037f4ed96266 id=0x7f090270) not attached to a context.
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.fragment.app.Fragment.requireContext(Fragment.java:967)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.fragment.app.Fragment.getDefaultViewModelCreationExtras(Fragment.java:474)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.fragment.app.FragmentViewModelLazyKt$createViewModelLazy$1.invoke(FragmentViewModelLazy.kt:198)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.fragment.app.FragmentViewModelLazyKt$createViewModelLazy$1.invoke(FragmentViewModelLazy.kt:195)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.lifecycle.ViewModelLazy.getValue(ViewModelLazy.kt:52)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at androidx.lifecycle.ViewModelLazy.getValue(ViewModelLazy.kt:35)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListFragment.getViewModel(MessageListFragment.kt:68)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.activity.MessageList.openMessage(MessageList.kt:1023)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListFragment.openMessage(MessageListFragment.kt:1127)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListFragment.onMessageClicked(MessageListFragment.kt:397)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListAdapter.messageClickedListener$lambda-6(MessageListAdapter.kt:174)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListAdapter.$r8$lambda$eGP6kgU1B27QiIncRujnT-sMY1w(Unknown Source:0)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.fsck.k9.fragment.MessageListAdapter$$ExternalSyntheticLambda1.onClick(Unknown Source:2)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.view.View.performClick(View.java:7792)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.view.View.performClickInternal(View.java:7769)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.view.View.access$3800(View.java:910)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.view.View$PerformClick.run(View.java:30218)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:938)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:226)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:313)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:8751)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
10-03 19:18:26.299 25972 25972 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```
 