### PR TITLE
Don't use smooth scrolling when moving to previous/next message

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -172,9 +172,7 @@ class MessageViewContainerFragment : Fragment() {
         val newPosition = viewPager.currentItem - 1
         return if (newPosition >= 0) {
             setActiveMessage(newPosition)
-
-            val smoothScroll = true
-            viewPager.setCurrentItem(newPosition, smoothScroll)
+            viewPager.setCurrentItem(newPosition, /* smoothScroll = */ false)
             true
         } else {
             false
@@ -185,9 +183,7 @@ class MessageViewContainerFragment : Fragment() {
         val newPosition = viewPager.currentItem + 1
         return if (newPosition < adapter.itemCount) {
             setActiveMessage(newPosition)
-
-            val smoothScroll = true
-            viewPager.setCurrentItem(newPosition, smoothScroll)
+            viewPager.setCurrentItem(newPosition, /* smoothScroll = */ false)
             true
         } else {
             false


### PR DESCRIPTION
This seems to work around a bug where sometimes the scroll operation isn't completed and the `MessageViewFragment` being scrolled to is never marked as active.

Fixes #6346