### PR TITLE
Set app theme before the first Activity is started

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
@@ -40,6 +40,9 @@ internal class RealGeneralSettingsManager(
     }
 
     override fun getSettingsFlow(): Flow<GeneralSettings> {
+        // Make sure to load settings now if they haven't been loaded already. This will also update settingsFlow.
+        getSettings()
+
         return settingsFlow.distinctUntilChanged()
     }
 

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/ThemeManager.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/ThemeManager.kt
@@ -64,7 +64,7 @@ class ThemeManager(
             .onEach {
                 updateAppTheme(it)
             }
-            .launchIn(appCoroutineScope + Dispatchers.Main)
+            .launchIn(appCoroutineScope + Dispatchers.Main.immediate)
     }
 
     private fun updateAppTheme(appTheme: AppTheme) {


### PR DESCRIPTION
If `AppCompatDelegate.setDefaultNightMode()` is called after the first Activity has already been started, the user might see the wrong theme being used briefly.

Fixes #6347