### PR TITLE
Sort list of folders in account settings

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -70,6 +70,11 @@ class AccountSettingsViewModel(
         viewModelScope.launch {
             val remoteFolderInfo = withContext(backgroundDispatcher) {
                 val folders = folderRepository.getRemoteFolders(account)
+                    .sortedWith(
+                        compareByDescending<RemoteFolder> { it.type == FolderType.INBOX }
+                            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
+                    )
+
                 val automaticSpecialFolders = getAutomaticSpecialFolders(folders)
                 RemoteFolderInfo(folders, automaticSpecialFolders)
             }


### PR DESCRIPTION
The inbox folder is special in many ways, e.g. it's the only folder name we localize. So we always display it first. The rest of the folders are sorted alphabetically.

<img src="https://user-images.githubusercontent.com/218061/206698315-defac5f6-d2aa-4604-a055-621b73056236.png" alt="image" width=300>
