### PR TITLE
Fix opening messages in a thread from the message list widget

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -384,10 +384,6 @@ public class LocalMessage extends MimeMessage {
         return mFolder;
     }
 
-    public String getUri() {
-        return "k9mail://messages/" +  getAccount().getAccountNumber() + "/" + getFolder().getDatabaseId() + "/" + getUid();
-    }
-
     @Override
     public void writeTo(OutputStream out) throws IOException, MessagingException {
         if (headerNeedsUpdating) {

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
@@ -1,6 +1,6 @@
 package app.k9mail.ui.widget.list
 
-import android.net.Uri
+import com.fsck.k9.controller.MessageReference
 
 internal data class MessageListItem(
     val displayName: String,
@@ -10,8 +10,8 @@ internal data class MessageListItem(
     val isRead: Boolean,
     val hasAttachments: Boolean,
     val threadCount: Int,
-    val uri: Uri,
     val accountColor: Int,
+    val messageReference: MessageReference,
     val uniqueId: Long,
 
     val sortSubject: String?,

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
@@ -9,6 +9,7 @@ internal data class MessageListItem(
     val preview: String,
     val isRead: Boolean,
     val hasAttachments: Boolean,
+    val threadCount: Int,
     val uri: Uri,
     val accountColor: Int,
     val uniqueId: Long,

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
@@ -1,7 +1,7 @@
 package app.k9mail.ui.widget.list
 
-import android.net.Uri
 import com.fsck.k9.Account
+import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mailstore.MessageDetailsAccessor
 import com.fsck.k9.mailstore.MessageMapper
@@ -28,7 +28,6 @@ internal class MessageListItemMapper(
         } else {
             messageHelper.getSenderDisplayName(displayAddress).toString()
         }
-        val uri = Uri.parse("k9mail://messages/${account.accountNumber}/${message.folderId}/${message.messageServerId}")
 
         return MessageListItem(
             displayName = displayName,
@@ -38,8 +37,8 @@ internal class MessageListItemMapper(
             isRead = message.isRead,
             hasAttachments = message.hasAttachments,
             threadCount = message.threadCount,
-            uri = uri,
             accountColor = account.chipColor,
+            messageReference = MessageReference(account.uuid, message.folderId, message.messageServerId),
             uniqueId = uniqueId,
             sortSubject = message.subject,
             sortMessageDate = message.messageDate,

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
@@ -37,6 +37,7 @@ internal class MessageListItemMapper(
             preview = previewText,
             isRead = message.isRead,
             hasAttachments = message.hasAttachments,
+            threadCount = message.threadCount,
             uri = uri,
             accountColor = account.chipColor,
             uniqueId = uniqueId,

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListRemoteViewFactory.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListRemoteViewFactory.kt
@@ -75,6 +75,13 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
         remoteView.setTextViewText(R.id.mail_date, item.displayDate)
         remoteView.setTextViewText(R.id.mail_preview, item.preview)
 
+        if (item.threadCount > 1) {
+            remoteView.setTextViewText(R.id.thread_count, item.threadCount.toString())
+            remoteView.setInt(R.id.thread_count, "setVisibility", View.VISIBLE)
+        } else {
+            remoteView.setInt(R.id.thread_count, "setVisibility", View.GONE)
+        }
+
         val textColor = getTextColor(item)
         remoteView.setTextColor(R.id.sender, textColor)
         remoteView.setTextColor(R.id.mail_subject, textColor)

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListRemoteViewFactory.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListRemoteViewFactory.kt
@@ -1,7 +1,6 @@
 package app.k9mail.ui.widget.list
 
 import android.content.Context
-import android.content.Intent
 import android.graphics.Typeface
 import android.text.SpannableString
 import android.text.style.StyleSpan
@@ -11,6 +10,7 @@ import android.widget.RemoteViewsService.RemoteViewsFactory
 import androidx.core.content.ContextCompat
 import com.fsck.k9.Account.SortType
 import com.fsck.k9.K9
+import com.fsck.k9.activity.MessageList
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
 import org.koin.core.component.KoinComponent
@@ -94,10 +94,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
             remoteView.setInt(R.id.attachment, "setVisibility", View.GONE)
         }
 
-        val intent = Intent().apply {
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            data = item.uri
-        }
+        val intent = MessageList.actionDisplayMessageTemplateFillIntent(item.messageReference)
         remoteView.setOnClickFillInIntent(R.id.mail_list_item, intent)
 
         remoteView.setInt(R.id.chip, "setBackgroundColor", item.accountColor)

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetProvider.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetProvider.kt
@@ -45,10 +45,13 @@ open class MessageListWidgetProvider : AppWidgetProvider() {
     }
 
     private fun viewActionTemplatePendingIntent(context: Context): PendingIntent {
-        val intent = Intent(context, MessageList::class.java).apply {
-            action = Intent.ACTION_VIEW
-        }
-        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or FLAG_MUTABLE)
+        val intent = MessageList.actionDisplayMessageTemplateIntent(
+            context,
+            openInUnifiedInbox = true,
+            messageViewOnly = true
+        )
+
+        return PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT or FLAG_MUTABLE)
     }
 
     private fun viewUnifiedInboxPendingIntent(context: Context): PendingIntent {

--- a/app/ui/message-list-widget/src/main/res/layout/message_list_widget_list_item.xml
+++ b/app/ui/message-list-widget/src/main/res/layout/message_list_widget_list_item.xml
@@ -40,13 +40,28 @@
             tools:visibility="visible" />
 
         <TextView
+            android:id="@+id/thread_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toStartOf="@id/attachment"
+            android:layout_marginStart="4dp"
+            android:maxLines="1"
+            android:paddingRight="4dip"
+            android:paddingBottom="1dip"
+            android:paddingLeft="4dip"
+            android:textSize="16sp"
+            android:textColor="?android:attr/colorBackground"
+            android:background="@drawable/thread_count_box_light"
+            tools:text="3" />
+
+        <TextView
             android:id="@+id/sender"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:layout_gravity="start"
-            android:layout_toStartOf="@id/attachment"
+            android:layout_toStartOf="@id/thread_count"
             android:ellipsize="end"
             android:maxLines="1"
             android:textSize="16sp"


### PR DESCRIPTION
The message list widget now follows the "threaded view" setting. 

Fixes #6397