### PR TITLE
Change `ThunderbirdDiscovery` to support all specified autoconfig URLs

### DIFF
--- a/app/autodiscovery/api/src/main/java/com/fsck/k9/autodiscovery/api/ConnectionSettingsDiscovery.kt
+++ b/app/autodiscovery/api/src/main/java/com/fsck/k9/autodiscovery/api/ConnectionSettingsDiscovery.kt
@@ -4,13 +4,7 @@ import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 
 interface ConnectionSettingsDiscovery {
-    fun discover(email: String, target: DiscoveryTarget): DiscoveryResults?
-}
-
-enum class DiscoveryTarget(val outgoing: Boolean, val incoming: Boolean) {
-    OUTGOING(true, false),
-    INCOMING(false, true),
-    INCOMING_AND_OUTGOING(true, true)
+    fun discover(email: String): DiscoveryResults?
 }
 
 data class DiscoveryResults(val incoming: List<DiscoveredServerSettings>, val outgoing: List<DiscoveredServerSettings>)

--- a/app/autodiscovery/providersxml/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
+++ b/app/autodiscovery/providersxml/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import com.fsck.k9.autodiscovery.api.ConnectionSettingsDiscovery
 import com.fsck.k9.autodiscovery.api.DiscoveredServerSettings
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 import com.fsck.k9.helper.EmailHelper
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
@@ -19,7 +18,7 @@ class ProvidersXmlDiscovery(
     private val oAuthConfigurationProvider: OAuthConfigurationProvider
 ) : ConnectionSettingsDiscovery {
 
-    override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
+    override fun discover(email: String): DiscoveryResults? {
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
 
         val provider = findProviderForDomain(domain) ?: return null

--- a/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.autodiscovery.providersxml
 
 import androidx.test.core.app.ApplicationProvider
 import com.fsck.k9.RobolectricTest
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.oauth.OAuthConfiguration
@@ -17,7 +16,7 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
 
     @Test
     fun discover_withGmailDomain_shouldReturnCorrectSettings() {
-        val connectionSettings = providersXmlDiscovery.discover("user@gmail.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val connectionSettings = providersXmlDiscovery.discover("user@gmail.com")
 
         assertThat(connectionSettings).isNotNull()
         with(connectionSettings!!.incoming.first()) {
@@ -37,7 +36,7 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
     @Test
     fun discover_withUnknownDomain_shouldReturnNull() {
         val connectionSettings = providersXmlDiscovery.discover(
-            "user@not.present.in.providers.xml.example", DiscoveryTarget.INCOMING_AND_OUTGOING
+            "user@not.present.in.providers.xml.example"
         )
 
         assertThat(connectionSettings).isNull()

--- a/app/autodiscovery/srvrecords/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
+++ b/app/autodiscovery/srvrecords/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.autodiscovery.srvrecords
 import com.fsck.k9.autodiscovery.api.ConnectionSettingsDiscovery
 import com.fsck.k9.autodiscovery.api.DiscoveredServerSettings
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 import com.fsck.k9.helper.EmailHelper
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
@@ -12,19 +11,19 @@ class SrvServiceDiscovery(
     private val srvResolver: MiniDnsSrvResolver
 ) : ConnectionSettingsDiscovery {
 
-    override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
+    override fun discover(email: String): DiscoveryResults? {
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
         val mailServicePriority = compareBy<MailService> { it.priority }.thenByDescending { it.security }
 
-        val outgoingSettings = if (target.outgoing)
-            listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION).flatMap { srvResolver.lookup(domain, it) }
-                .sortedWith(mailServicePriority).map { newServerSettings(it, email) }
-        else listOf()
+        val outgoingSettings = listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION)
+            .flatMap { srvResolver.lookup(domain, it) }
+            .sortedWith(mailServicePriority)
+            .map { newServerSettings(it, email) }
 
-        val incomingSettings = if (target.incoming)
-            listOf(SrvType.IMAPS, SrvType.IMAP).flatMap { srvResolver.lookup(domain, it) }
-                .sortedWith(mailServicePriority).map { newServerSettings(it, email) }
-        else listOf()
+        val incomingSettings = listOf(SrvType.IMAPS, SrvType.IMAP)
+            .flatMap { srvResolver.lookup(domain, it) }
+            .sortedWith(mailServicePriority)
+            .map { newServerSettings(it, email) }
 
         return DiscoveryResults(incoming = incomingSettings, outgoing = outgoingSettings)
     }

--- a/app/autodiscovery/srvrecords/src/test/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscoveryTest.kt
+++ b/app/autodiscovery/srvrecords/src/test/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscoveryTest.kt
@@ -1,15 +1,11 @@
 package com.fsck.k9.autodiscovery.srvrecords
 
-import com.fsck.k9.autodiscovery.api.DiscoveredServerSettings
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 import com.fsck.k9.mail.ConnectionSecurity
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 
 class SrvServiceDiscoveryTest {
 
@@ -18,7 +14,7 @@ class SrvServiceDiscoveryTest {
         val srvResolver = newMockSrvResolver()
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val result = srvServiceDiscovery.discover("test@example.com")
 
         assertEquals(DiscoveryResults(listOf(), listOf()), result)
     }
@@ -33,7 +29,7 @@ class SrvServiceDiscoveryTest {
         )
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val result = srvServiceDiscovery.discover("test@example.com")
 
         assertEquals(2, result!!.incoming.size)
         assertEquals(0, result.outgoing.size)
@@ -57,7 +53,7 @@ class SrvServiceDiscoveryTest {
         )
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val result = srvServiceDiscovery.discover("test@example.com")
 
         assertEquals(0, result!!.incoming.size)
         assertEquals(2, result.outgoing.size)
@@ -133,7 +129,7 @@ class SrvServiceDiscoveryTest {
         )
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val result = srvServiceDiscovery.discover("test@example.com")
 
         assertEquals(
             listOf(
@@ -153,54 +149,6 @@ class SrvServiceDiscoveryTest {
             ),
             result?.incoming?.map { it.host }
         )
-    }
-
-    @Test
-    fun discover_whenOnlyOutgoingTrue_shouldOnlyFetchOutgoing() {
-        val srvResolver = newMockSrvResolver(
-            submissionServices = listOf(
-                newMailService(
-                    host = "smtp.example.com",
-                    port = 465,
-                    srvType = SrvType.SUBMISSIONS,
-                    security = ConnectionSecurity.SSL_TLS_REQUIRED,
-                    priority = 0
-                )
-            )
-        )
-
-        val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.OUTGOING)
-
-        verify(srvResolver).lookup("example.com", SrvType.SUBMISSIONS)
-        verify(srvResolver).lookup("example.com", SrvType.SUBMISSION)
-        verifyNoMoreInteractions(srvResolver)
-        assertEquals(1, result!!.outgoing.size)
-        assertEquals(listOf<DiscoveredServerSettings>(), result.incoming)
-    }
-
-    @Test
-    fun discover_whenOnlyIncomingTrue_shouldOnlyFetchIncoming() {
-        val srvResolver = newMockSrvResolver(
-            imapsServices = listOf(
-                newMailService(
-                    host = "imaps.example.com",
-                    port = 993,
-                    srvType = SrvType.IMAPS,
-                    security = ConnectionSecurity.SSL_TLS_REQUIRED,
-                    priority = 0
-                )
-            )
-        )
-
-        val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com", DiscoveryTarget.INCOMING)
-
-        verify(srvResolver).lookup("example.com", SrvType.IMAPS)
-        verify(srvResolver).lookup("example.com", SrvType.IMAP)
-        verifyNoMoreInteractions(srvResolver)
-        assertEquals(1, result!!.incoming.size)
-        assertEquals(listOf<DiscoveredServerSettings>(), result.outgoing)
     }
 
     private fun newMailService(

--- a/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigFetcher.kt
+++ b/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigFetcher.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
-import com.fsck.k9.helper.EmailHelper
 import java.io.InputStream
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -8,8 +7,7 @@ import okhttp3.Request
 
 class ThunderbirdAutoconfigFetcher(private val okHttpClient: OkHttpClient) {
 
-    fun fetchAutoconfigFile(email: String): InputStream? {
-        val url = getAutodiscoveryAddress(email)
+    fun fetchAutoconfigFile(url: HttpUrl): InputStream? {
         val request = Request.Builder().url(url).build()
 
         val response = okHttpClient.newCall(request).execute()
@@ -18,22 +16,6 @@ class ThunderbirdAutoconfigFetcher(private val okHttpClient: OkHttpClient) {
             response.body?.byteStream()
         } else {
             null
-        }
-    }
-
-    companion object {
-        // address described at:
-        // https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration#Configuration_server_at_ISP
-        internal fun getAutodiscoveryAddress(email: String): HttpUrl {
-            val domain = EmailHelper.getDomainFromEmailAddress(email)
-            requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
-
-            return HttpUrl.Builder()
-                .scheme("https")
-                .host(domain)
-                .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
-                .addQueryParameter("emailaddress", email)
-                .build()
         }
     }
 }

--- a/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProvider.kt
+++ b/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProvider.kt
@@ -1,0 +1,47 @@
+package com.fsck.k9.autodiscovery.thunderbird
+
+import com.fsck.k9.helper.EmailHelper
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+class ThunderbirdAutoconfigUrlProvider {
+    fun getAutoconfigUrls(email: String): List<HttpUrl> {
+        val domain = EmailHelper.getDomainFromEmailAddress(email)
+        requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
+
+        return listOf(
+            createProviderUrl(domain, email),
+            createDomainUrl(scheme = "https", domain),
+            createDomainUrl(scheme = "http", domain),
+            createIspDbUrl(domain)
+        )
+    }
+
+    private fun createProviderUrl(domain: String?, email: String): HttpUrl {
+        // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
+        return HttpUrl.Builder()
+            .scheme("https")
+            .host("autoconfig.$domain")
+            .addEncodedPathSegments("mail/config-v1.1.xml")
+            .addQueryParameter("emailaddress", email)
+            .build()
+    }
+
+    private fun createDomainUrl(scheme: String, domain: String): HttpUrl {
+        // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
+        // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
+        return HttpUrl.Builder()
+            .scheme(scheme)
+            .host(domain)
+            .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
+            .build()
+    }
+
+    private fun createIspDbUrl(domain: String): HttpUrl {
+        // https://autoconfig.thunderbird.net/v1.1/{domain}
+        return "https://autoconfig.thunderbird.net/v1.1/".toHttpUrl()
+            .newBuilder()
+            .addPathSegment(domain)
+            .build()
+    }
+}

--- a/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
+++ b/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
@@ -2,14 +2,13 @@ package com.fsck.k9.autodiscovery.thunderbird
 
 import com.fsck.k9.autodiscovery.api.ConnectionSettingsDiscovery
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 
 class ThunderbirdDiscovery(
     private val fetcher: ThunderbirdAutoconfigFetcher,
     private val parser: ThunderbirdAutoconfigParser
 ) : ConnectionSettingsDiscovery {
 
-    override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
+    override fun discover(email: String): DiscoveryResults? {
         val autoconfigInputStream = fetcher.fetchAutoconfigFile(email) ?: return null
 
         return autoconfigInputStream.use {

--- a/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
+++ b/app/autodiscovery/thunderbird/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
@@ -4,16 +4,24 @@ import com.fsck.k9.autodiscovery.api.ConnectionSettingsDiscovery
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
 
 class ThunderbirdDiscovery(
+    private val urlProvider: ThunderbirdAutoconfigUrlProvider,
     private val fetcher: ThunderbirdAutoconfigFetcher,
     private val parser: ThunderbirdAutoconfigParser
 ) : ConnectionSettingsDiscovery {
 
     override fun discover(email: String): DiscoveryResults? {
-        val autoconfigInputStream = fetcher.fetchAutoconfigFile(email) ?: return null
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(email)
 
-        return autoconfigInputStream.use {
-            parser.parseSettings(it, email)
-        }
+        return autoconfigUrls
+            .asSequence()
+            .mapNotNull { autoconfigUrl ->
+                fetcher.fetchAutoconfigFile(autoconfigUrl)?.use { inputStream ->
+                    parser.parseSettings(inputStream, email)
+                }
+            }
+            .firstOrNull { result ->
+                result.incoming.isNotEmpty() || result.outgoing.isNotEmpty()
+            }
     }
 
     override fun toString(): String = "Thunderbird autoconfig"

--- a/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
+++ b/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
@@ -169,13 +169,4 @@ class ThunderbirdAutoconfigTest {
             )
         )
     }
-
-    @Test
-    fun generatedUrls() {
-        val autoDiscoveryAddress = ThunderbirdAutoconfigFetcher.getAutodiscoveryAddress("test@metacode.biz")
-
-        assertThat(autoDiscoveryAddress.toString()).isEqualTo(
-            "https://metacode.biz/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40metacode.biz"
-        )
-    }
 }

--- a/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProviderTest.kt
+++ b/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProviderTest.kt
@@ -1,0 +1,20 @@
+package com.fsck.k9.autodiscovery.thunderbird
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ThunderbirdAutoconfigUrlProviderTest {
+    private val urlProvider = ThunderbirdAutoconfigUrlProvider()
+
+    @Test
+    fun `getAutoconfigUrls with ASCII email address`() {
+        val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
+
+        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+            "https://autoconfig.thunderbird.net/v1.1/domain.example"
+        )
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.kt
@@ -17,7 +17,6 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.account.AccountCreator
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection
 import com.fsck.k9.autodiscovery.api.DiscoveredServerSettings
-import com.fsck.k9.autodiscovery.api.DiscoveryTarget
 import com.fsck.k9.autodiscovery.providersxml.ProvidersXmlDiscovery
 import com.fsck.k9.helper.SimpleTextWatcher
 import com.fsck.k9.helper.Utility.requiredFieldValid
@@ -311,7 +310,7 @@ class AccountSetupBasics : K9Activity() {
     }
 
     private fun providersXmlDiscoveryDiscover(email: String): ConnectionSettings? {
-        val discoveryResults = providersXmlDiscovery.discover(email, DiscoveryTarget.INCOMING_AND_OUTGOING)
+        val discoveryResults = providersXmlDiscovery.discover(email)
         if (discoveryResults == null || discoveryResults.incoming.isEmpty() || discoveryResults.outgoing.isEmpty()) {
             return null
         }


### PR DESCRIPTION
Note: `ThunderbirdDiscovery` is currently not used by the app.