### PR TITLE
Don't throw when calling `MessageStore.getMessageServerId()`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -75,8 +75,10 @@ internal class DraftOperations(
             messagingController.queuePendingCommand(account, command)
         } else {
             val fakeMessageServerId = messageStore.getMessageServerId(messageId)
-            val command = PendingAppend.create(folderId, fakeMessageServerId)
-            messagingController.queuePendingCommand(account, command)
+            if (fakeMessageServerId != null) {
+                val command = PendingAppend.create(folderId, fakeMessageServerId)
+                messagingController.queuePendingCommand(account, command)
+            }
         }
 
         messagingController.processPendingCommands(account)

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1615,9 +1615,11 @@ public class MessagingController {
 
             if (!sentFolder.isLocalOnly()) {
                 String destinationUid = messageStore.getMessageServerId(destinationMessageId);
-                PendingCommand command = PendingAppend.create(sentFolderId, destinationUid);
-                queuePendingCommand(account, command);
-                processPendingCommands(account);
+                if (destinationUid != null) {
+                    PendingCommand command = PendingAppend.create(sentFolderId, destinationUid);
+                    queuePendingCommand(account, command);
+                    processPendingCommands(account);
+                }
             }
         }
 
@@ -1901,9 +1903,10 @@ public class MessagingController {
 
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         String messageServerId = messageStore.getMessageServerId(messageId);
-        MessageReference messageReference = new MessageReference(account.getUuid(), folderId, messageServerId);
-
-        deleteMessage(messageReference);
+        if (messageServerId != null) {
+            MessageReference messageReference = new MessageReference(account.getUuid(), folderId, messageServerId);
+            deleteMessage(messageReference);
+        }
     }
 
     public void deleteThreads(final List<MessageReference> messages) {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -91,7 +91,7 @@ interface MessageStore {
     /**
      * Retrieve the server ID for a given message.
      */
-    fun getMessageServerId(messageId: Long): String
+    fun getMessageServerId(messageId: Long): String?
 
     /**
      * Retrieve the server IDs for the given messages.

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -78,7 +78,7 @@ class K9MessageStore(
         updateMessageOperations.clearNewMessageState()
     }
 
-    override fun getMessageServerId(messageId: Long): String {
+    override fun getMessageServerId(messageId: Long): String? {
         return retrieveMessageOperations.getMessageServerId(messageId)
     }
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageOperations.kt
@@ -4,7 +4,6 @@ import androidx.core.database.getLongOrNull
 import com.fsck.k9.K9
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Header
-import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.internet.MimeHeader
 import com.fsck.k9.mail.message.MessageHeaderParser
 import com.fsck.k9.mailstore.LockableDatabase
@@ -13,7 +12,7 @@ import java.util.Date
 
 internal class RetrieveMessageOperations(private val lockableDatabase: LockableDatabase) {
 
-    fun getMessageServerId(messageId: Long): String {
+    fun getMessageServerId(messageId: Long): String? {
         return lockableDatabase.execute(false) { database ->
             database.query(
                 "messages",
@@ -25,7 +24,7 @@ internal class RetrieveMessageOperations(private val lockableDatabase: LockableD
                 if (cursor.moveToFirst()) {
                     cursor.getString(0)
                 } else {
-                    throw MessagingException("Message [ID: $messageId] not found in database")
+                    null
                 }
             }
         }

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveMessageOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveMessageOperationsTest.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.storage.messages
 
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Header
-import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.crlf
 import com.fsck.k9.storage.RobolectricTest
 import com.google.common.truth.Truth.assertThat
@@ -14,9 +13,11 @@ class RetrieveMessageOperationsTest : RobolectricTest() {
     private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
     private val retrieveMessageOperations = RetrieveMessageOperations(lockableDatabase)
 
-    @Test(expected = MessagingException::class)
+    @Test
     fun `get message server id of non-existent message`() {
-        retrieveMessageOperations.getMessageServerId(42)
+        val messageServerId = retrieveMessageOperations.getMessageServerId(42)
+
+        assertThat(messageServerId).isNull()
     }
 
     @Test


### PR DESCRIPTION
Return `null` when the message can no longer be found in the message store.

Fixes #6432