### PR TITLE
Switch to MaterialComponents themes

### DIFF
--- a/app/ui/base/src/main/res/layout/toolbar.xml
+++ b/app/ui/base/src/main/res/layout/toolbar.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="4dp"/>
+<com.google.android.material.appbar.MaterialToolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/toolbar"
+    style="?attr/toolbarStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize" />

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -238,7 +238,8 @@ class MessageViewFragment :
                 intArrayOf(R.attr.iconActionMarkAsRead)
             }
 
-            requireContext().withStyledAttributes(attrs = drawableAttr) {
+            val toolbarContext = requireActivity().findViewById<View>(R.id.toolbar).context
+            toolbarContext.withStyledAttributes(attrs = drawableAttr) {
                 menu.findItem(R.id.toggle_unread).icon = getDrawable(0)
             }
         }

--- a/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
@@ -8,10 +8,9 @@
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
+        style="?attr/toolbarStyle"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="4dp"
         tools:navigationIcon="@drawable/ic_arrow_back">
 
         <com.fsck.k9.ui.settings.account.AccountSelectionSpinner

--- a/app/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -148,6 +148,7 @@
                 android:textColor="?android:attr/textColorSecondary"
                 tools:text="Oct 27"/>
 
+        <!-- TODO: Replace with an ImageView. MaterialCheckBox comes with a lot of styling that we don't want. -->
         <CheckBox
                 android:id="@+id/star"
                 style="@style/MessageStarStyle"

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <declare-styleable name="K9Styles">
+        <attr name="toolbarColor" format="reference|color" />
         <attr name="bottomBarBackground" format="reference|color" />
         <attr name="iconUnifiedInbox" format="reference" />
         <attr name="iconFolder" format="reference" />

--- a/app/ui/legacy/src/main/res/values/styles.xml
+++ b/app/ui/legacy/src/main/res/values/styles.xml
@@ -107,5 +107,17 @@
         <item name="android:layout_width">match_parent</item>
     </style>
 
+    <style name="Widget.K9.Toolbar" parent="Widget.MaterialComponents.Toolbar.Primary">
+        <item name="android:background">?attr/toolbarColor</item>
+        <item name="titleTextColor">?android:attr/textColorPrimary</item>
+        <item name="subtitleTextColor">?android:attr/textColorSecondary</item>
+        <item name="android:theme">@style/ThemeOverlay.K9.Toolbar</item>
+    </style>
+
+    <style name="ThemeOverlay.K9.Toolbar" parent="">
+        <item name="colorControlNormal">?android:attr/textColorSecondary</item>
+        <item name="actionMenuTextColor">?android:attr/textColorSecondary</item>
+    </style>
+
 </resources>
 

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -6,17 +6,26 @@
     </style>
 
     <!-- Empty base themes that can be easily replaced by RRO (Runtime Resource Overlay) themes -->
-    <style name="Theme.K9.Light.Base" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge" />
-    <style name="Theme.K9.Dark.Base" parent="Theme.MaterialComponents.NoActionBar.Bridge" />
+    <style name="Theme.K9.Light.Base" parent="Theme.MaterialComponents.Light.NoActionBar" />
+    <style name="Theme.K9.Dark.Base" parent="Theme.MaterialComponents.NoActionBar" />
 
     <style name="Theme.K9.Light.Common" parent="Theme.K9.Light.Base">
         <item name="windowActionModeOverlay">true</item>
+
         <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
-        <item name="colorPrimary">@color/material_gray_100</item>
-        <item name="colorPrimaryDark">@color/material_gray_100</item>
+        <item name="android:statusBarColor">@color/material_gray_100</item>
+        <item name="toolbarColor">@color/material_gray_100</item>
+
+        <item name="colorPrimary">@color/material_blue_600</item>
+        <item name="colorPrimaryVariant">@color/material_blue_800</item>
+        <item name="colorSecondary">@color/material_pink_400</item>
+        <item name="colorSecondaryVariant">@color/material_pink_200</item>
         <item name="bottomBarBackground">@color/material_gray_50</item>
 
+        <item name="toolbarStyle">@style/Widget.K9.Toolbar</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+        <item name="textInputStyle">?attr/textInputOutlinedStyle</item>
+
         <item name="iconUnifiedInbox">@drawable/ic_inbox_multiple</item>
         <item name="iconFolder">@drawable/ic_folder</item>
         <item name="iconFolderInbox">@drawable/ic_inbox</item>
@@ -155,12 +164,21 @@
     <style name="Theme.K9.Dark.Common" parent="Theme.K9.Dark.Base">
         <item name="android:navigationBarColor">#000000</item>
         <item name="windowActionModeOverlay">true</item>
+
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
-        <item name="colorPrimary">@color/material_gray_900</item>
-        <item name="colorPrimaryDark">@color/material_gray_900</item>
+        <item name="android:statusBarColor">@color/material_gray_900</item>
+        <item name="toolbarColor">@color/material_gray_900</item>
+
+        <item name="colorPrimary">@color/material_blue_400</item>
+        <item name="colorPrimaryVariant">@color/material_blue_600</item>
+        <item name="colorSecondary">@color/material_pink_300</item>
+        <item name="colorSecondaryVariant">@color/material_pink_500</item>
         <item name="bottomBarBackground">@color/material_gray_900</item>
 
+        <item name="toolbarStyle">@style/Widget.K9.Toolbar</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+        <item name="textInputStyle">?attr/textInputOutlinedStyle</item>
+
         <item name="iconUnifiedInbox">@drawable/ic_inbox_multiple</item>
         <item name="iconFolder">@drawable/ic_folder</item>
         <item name="iconFolderInbox">@drawable/ic_inbox</item>


### PR DESCRIPTION
This will make it easier to implement
- #6395

Once K-9 Mail 6.400 was released, this will also be merged into `main`. It'll allow us to use Jetpack Compose with [MDC-Android Compose Theme Adapter](https://material-components.github.io/material-components-android-compose-theme-adapter/).

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/203352792-973e8407-9600-46a0-af68-979e455c731c.png)|![image](https://user-images.githubusercontent.com/218061/203351972-b4fbe902-d6d4-4888-80a4-f1d9a20f0f0c.png)|
|![image](https://user-images.githubusercontent.com/218061/203352954-305a8d0f-0153-40cb-a4d9-0da615c38dce.png)|![image](https://user-images.githubusercontent.com/218061/203352135-3ea4cc64-f425-44e3-a948-6df5ae588b5e.png)|
|![image](https://user-images.githubusercontent.com/218061/203353055-fd5e2c65-f9e6-4575-9e49-ca7767387d6c.png)|![image](https://user-images.githubusercontent.com/218061/203352548-dc2e60f9-477e-4dae-bedd-4f8004baf265.png)|

We might want to tweak the primary and secondary colors later. I just picked something I thought doesn't look terrible.