### PR TITLE
Change minimum size for message list widget to 2x2 cells

### DIFF
--- a/app/k9mail/src/main/res/xml/message_list_widget_info.xml
+++ b/app/k9mail/src/main/res/xml/message_list_widget_info.xml
@@ -4,7 +4,7 @@
     android:initialLayout="@layout/message_list_widget_layout"
     android:minHeight="180dp"
     android:minWidth="250dp"
-    android:minResizeWidth="180dp"
+    android:minResizeWidth="110dp"
     android:minResizeHeight="110dp"
     android:previewImage="@drawable/message_list_widget_preview"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
See https://developer.android.com/guide/practices/ui_guidelines/widget_design.html#anatomy_determining_size

Fixes #6352