### PR TITLE
Various swipe fixes

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1542,7 +1542,9 @@ class MessageListFragment :
             SwipeAction.ToggleSelection -> true
             SwipeAction.ToggleRead -> !isOutbox
             SwipeAction.ToggleStar -> !isOutbox
-            SwipeAction.Archive -> !isOutbox && item.account.hasArchiveFolder()
+            SwipeAction.Archive -> {
+                !isOutbox && item.account.hasArchiveFolder() && item.folderId != item.account.archiveFolderId
+            }
             SwipeAction.Delete -> true
             SwipeAction.Move -> !isOutbox && messagingController.isMoveCapable(item.account)
             SwipeAction.Spam -> !isOutbox && item.account.hasSpamFolder() && item.folderId != item.account.spamFolderId

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1517,8 +1517,9 @@ class MessageListFragment :
                     onSpam(listOf(item.messageReference))
                 }
                 SwipeAction.Move -> {
-                    notifyItemChanged(item)
-                    onMove(item.messageReference)
+                    val messageReference = item.messageReference
+                    resetSwipedView(messageReference)
+                    onMove(messageReference)
                 }
             }
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
@@ -69,6 +69,9 @@ class MessageListSwipeCallback(
     }
 
     override fun onSwipeStarted(viewHolder: ViewHolder, direction: Int) {
+        // Mark view to prevent MessageListItemAnimator from interfering with swipe animations
+        viewHolder.markAsSwiped(true)
+
         val swipeAction = when (direction) {
             ItemTouchHelper.RIGHT -> swipeRightAction
             ItemTouchHelper.LEFT -> swipeLeftAction
@@ -90,9 +93,6 @@ class MessageListSwipeCallback(
 
     override fun onSwiped(viewHolder: ViewHolder, direction: Int) {
         val item = viewHolder.messageListItem
-
-        // Mark view to prevent MessageListItemAnimator from interfering with swipe animations
-        viewHolder.markAsSwiped(true)
 
         when (direction) {
             ItemTouchHelper.RIGHT -> listener.onSwipeAction(item, swipeRightAction)

--- a/ui-utils/ItemTouchHelper/src/main/java/app/k9mail/ui/utils/itemtouchhelper/ItemTouchHelper.java
+++ b/ui-utils/ItemTouchHelper/src/main/java/app/k9mail/ui/utils/itemtouchhelper/ItemTouchHelper.java
@@ -938,6 +938,10 @@ public class ItemTouchHelper extends RecyclerView.ItemDecoration
 
     @Override
     public void onChildViewDetachedFromWindow(@NonNull View view) {
+        resetSwipeView(view);
+    }
+
+    private void resetSwipeView(@NonNull View view) {
         removeChildDrawingOrderCallbackIfNecessary(view);
         final ViewHolder holder = mRecyclerView.getChildViewHolder(view);
         if (holder == null) {
@@ -951,6 +955,10 @@ public class ItemTouchHelper extends RecyclerView.ItemDecoration
                 mCallback.clearView(mRecyclerView, holder);
             }
         }
+    }
+
+    public void stopSwipe(@NonNull ViewHolder viewHolder) {
+        resetSwipeView(viewHolder.itemView);
     }
 
     /**


### PR DESCRIPTION
- Stop `MessageListItemAnimator` from running change animations when a message is being swiped (e.g. when the read state changes during swipe and is synced via Push)
- Reset swiped views when canceling a swipe action in the confirmation dialog (delete and spam can be configured to show confirmation dialogs)
- Reset swiped view when moving an item
- Don't enable archive swipe action in archive folder