### PR TITLE
Opt in to the predictive back gesture

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
     <application
         android:name="com.fsck.k9.App"
         android:allowTaskReparenting="false"
+        android:enableOnBackInvokedCallback="true"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
Android 13 (API level 33) introduces a predictive back gesture for Android devices such as phones, large screens, and foldables. This feature lets users preview the destination or other result of a back gesture before fully completing it, allowing them to decide whether to continue or stay in the current view.

See: https://developer.android.com/guide/navigation/predictive-back-gesture
See: https://github.com/thundernest/k-9/issues/6476