### PR TITLE
Fix message header background color

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -75,7 +75,7 @@
         android:id="@+id/participants_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
+        android:background="?attr/messageHeaderBackground"
         android:clickable="true"
         android:focusable="true"
         android:foreground="?attr/selectableItemBackground"

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
 
     <declare-styleable name="K9Styles">
         <attr name="toolbarColor" format="reference|color" />
+        <attr name="messageHeaderBackground" format="reference|color" />
         <attr name="bottomBarBackground" format="reference|color" />
         <attr name="iconUnifiedInbox" format="reference" />
         <attr name="iconFolder" format="reference" />

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -20,6 +20,7 @@
         <item name="colorPrimaryVariant">@color/material_blue_800</item>
         <item name="colorSecondary">@color/material_pink_400</item>
         <item name="colorSecondaryVariant">@color/material_pink_200</item>
+        <item name="messageHeaderBackground">@color/material_gray_100</item>
         <item name="bottomBarBackground">@color/material_gray_50</item>
 
         <item name="toolbarStyle">@style/Widget.K9.Toolbar</item>
@@ -173,6 +174,7 @@
         <item name="colorPrimaryVariant">@color/material_blue_600</item>
         <item name="colorSecondary">@color/material_pink_300</item>
         <item name="colorSecondaryVariant">@color/material_pink_500</item>
+        <item name="messageHeaderBackground">@color/material_gray_900</item>
         <item name="bottomBarBackground">@color/material_gray_900</item>
 
         <item name="toolbarStyle">@style/Widget.K9.Toolbar</item>


### PR DESCRIPTION
We used `?attr/colorPrimary` for the message header background. But #6484 changed this from "toolbar gray" to blue.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/203624027-48884702-28d5-40a0-aa79-e1498d08108f.png)|![image](https://user-images.githubusercontent.com/218061/203623734-53cba58c-a05d-485c-8f86-74d2155ae3b5.png)|
