### PR TITLE
Stop using `white-space: pre-wrap` for the HTML signature

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/TextBodyBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/message/TextBodyBuilder.java
@@ -188,8 +188,7 @@ class TextBodyBuilder {
     private String getSignatureHtml() {
         String signature = "";
         if (!isEmpty(mSignature)) {
-            signature = "<div style='white-space: pre-wrap'>" +
-                    HtmlConverter.textToHtmlFragmentWithOriginalWhitespace(mSignature) + "</div>";
+            signature = HtmlConverter.textToHtmlFragment(mSignature);
         }
         return signature;
     }

--- a/app/core/src/test/java/com/fsck/k9/message/TextBodyBuilderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/TextBodyBuilderTest.kt
@@ -18,8 +18,8 @@ class TextBodyBuilderTest(val testData: TestData) {
         private const val QUOTED_HTML_TAGS_END = "</body>\n</html>"
         private const val QUOTED_HTML_TAGS_START = "<!DOCTYPE html><html><head></head><body>"
         private const val SIGNATURE_TEXT = "-- \r\n\r\nsignature\r\n  indented second line"
-        private const val SIGNATURE_TEXT_HTML = "<div style='white-space: pre-wrap'>" +
-            "<div class='k9mail-signature'>-- <br><br>signature<br>  indented second line</div></div>"
+        private const val SIGNATURE_TEXT_HTML =
+            "<div class='k9mail-signature'>-- <br><br>signature<br>\u00A0 indented second line</div>"
 
         @JvmStatic
         @Parameterized.Parameters(name = "{index}: {0}")


### PR DESCRIPTION
Apparently line breaks display inconsistently across browser implementations when using both `<br>` and the CSS rule `white-space: pre-wrap`.

See https://forum.k9mail.app/t/extra-line-breaks-appear-in-email-signature/5520