### PR TITLE
`NotificationActionService` fixes

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
@@ -26,14 +26,15 @@ class NotificationActionService : Service() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         Timber.i("NotificationActionService started with startId = %d", startId)
 
-        startHandleCommand(intent)
+        startHandleCommand(intent, startId)
 
         return START_NOT_STICKY
     }
 
-    private fun startHandleCommand(intent: Intent) {
+    private fun startHandleCommand(intent: Intent, startId: Int) {
         coroutineScope.launch(Dispatchers.IO) {
             handleCommand(intent)
+            stopSelf(startId)
         }
     }
 


### PR DESCRIPTION
- Make `NotificationActionService` handle actions in a background thread.
- Stop `NotificationActionService` after the work is done.