### PR TITLE
Remove `enabled` attr overriding in manifests

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -323,8 +323,7 @@
         </receiver>
 
         <service
-            android:name=".notification.NotificationActionService"
-            android:enabled="true"/>
+            android:name=".notification.NotificationActionService"/>
 
         <service
             android:name=".service.DatabaseUpgradeService"

--- a/app/ui/message-list-widget/src/main/AndroidManifest.xml
+++ b/app/ui/message-list-widget/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
         <service
             android:name=".MessageListWidgetService"
-            android:enabled="true"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
 
     </application>


### PR DESCRIPTION
https://developer.android.com/guide/topics/manifest/activity-element#enabled

> Whether or not the activity can be instantiated by the system — "true" if it can be, and "false" if not. The default value is "true".
The [<application>](https://developer.android.com/guide/topics/manifest/application-element) element has its own [enabled](https://developer.android.com/guide/topics/manifest/application-element#enabled) attribute that applies to all application components, including activities. The [<application>](https://developer.android.com/guide/topics/manifest/application-element) and <activity> attributes must both be "true" (as they both are by default) for the system to be able to instantiate the activity. If either is "false", it cannot be instantiated.