### PR TITLE
Ignore extraneous spaces when filtering the folder list

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -212,6 +212,7 @@ class ChooseFolderActivity : K9Activity() {
         val locale = Locale.getDefault()
         val displayName = item.displayName.lowercase(locale)
         return constraint.splitToSequence(" ")
+            .filter { it.isNotEmpty() }
             .map { it.lowercase(locale) }
             .any { it in displayName }
     }


### PR DESCRIPTION
#5531 fixed the issue for the "Manage folders" screen. This change fixes the issue for the screen to pick a folder when moving/copying a message.

Fixes #5524