### PR TITLE
Small `MessageListFragment` cleanup

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -5,7 +5,6 @@ import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.os.Parcelable
 import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.Menu
@@ -175,10 +174,6 @@ class MessageListFragment :
 
     private fun restoreSelectedMessages(savedInstanceState: Bundle) {
         rememberedSelected = savedInstanceState.getLongArray(STATE_SELECTED_MESSAGES)?.toSet()
-    }
-
-    fun restoreListState(savedListState: Parcelable) {
-        recyclerView?.layoutManager?.onRestoreInstanceState(savedListState)
     }
 
     private fun decodeArguments(): MessageListFragment? {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -76,8 +76,9 @@ class MessageListFragment :
 
     private lateinit var fragmentListener: MessageListFragmentListener
 
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
+    private var recyclerView: RecyclerView? = null
+    private var swipeRefreshLayout: SwipeRefreshLayout? = null
+
     private lateinit var adapter: MessageListAdapter
 
     private lateinit var accountUuids: Array<String>
@@ -157,6 +158,8 @@ class MessageListFragment :
             setMessageList(messageListInfo)
         }
 
+        adapter = createMessageListAdapter()
+
         isInitialized = true
     }
 
@@ -175,7 +178,7 @@ class MessageListFragment :
     }
 
     fun restoreListState(savedListState: Parcelable) {
-        recyclerView.layoutManager?.onRestoreInstanceState(savedListState)
+        recyclerView?.layoutManager?.onRestoreInstanceState(savedListState)
     }
 
     private fun decodeArguments(): MessageListFragment? {
@@ -212,15 +215,36 @@ class MessageListFragment :
         return this
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.message_list_fragment, container, false).apply {
-            initializeSwipeRefreshLayout(this)
-            initializeRecyclerView(this)
+    private fun createMessageListAdapter(): MessageListAdapter {
+        return MessageListAdapter(
+            theme = requireActivity().theme,
+            res = resources,
+            layoutInflater = layoutInflater,
+            contactsPictureLoader = ContactPicture.getContactPictureLoader(),
+            listItemListener = this,
+            appearance = messageListAppearance,
+            relativeDateTimeFormatter = RelativeDateTimeFormatter(requireContext(), clock)
+        ).apply {
+            activeMessage = this@MessageListFragment.activeMessage
         }
     }
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.message_list_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        initializeSwipeRefreshLayout(view)
+        initializeRecyclerView(view)
+
+        // This needs to be done before loading the message list below
+        initializeSortSettings()
+
+        loadMessageList()
+    }
+
     private fun initializeSwipeRefreshLayout(view: View) {
-        swipeRefreshLayout = view.findViewById(R.id.swiperefresh)
+        val swipeRefreshLayout = view.findViewById<SwipeRefreshLayout>(R.id.swiperefresh)
 
         if (isRemoteSearchAllowed) {
             swipeRefreshLayout.setOnRefreshListener { onRemoteSearchRequested() }
@@ -230,49 +254,23 @@ class MessageListFragment :
 
         // Disable pull-to-refresh until the message list has been loaded
         swipeRefreshLayout.isEnabled = false
+
+        this.swipeRefreshLayout = swipeRefreshLayout
     }
 
     private fun initializeRecyclerView(view: View) {
-        recyclerView = view.findViewById(R.id.message_list)
+        val recyclerView = view.findViewById<RecyclerView>(R.id.message_list)
 
         val itemDecoration = MessageListItemDecoration(requireContext())
         recyclerView.addItemDecoration(itemDecoration)
 
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.itemAnimator = MessageListItemAnimator()
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-
-        initializeMessageList()
-
-        // This needs to be done before loading the message list below
-        initializeSortSettings()
-        loadMessageList()
-    }
-
-    private fun initializeMessageList() {
-        val theme = requireActivity().theme
-
-        adapter = MessageListAdapter(
-            theme = theme,
-            res = resources,
-            layoutInflater = layoutInflater,
-            contactsPictureLoader = ContactPicture.getContactPictureLoader(),
-            listItemListener = this,
-            appearance = messageListAppearance,
-            relativeDateTimeFormatter = RelativeDateTimeFormatter(requireContext(), clock)
-        )
-
-        adapter.activeMessage = activeMessage
-
-        recyclerView.adapter = adapter
 
         val itemTouchHelper = ItemTouchHelper(
             MessageListSwipeCallback(
                 resources,
-                resourceProvider = SwipeResourceProvider(theme),
+                resourceProvider = SwipeResourceProvider(requireActivity().theme),
                 swipeActionSupportProvider,
                 swipeRightAction = K9.swipeRightAction,
                 swipeLeftAction = K9.swipeLeftAction,
@@ -281,6 +279,10 @@ class MessageListFragment :
             )
         )
         itemTouchHelper.attachToRecyclerView(recyclerView)
+
+        recyclerView.adapter = adapter
+
+        this.recyclerView = recyclerView
     }
 
     private fun initializeSortSettings() {
@@ -363,7 +365,7 @@ class MessageListFragment :
 
     fun progress(progress: Boolean) {
         if (!progress) {
-            swipeRefreshLayout.isRefreshing = false
+            swipeRefreshLayout?.isRefreshing = false
         }
 
         fragmentListener.setMessageListProgressEnabled(progress)
@@ -423,6 +425,9 @@ class MessageListFragment :
     }
 
     override fun onDestroyView() {
+        recyclerView = null
+        swipeRefreshLayout = null
+
         if (isNewMessagesView && !requireActivity().isChangingConfigurations) {
             messagingController.clearNewMessages(account)
         }
@@ -502,7 +507,7 @@ class MessageListFragment :
         val queryString = localSearch.remoteSearchArguments
 
         isRemoteSearch = true
-        swipeRefreshLayout.isEnabled = false
+        swipeRefreshLayout?.isEnabled = false
 
         remoteSearchFuture = messagingController.searchRemoteMessages(
             searchAccount,
@@ -1159,6 +1164,7 @@ class MessageListFragment :
 
     private val selectedMessageListItem: MessageListItem?
         get() {
+            val recyclerView = recyclerView ?: return null
             val focusedView = recyclerView.focusedChild ?: return null
             val viewHolder = recyclerView.findContainingViewHolder(focusedView) as? MessageViewHolder ?: return null
             return adapter.getItemById(viewHolder.uniqueId)
@@ -1271,8 +1277,10 @@ class MessageListFragment :
             return
         }
 
-        swipeRefreshLayout.isRefreshing = false
-        swipeRefreshLayout.isEnabled = isPullToRefreshAllowed
+        swipeRefreshLayout?.let { swipeRefreshLayout ->
+            swipeRefreshLayout.isRefreshing = false
+            swipeRefreshLayout.isEnabled = isPullToRefreshAllowed
+        }
 
         if (isThreadDisplay) {
             if (messageListItems.isNotEmpty()) {
@@ -1389,6 +1397,7 @@ class MessageListFragment :
     }
 
     private fun scrollToMessage(messageReference: MessageReference) {
+        val recyclerView = recyclerView ?: return
         val messageListItem = adapter.getItem(messageReference) ?: return
         val position = adapter.getPosition(messageListItem) ?: return
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListHandler.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListHandler.java
@@ -5,7 +5,6 @@ import java.lang.ref.WeakReference;
 
 import android.app.Activity;
 import android.os.Handler;
-import android.os.Parcelable;
 
 /**
  * This class is used to run operations that modify UI elements in the UI thread.
@@ -22,7 +21,6 @@ public class MessageListHandler extends Handler {
     private static final int ACTION_PROGRESS = 3;
     private static final int ACTION_REMOTE_SEARCH_FINISHED = 4;
     private static final int ACTION_GO_BACK = 5;
-    private static final int ACTION_RESTORE_LIST_POSITION = 6;
 
     private WeakReference<MessageListFragment> mFragment;
 
@@ -68,14 +66,6 @@ public class MessageListHandler extends Handler {
         sendMessage(msg);
     }
 
-    public void restoreListPosition(Parcelable savedListState) {
-        MessageListFragment fragment = mFragment.get();
-        if (fragment != null) {
-            android.os.Message msg = android.os.Message.obtain(this, ACTION_RESTORE_LIST_POSITION, savedListState);
-            sendMessage(msg);
-        }
-    }
-
     @Override
     public void handleMessage(android.os.Message msg) {
         MessageListFragment fragment = mFragment.get();
@@ -115,11 +105,6 @@ public class MessageListHandler extends Handler {
             }
             case ACTION_GO_BACK: {
                 fragment.goBack();
-                break;
-            }
-            case ACTION_RESTORE_LIST_POSITION: {
-                Parcelable savedListState = (Parcelable) msg.obj;
-                fragment.restoreListState(savedListState);
                 break;
             }
         }


### PR DESCRIPTION
- Restructure the code so `MessageListAdapter` is only created once and initialized early.
- Remove view references in `onDestroyView()`
- Remove unused code

This hopefully fixes a couple of `lateinit`-related crashes we're seeing in the Google Play Developer Console.