### PR TITLE
Message View Redesign: Add "line of death"

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message.xml
+++ b/app/ui/legacy/src/main/res/layout/message.xml
@@ -39,6 +39,11 @@
                 android:visibility="gone"
                 tools:visibility="visible"/>
 
+            <Space
+                android:id="@+id/line_of_death"
+                android:layout_width="match_parent"
+                android:layout_height="8dp" />
+
             <com.fsck.k9.view.ToolableViewAnimator
                 android:id="@+id/message_layout_animator"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Our "line of death" is the space between the message header and the `WebView`.

<img src="https://user-images.githubusercontent.com/218061/203067634-ecaec0ff-9087-4ece-9706-e8458b4e6957.png" alt="image" width=300>

Closes #6394