### PR TITLE
Display recipient names

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/AddressFormatter.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/AddressFormatter.kt
@@ -1,0 +1,74 @@
+package com.fsck.k9.helper
+
+import android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import com.fsck.k9.Account
+import com.fsck.k9.Identity
+import com.fsck.k9.mail.Address
+
+/**
+ * Get the display name for an email address.
+ */
+interface AddressFormatter {
+    fun getDisplayName(address: Address): CharSequence
+}
+
+class RealAddressFormatter(
+    private val contactNameProvider: ContactNameProvider,
+    private val account: Account,
+    private val showCorrespondentNames: Boolean,
+    private val showContactNames: Boolean,
+    private val contactNameColor: Int?,
+    private val meText: String
+) : AddressFormatter {
+    override fun getDisplayName(address: Address): CharSequence {
+        val identity = account.findIdentity(address)
+        if (identity != null) {
+            return getIdentityName(identity)
+        }
+
+        return if (!showCorrespondentNames) {
+            address.address
+        } else if (showContactNames) {
+            getContactName(address)
+        } else {
+            buildDisplayName(address)
+        }
+    }
+
+    private fun getIdentityName(identity: Identity): String {
+        return if (account.identities.size == 1) {
+            meText
+        } else {
+            identity.description ?: identity.name ?: identity.email ?: meText
+        }
+    }
+
+    private fun getContactName(address: Address): CharSequence {
+        val contactName = contactNameProvider.getNameForAddress(address.address) ?: return buildDisplayName(address)
+
+        return if (contactNameColor != null) {
+            SpannableString(contactName).apply {
+                setSpan(ForegroundColorSpan(contactNameColor), 0, contactName.length, SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        } else {
+            contactName
+        }
+    }
+
+    private fun buildDisplayName(address: Address): CharSequence {
+        return address.personal?.takeIf {
+            it.isNotBlank() && !it.equals(meText, ignoreCase = true) && !isSpoofAddress(it)
+        } ?: address.address
+    }
+
+    private fun isSpoofAddress(displayName: String): Boolean {
+        val atIndex = displayName.indexOf('@')
+        return if (atIndex > 0) {
+            displayName[atIndex - 1] != '('
+        } else {
+            false
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/helper/ContactNameProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/ContactNameProvider.kt
@@ -1,0 +1,11 @@
+package com.fsck.k9.helper
+
+interface ContactNameProvider {
+    fun getNameForAddress(address: String): String?
+}
+
+class RealContactNameProvider(private val contacts: Contacts) : ContactNameProvider {
+    override fun getNameForAddress(address: String): String? {
+        return contacts.getNameForAddress(address)
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/helper/RealAddressFormatterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/helper/RealAddressFormatterTest.kt
@@ -1,0 +1,206 @@
+package com.fsck.k9.helper
+
+import android.graphics.Color
+import android.text.Spannable
+import android.text.style.ForegroundColorSpan
+import androidx.core.text.getSpans
+import com.fsck.k9.Account
+import com.fsck.k9.Identity
+import com.fsck.k9.RobolectricTest
+import com.fsck.k9.mail.Address
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+private const val IDENTITY_ADDRESS = "me@domain.example"
+private const val ME_TEXT = "me"
+
+class RealAddressFormatterTest : RobolectricTest() {
+    private val contactNameProvider = object : ContactNameProvider {
+        override fun getNameForAddress(address: String): String? {
+            return when (address) {
+                "user1@domain.example" -> "Contact One"
+                "spoof@domain.example" -> "contact@important.example"
+                else -> null
+            }
+        }
+    }
+
+    private val account = Account("uuid").apply {
+        identities += Identity(email = IDENTITY_ADDRESS)
+    }
+
+    @Test
+    fun `single identity`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+
+        assertThat(displayName).isEqualTo(ME_TEXT)
+    }
+
+    @Test
+    fun `multiple identities`() {
+        val account = Account("uuid").apply {
+            identities += Identity(description = "My identity", email = IDENTITY_ADDRESS)
+            identities += Identity(email = "another.one@domain.example")
+        }
+        val addressFormatter = createAddressFormatter(account)
+
+        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+
+        assertThat(displayName).isEqualTo("My identity")
+    }
+
+    @Test
+    fun `identity without a description`() {
+        val account = Account("uuid").apply {
+            identities += Identity(name = "My name", email = IDENTITY_ADDRESS)
+            identities += Identity(email = "another.one@domain.example")
+        }
+        val addressFormatter = createAddressFormatter(account)
+
+        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+
+        assertThat(displayName).isEqualTo("My name")
+    }
+
+    @Test
+    fun `identity without a description and name`() {
+        val account = Account("uuid").apply {
+            identities += Identity(email = IDENTITY_ADDRESS)
+            identities += Identity(email = "another.one@domain.example")
+        }
+        val addressFormatter = createAddressFormatter(account)
+
+        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+
+        assertThat(displayName).isEqualTo(IDENTITY_ADDRESS)
+    }
+
+    @Test
+    fun `email address without display name`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example"))
+
+        assertThat(displayName).isEqualTo("alice@domain.example")
+    }
+
+    @Test
+    fun `email address with display name`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example", "Alice"))
+
+        assertThat(displayName).isEqualTo("Alice")
+    }
+
+    @Test
+    fun `don't look up contact when showContactNames = false`() {
+        val addressFormatter = createAddressFormatter(showContactNames = false)
+
+        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example", "User 1"))
+
+        assertThat(displayName).isEqualTo("User 1")
+    }
+
+    @Test
+    fun `contact lookup`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example"))
+
+        assertThat(displayName).isEqualTo("Contact One")
+    }
+
+    @Test
+    fun `contact lookup despite display name`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example", "User 1"))
+
+        assertThat(displayName).isEqualTo("Contact One")
+    }
+
+    @Test
+    fun `colored contact name`() {
+        val addressFormatter = createAddressFormatter(contactNameColor = Color.RED)
+
+        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example"))
+
+        assertThat(displayName.toString()).isEqualTo("Contact One")
+        assertThat(displayName).isInstanceOf(Spannable::class.java)
+        val spans = (displayName as Spannable).getSpans<ForegroundColorSpan>(0, displayName.length)
+        assertThat(spans.map { it.foregroundColor }).containsExactly(Color.RED)
+    }
+
+    @Test
+    fun `email address with display name but not showing correspondent names`() {
+        val addressFormatter = createAddressFormatter(showCorrespondentNames = false)
+
+        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example", "Alice"))
+
+        assertThat(displayName).isEqualTo("alice@domain.example")
+    }
+
+    @Test
+    fun `do not show display name that looks like an email address`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("mallory@domain.example", "potus@whitehouse.gov"))
+
+        assertThat(displayName).isEqualTo("mallory@domain.example")
+    }
+
+    @Test
+    fun `do show display name that contains an @ preceded by an opening parenthesis`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("gitlab@gitlab.example", "username (@username)"))
+
+        assertThat(displayName).isEqualTo("username (@username)")
+    }
+
+    @Test
+    fun `do show display name that starts with an @`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("address@domain.example", "@username"))
+
+        assertThat(displayName).isEqualTo("@username")
+    }
+
+    @Test
+    fun `spoof prevention doesn't apply to contact names`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("spoof@domain.example", "contact@important.example"))
+
+        assertThat(displayName).isEqualTo("contact@important.example")
+    }
+
+    @Test
+    fun `display name matches me text`() {
+        val addressFormatter = createAddressFormatter()
+
+        val displayName = addressFormatter.getDisplayName(Address("someone_named_me@domain.example", "ME"))
+
+        assertThat(displayName).isEqualTo("someone_named_me@domain.example")
+    }
+
+    private fun createAddressFormatter(
+        account: Account = this.account,
+        showCorrespondentNames: Boolean = true,
+        showContactNames: Boolean = true,
+        contactNameColor: Int? = null
+    ): RealAddressFormatter {
+        return RealAddressFormatter(
+            contactNameProvider = contactNameProvider,
+            account = account,
+            showCorrespondentNames = showCorrespondentNames,
+            showContactNames = showContactNames,
+            contactNameColor = contactNameColor,
+            meText = ME_TEXT
+        )
+    }
+}

--- a/app/k9mail/proguard-rules.pro
+++ b/app/k9mail/proguard-rules.pro
@@ -29,6 +29,10 @@
 -dontnote com.fsck.k9.ui.messageview.**
 -dontnote com.fsck.k9.view.**
 
+-assumevalues class * extends android.view.View {
+    boolean isInEditMode() return false;
+}
+
 -keep public class org.openintents.openpgp.**
 
 -keepclassmembers class * extends androidx.appcompat.widget.SearchView {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
@@ -1,0 +1,59 @@
+package com.fsck.k9.ui.messageview
+
+import com.fsck.k9.Account
+import com.fsck.k9.helper.AddressFormatter
+import com.fsck.k9.mail.Address
+import com.fsck.k9.mail.Message
+
+/**
+ * Extract recipient names from a message to display them in the message view.
+ *
+ * This class extracts up to [maxNumberOfDisplayRecipients] recipients from the message and converts them to their
+ * display name using an [AddressFormatter].
+ */
+internal class DisplayRecipientsExtractor(
+    private val addressFormatter: AddressFormatter,
+    private val maxNumberOfDisplayRecipients: Int
+) {
+    fun extractDisplayRecipients(message: Message, account: Account): DisplayRecipients {
+        val toRecipients = message.getRecipients(Message.RecipientType.TO)
+        val ccRecipients = message.getRecipients(Message.RecipientType.CC)
+        val bccRecipients = message.getRecipients(Message.RecipientType.BCC)
+
+        val numberOfRecipients = toRecipients.size + ccRecipients.size + bccRecipients.size
+
+        val identity = sequenceOf(toRecipients, ccRecipients, bccRecipients)
+            .flatMap { addressArray -> addressArray.asSequence() }
+            .mapNotNull { address -> account.findIdentity(address) }
+            .firstOrNull()
+
+        val identityEmail = identity?.email
+        val maxAdditionalRecipients = if (identity != null) {
+            maxNumberOfDisplayRecipients - 1
+        } else {
+            maxNumberOfDisplayRecipients
+        }
+
+        val recipientNames = sequenceOf(toRecipients, ccRecipients, bccRecipients)
+            .flatMap { addressArray -> addressArray.asSequence() }
+            .filter { address -> address.address != identityEmail }
+            .map { address -> addressFormatter.getDisplayName(address) }
+            .take(maxAdditionalRecipients)
+            .toList()
+
+        return if (identity != null) {
+            val identityAddress = Address(identity.email)
+            val meName = addressFormatter.getDisplayName(identityAddress)
+            val recipients = listOf(meName) + recipientNames
+
+            DisplayRecipients(recipients, numberOfRecipients)
+        } else {
+            DisplayRecipients(recipientNames, numberOfRecipients)
+        }
+    }
+}
+
+internal data class DisplayRecipients(
+    val recipientNames: List<CharSequence>,
+    val numberOfRecipients: Int
+)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientLayoutCreator.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientLayoutCreator.kt
@@ -1,0 +1,119 @@
+package com.fsck.k9.ui.messageview
+
+import android.text.SpannableStringBuilder
+
+private const val LIST_SEPARATOR = ", "
+
+/**
+ * Calculates how many recipient names can be displayed given the available width.
+ *
+ * We display up to [maxNumberOfRecipientNames] recipient names, then the number of additional recipients.
+ *
+ * Example:
+ *   to me, Alice, Bob, Charly, Dora +11
+ *
+ * If there's not enough room to display the first recipient name, we return it anyway and expect the component that is
+ * actually rendering the text to ellipsize [RecipientLayoutData.recipientNames], but not
+ * [RecipientLayoutData.additionalRecipients].
+ */
+internal class RecipientLayoutCreator(
+    private val textMeasure: TextMeasure,
+    private val maxNumberOfRecipientNames: Int,
+    private val recipientsPrefix: String,
+    private val additionalRecipientSpacing: Int,
+    private val additionalRecipientsPrefix: String
+) {
+    fun createRecipientLayout(
+        recipientNames: List<CharSequence>,
+        totalNumberOfRecipients: Int,
+        availableWidth: Int
+    ): RecipientLayoutData {
+        require(recipientNames.isNotEmpty())
+
+        val displayRecipientsBuilder = SpannableStringBuilder()
+
+        if (recipientNames.size == 1) {
+            displayRecipientsBuilder.append(recipientsPrefix)
+            displayRecipientsBuilder.append(recipientNames.first())
+
+            return RecipientLayoutData(
+                recipientNames = displayRecipientsBuilder,
+                additionalRecipients = null
+            )
+        }
+
+        val additionalRecipientsBuilder = StringBuilder(additionalRecipientsPrefix + 10)
+
+        val maxRecipientNames = recipientNames.size.coerceAtMost(maxNumberOfRecipientNames)
+        for (numberOfDisplayRecipients in maxRecipientNames downTo 2) {
+            displayRecipientsBuilder.clear()
+            displayRecipientsBuilder.append(recipientsPrefix)
+
+            recipientNames.asSequence()
+                .take(numberOfDisplayRecipients)
+                .joinTo(displayRecipientsBuilder, separator = LIST_SEPARATOR)
+
+            additionalRecipientsBuilder.setLength(0)
+            val numberOfAdditionalRecipients = totalNumberOfRecipients - numberOfDisplayRecipients
+            if (numberOfAdditionalRecipients > 0) {
+                additionalRecipientsBuilder.append(additionalRecipientsPrefix)
+                additionalRecipientsBuilder.append(numberOfAdditionalRecipients)
+            }
+
+            if (doesTextFitAvailableWidth(displayRecipientsBuilder, additionalRecipientsBuilder, availableWidth)) {
+                return RecipientLayoutData(
+                    recipientNames = displayRecipientsBuilder,
+                    additionalRecipients = additionalRecipientsBuilder.toStringOrNull()
+                )
+            }
+        }
+
+        displayRecipientsBuilder.clear()
+        displayRecipientsBuilder.append(recipientsPrefix)
+        displayRecipientsBuilder.append(recipientNames.first())
+
+        return RecipientLayoutData(
+            recipientNames = displayRecipientsBuilder,
+            additionalRecipients = "$additionalRecipientsPrefix${totalNumberOfRecipients - 1}"
+        )
+    }
+
+    private fun doesTextFitAvailableWidth(
+        displayRecipients: CharSequence,
+        additionalRecipients: CharSequence,
+        availableWidth: Int
+    ): Boolean {
+        val recipientNamesWidth = textMeasure.measureRecipientNames(displayRecipients)
+        if (recipientNamesWidth > availableWidth) {
+            return false
+        } else if (additionalRecipients.isEmpty()) {
+            return true
+        }
+
+        val totalWidth = recipientNamesWidth + additionalRecipientSpacing +
+            textMeasure.measureRecipientCount(additionalRecipients)
+
+        return totalWidth <= availableWidth
+    }
+}
+
+private fun StringBuilder.toStringOrNull(): String? {
+    return if (isEmpty()) null else toString()
+}
+
+internal data class RecipientLayoutData(
+    val recipientNames: CharSequence,
+    val additionalRecipients: String?
+)
+
+internal interface TextMeasure {
+    /**
+     * Measure the width of the supplied recipient names when rendered.
+     */
+    fun measureRecipientNames(text: CharSequence): Int
+
+    /**
+     * Measure the width of the supplied recipient count when rendered.
+     */
+    fun measureRecipientCount(text: CharSequence): Int
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
@@ -1,0 +1,184 @@
+package com.fsck.k9.ui.messageview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.view.isGone
+import com.fsck.k9.ui.R
+
+private const val MAX_NUMBER_OF_RECIPIENT_NAMES = 5
+
+/**
+ * View that displays the names of recipients of a message.
+ *
+ * Up to [MAX_NUMBER_OF_RECIPIENT_NAMES] names of recipients are displayed, followed by the number of recipients that
+ * weren't displayed.
+ *
+ * Examples:
+ * - to me, Alice, Bob, Charly +3
+ * - to Camila Hyphenated-Nam… +5
+ *
+ * This custom layout uses [RecipientLayoutCreator] to figure out how many recipient names can be displayed without
+ * being truncated. If not even one recipient name can be displayed without being truncated, we first measure the space
+ * needed for number of additional recipients, then use the rest to display the first recipient and ellipsize the end.
+ */
+class RecipientNamesView(context: Context, attrs: AttributeSet?) : ViewGroup(context, attrs) {
+    val maxNumberOfRecipientNames: Int = MAX_NUMBER_OF_RECIPIENT_NAMES
+
+    private val recipientLayoutCreator: RecipientLayoutCreator
+
+    private val recipientNameTextView: TextView
+    private val recipientCountTextView: TextView
+    private val additionRecipientSpacing: Int
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.recipient_names, this, true)
+        recipientNameTextView = findViewById(R.id.recipient_names)
+        recipientCountTextView = findViewById(R.id.recipient_count)
+        additionRecipientSpacing = (recipientCountTextView.layoutParams as MarginLayoutParams).marginStart
+    }
+
+    private var recipientNames: List<CharSequence> = emptyList()
+    private var numberOfRecipients: Int = 0
+
+    private val textMeasure = object : TextMeasure {
+        override fun measureRecipientNames(text: CharSequence): Int {
+            return measureWidth(recipientNameTextView, text)
+        }
+
+        override fun measureRecipientCount(text: CharSequence): Int {
+            return measureWidth(recipientCountTextView, text)
+        }
+
+        private fun measureWidth(textView: TextView, text: CharSequence): Int {
+            textView.text = text
+
+            val widthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+            val heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.AT_MOST)
+            textView.measure(widthMeasureSpec, heightMeasureSpec)
+
+            return textView.measuredWidth
+        }
+    }
+
+    init {
+        recipientLayoutCreator = RecipientLayoutCreator(
+            textMeasure = textMeasure,
+            maxNumberOfRecipientNames = MAX_NUMBER_OF_RECIPIENT_NAMES,
+            recipientsPrefix = context.getString(R.string.message_view_recipient_prefix),
+            additionalRecipientSpacing = additionRecipientSpacing,
+            additionalRecipientsPrefix = context.getString(R.string.message_view_additional_recipient_prefix)
+        )
+
+        if (isInEditMode) {
+            recipientNames = listOf(
+                "Grace Hopper", "Katherine Johnson", "Margaret Hamilton", "Adele Goldberg", "Steve Shirley"
+            )
+            numberOfRecipients = 8
+        }
+    }
+
+    fun setTextSize(textSize: Int) {
+        recipientNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize.toFloat())
+        recipientCountTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize.toFloat())
+    }
+
+    fun setRecipients(recipientNames: List<CharSequence>, numberOfRecipients: Int) {
+        if (recipientNames != this.recipientNames && numberOfRecipients != this.numberOfRecipients) {
+            this.recipientNames = recipientNames
+            this.numberOfRecipients = numberOfRecipients
+            requestLayout()
+        }
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        require(MeasureSpec.getMode(widthMeasureSpec) != MeasureSpec.UNSPECIFIED) {
+            "Width of RecipientNamesView needs to be constrained"
+        }
+
+        recipientNameTextView.measure(widthMeasureSpec, heightMeasureSpec)
+        recipientCountTextView.measure(widthMeasureSpec, heightMeasureSpec)
+
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        val height = maxOf(recipientNameTextView.measuredHeight, recipientCountTextView.measuredHeight)
+        setMeasuredDimension(width, height)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        val availableWidth = width
+
+        val recipientLayoutData = recipientLayoutCreator.createRecipientLayout(
+            recipientNames, numberOfRecipients, availableWidth
+        )
+
+        recipientNameTextView.text = recipientLayoutData.recipientNames
+        val additionalRecipientsVisible = recipientLayoutData.additionalRecipients != null
+        val remainingWidth: Int
+        if (additionalRecipientsVisible) {
+            recipientCountTextView.isGone = false
+            recipientCountTextView.text = recipientLayoutData.additionalRecipients
+
+            recipientCountTextView.measure(
+                MeasureSpec.makeMeasureSpec(availableWidth, MeasureSpec.AT_MOST),
+                MeasureSpec.makeMeasureSpec(measuredHeight, MeasureSpec.AT_MOST)
+            )
+
+            remainingWidth = availableWidth - additionRecipientSpacing - recipientCountTextView.measuredWidth
+        } else {
+            recipientCountTextView.isGone = true
+            remainingWidth = availableWidth
+        }
+
+        recipientNameTextView.measure(
+            MeasureSpec.makeMeasureSpec(remainingWidth, MeasureSpec.AT_MOST),
+            MeasureSpec.makeMeasureSpec(measuredHeight, MeasureSpec.AT_MOST)
+        )
+
+        if (layoutDirection == LAYOUT_DIRECTION_LTR) {
+            val recipientNameRight = recipientNameTextView.measuredWidth
+            recipientNameTextView.layout(
+                0,
+                0,
+                recipientNameRight,
+                recipientNameTextView.measuredHeight
+            )
+            val recipientCountLeft = recipientNameRight + additionRecipientSpacing
+            recipientCountTextView.layout(
+                recipientCountLeft,
+                0,
+                recipientCountLeft + recipientCountTextView.measuredWidth,
+                recipientCountTextView.measuredHeight
+            )
+        } else {
+            val recipientNameLeft = width - recipientNameTextView.measuredWidth
+            recipientNameTextView.layout(
+                recipientNameLeft,
+                0,
+                right,
+                recipientNameTextView.measuredHeight
+            )
+            val recipientCountRight = recipientNameLeft - additionRecipientSpacing
+            recipientCountTextView.layout(
+                recipientCountRight - recipientCountTextView.measuredWidth,
+                0,
+                recipientCountRight,
+                0 + recipientCountTextView.measuredHeight
+            )
+        }
+    }
+
+    override fun checkLayoutParams(p: LayoutParams?): Boolean {
+        return p is MarginLayoutParams
+    }
+
+    override fun generateDefaultLayoutParams(): LayoutParams {
+        return MarginLayoutParams(0, 0)
+    }
+
+    override fun generateLayoutParams(attrs: AttributeSet?): LayoutParams {
+        return MarginLayoutParams(context, attrs)
+    }
+}

--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -118,7 +118,7 @@
             android:id="@+id/date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="4dp"
             android:ellipsize="none"
             android:singleLine="true"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
@@ -134,48 +134,25 @@
             android:layout_height="18sp"
             android:layout_marginStart="16dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@+id/to"
+            app:layout_constraintBottom_toBottomOf="@+id/recipients"
             app:layout_constraintStart_toEndOf="@id/contact_picture"
             app:srcCompat="@drawable/status_lock_disabled"
             app:tint="?attr/openpgp_grey"
             tools:visibility="visible" />
 
-        <TextView
-            android:id="@+id/to"
-            android:layout_width="wrap_content"
+        <com.fsck.k9.ui.messageview.RecipientNamesView
+            android:id="@+id/recipients"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
             android:layout_marginBottom="16dp"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:text="to me"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="?android:attr/textColorSecondary"
-            app:layout_constrainedWidth="true"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/to_count"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintEnd_toStartOf="@+id/menu_primary_action"
             app:layout_constraintStart_toEndOf="@id/crypto_status_icon"
             app:layout_constraintTop_toBottomOf="@+id/from"
             app:layout_constraintVertical_bias="0.0"
             app:layout_goneMarginStart="16dp" />
-
-        <TextView
-            android:id="@+id/to_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="4dp"
-            android:layout_marginStart="4dp"
-            android:layout_marginEnd="16dp"
-            android:layout_weight="1"
-            android:singleLine="true"
-            android:text="+2"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="?attr/colorAccent"
-            app:layout_constraintBottom_toBottomOf="@+id/to"
-            app:layout_constraintEnd_toStartOf="@+id/menu_primary_action"
-            app:layout_constraintStart_toEndOf="@id/to" />
 
         <ImageView
             android:id="@+id/menu_primary_action"

--- a/app/ui/legacy/src/main/res/layout/recipient_names.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_names.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="LinearLayout"
+    tools:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/recipient_names"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:textColor="?android:attr/textColorSecondary"
+        tools:text="to me" />
+
+    <TextView
+        android:id="@+id/recipient_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:singleLine="true"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:textColor="?attr/colorAccent"
+        tools:text="+2" />
+
+</merge>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -265,6 +265,13 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_view_bcc_label">Bcc:</string>
     <string name="message_view_status_attachment_not_saved">Unable to save attachment.</string>
 
+    <!-- Displayed in the message view screen in front of the recipient list. For most languages this should end with a space. -->
+    <string name="message_view_recipient_prefix">"to "</string>
+    <!-- Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed). -->
+    <string name="message_view_additional_recipient_prefix">+</string>
+    <!-- Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me". -->
+    <string name="message_view_me_text">me</string>
+
     <!-- Text of the button that is displayed below the message header when the message body references one or more remote images -->
     <string name="message_view_show_remote_images_action">Show remote images</string>
 

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -1,0 +1,148 @@
+package com.fsck.k9.ui.messageview
+
+import com.fsck.k9.Account
+import com.fsck.k9.Identity
+import com.fsck.k9.helper.AddressFormatter
+import com.fsck.k9.mail.Address
+import com.fsck.k9.mail.buildMessage
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+private const val IDENTITY_ADDRESS = "me@domain.example"
+
+class DisplayRecipientsExtractorTest {
+    private val account = Account("uuid").apply {
+        identities += Identity(
+            email = IDENTITY_ADDRESS
+        )
+    }
+
+    private val addressFormatter = object : AddressFormatter {
+        override fun getDisplayName(address: Address): CharSequence {
+            return when (address.address) {
+                IDENTITY_ADDRESS -> "me"
+                "user1@domain.example" -> "Contact One"
+                "user2@domain.example" -> "Contact Two"
+                "user3@domain.example" -> "Contact Three"
+                "user4@domain.example" -> "Contact Four"
+                else -> address.personal ?: address.address
+            }
+        }
+    }
+
+    private val displayRecipientsExtractor = DisplayRecipientsExtractor(
+        addressFormatter,
+        maxNumberOfDisplayRecipients = 5
+    )
+
+    @Test
+    fun `single recipient is identity address`() {
+        val message = buildMessage {
+            header("To", "Test User <$IDENTITY_ADDRESS>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("me"), numberOfRecipients = 1)
+        )
+    }
+
+    @Test
+    fun `single recipient is a contact`() {
+        val message = buildMessage {
+            header("To", "User 1 <user1@domain.example>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("Contact One"), numberOfRecipients = 1)
+        )
+    }
+
+    @Test
+    fun `single recipient is not a contact`() {
+        val message = buildMessage {
+            header("To", "Alice <alice@domain.example>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("Alice"), numberOfRecipients = 1)
+        )
+    }
+
+    @Test
+    fun `single recipient without name and not a contact`() {
+        val message = buildMessage {
+            header("To", "alice@domain.example")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("alice@domain.example"), numberOfRecipients = 1)
+        )
+    }
+
+    @Test
+    fun `three unknown recipients`() {
+        val message = buildMessage {
+            header("To", "Unknown 1 <unknown1@domain.example>, Unknown 2 <unknown2@domain.example>")
+            header("Cc", "Unknown 3 <unknown3@domain.example>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(
+                recipientNames = listOf("Unknown 1", "Unknown 2", "Unknown 3"),
+                numberOfRecipients = 3
+            )
+        )
+    }
+
+    @Test
+    fun `recipients spread across To and Cc header`() {
+        val message = buildMessage {
+            header("To", "user1@domain.example, Alice <alice@domain.example>, $IDENTITY_ADDRESS")
+            header("Cc", "user2@domain.example, User 4 <user4@domain.example>, someone.else@domain.example")
+            header("Bcc", "hidden@domain.example")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(
+                recipientNames = listOf("me", "Contact One", "Alice", "Contact Two", "Contact Four"),
+                numberOfRecipients = 7
+            )
+        )
+    }
+
+    @Test
+    fun `100 recipients, AddressFormatter_getDisplayName() should only be called maxNumberOfDisplayRecipients times`() {
+        val recipients = (1..100).joinToString(separator = ", ") { "unknown$it@domain.example" }
+        val message = buildMessage {
+            header("To", recipients)
+        }
+        var numberOfTimesCalled = 0
+        val addressFormatter = object : AddressFormatter {
+            override fun getDisplayName(address: Address): CharSequence {
+                numberOfTimesCalled++
+                return address.address
+            }
+        }
+        val displayRecipientsExtractor = DisplayRecipientsExtractor(
+            addressFormatter,
+            maxNumberOfDisplayRecipients = 5
+        )
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients.numberOfRecipients).isEqualTo(100)
+        assertThat(numberOfTimesCalled).isEqualTo(5)
+    }
+}

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
@@ -1,0 +1,146 @@
+package com.fsck.k9.ui.messageview
+
+import com.fsck.k9.RobolectricTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RecipientLayoutCreatorTest : RobolectricTest() {
+    private val textMeasure = object : TextMeasure {
+        override fun measureRecipientNames(text: CharSequence): Int {
+            return measureText(text)
+        }
+
+        override fun measureRecipientCount(text: CharSequence): Int {
+            return measureText(text)
+        }
+
+        private fun measureText(text: CharSequence): Int {
+            return text.length
+        }
+    }
+
+    private val recipientLayoutCreator = RecipientLayoutCreator(
+        textMeasure = textMeasure,
+        maxNumberOfRecipientNames = 5,
+        recipientsPrefix = "to ",
+        additionalRecipientSpacing = 1,
+        additionalRecipientsPrefix = "+"
+    )
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty recipient list should throw`() {
+        recipientLayoutCreator.createRecipientLayout(
+            recipientNames = emptyList(),
+            totalNumberOfRecipients = 0,
+            availableWidth = 100
+        )
+    }
+
+    @Test
+    fun `single recipient name that fits available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("me"),
+            totalNumberOfRecipients = 1,
+            availableWidth = 10
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to me")
+        assertThat(result.additionalRecipients).isNull()
+    }
+
+    @Test
+    fun `single recipient name that doesn't fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("me"),
+            totalNumberOfRecipients = 1,
+            availableWidth = 1
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to me")
+        assertThat(result.additionalRecipients).isNull()
+    }
+
+    @Test
+    fun `two recipient names where first one doesn't fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("Alice", "Bob"),
+            totalNumberOfRecipients = 2,
+            availableWidth = 5
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to Alice")
+        assertThat(result.additionalRecipients).isEqualTo("+1")
+    }
+
+    @Test
+    fun `two recipient names where both fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("Alice", "Bob"),
+            totalNumberOfRecipients = 2,
+            availableWidth = 13
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob")
+        assertThat(result.additionalRecipients).isNull()
+    }
+
+    @Test
+    fun `three recipient names where only first one fits available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("Alice", "Bob", "Charly"),
+            totalNumberOfRecipients = 3,
+            availableWidth = 13
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to Alice")
+        assertThat(result.additionalRecipients).isEqualTo("+2")
+    }
+
+    @Test
+    fun `three recipient names where only first two fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("Alice", "Bob", "Charly"),
+            totalNumberOfRecipients = 3,
+            availableWidth = 16
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob")
+        assertThat(result.additionalRecipients).isEqualTo("+1")
+    }
+
+    @Test
+    fun `three recipient names where all fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("Alice", "Bob", "Charly"),
+            totalNumberOfRecipients = 3,
+            availableWidth = 100
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob, Charly")
+        assertThat(result.additionalRecipients).isNull()
+    }
+
+    @Test
+    fun `five recipient names and additional recipients where only two fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("One", "Two", "Three", "Four", "Five"),
+            totalNumberOfRecipients = 10,
+            availableWidth = 20
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to One, Two")
+        assertThat(result.additionalRecipients).isEqualTo("+8")
+    }
+
+    @Test
+    fun `five recipient names and additional recipients where all five fit available width`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf("One", "Two", "Three", "Four", "Five"),
+            totalNumberOfRecipients = 10,
+            availableWidth = 100
+        )
+
+        assertThat(result.recipientNames.toString()).isEqualTo("to One, Two, Three, Four, Five")
+        assertThat(result.additionalRecipients).isEqualTo("+5")
+    }
+}


### PR DESCRIPTION
- Displays up to X (currently 5) recipient names and the number of additional recipients (if there are any).
- Only displays recipient names that fit the available space without being truncated.
- If the first recipient name doesn't fit the available space, it is displayed anyway and ellipsized at the end.

<img src="https://user-images.githubusercontent.com/218061/205730730-8d05b612-ad1c-4453-87c2-d3d10f121ab4.png" alt="image" width=300>

<img src="https://user-images.githubusercontent.com/218061/205730894-adf126e9-ba76-46d5-9bfd-8af30f9c7e6c.png" alt="image" width=300> <img src="https://user-images.githubusercontent.com/218061/205730937-dced9656-39b6-40f8-b884-7a46b197a6e0.png" alt="image" width=300>

Closes #6387