### PR TITLE
After sending, delete the draft message immediately, skipping the Trash folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1894,7 +1894,15 @@ public class MessagingController {
         });
     }
 
+    public void deleteDraftSkippingTrashFolder(Account account, long messageId) {
+        deleteDraft(account, messageId, true);
+    }
+
     public void deleteDraft(Account account, long messageId) {
+        deleteDraft(account, messageId, false);
+    }
+
+    private void deleteDraft(Account account, long messageId, boolean skipTrashFolder) {
         Long folderId = account.getDraftsFolderId();
         if (folderId == null) {
             Timber.w("No Drafts folder configured. Can't delete draft.");
@@ -1905,7 +1913,7 @@ public class MessagingController {
         String messageServerId = messageStore.getMessageServerId(messageId);
         if (messageServerId != null) {
             MessageReference messageReference = new MessageReference(account.getUuid(), folderId, messageServerId);
-            deleteMessage(messageReference);
+            deleteMessages(Collections.singletonList(messageReference), skipTrashFolder);
         }
     }
 
@@ -1913,15 +1921,15 @@ public class MessagingController {
         actOnMessagesGroupedByAccountAndFolder(messages, (account, messageFolder, accountMessages) -> {
             suppressMessages(account, accountMessages);
             putBackground("deleteThreads", null, () ->
-                    deleteThreadsSynchronous(account, messageFolder.getDatabaseId(), accountMessages)
+                deleteThreadsSynchronous(account, messageFolder.getDatabaseId(), accountMessages, false)
             );
         });
     }
 
-    private void deleteThreadsSynchronous(Account account, long folderId, List<LocalMessage> messages) {
+    private void deleteThreadsSynchronous(Account account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> messagesToDelete = collectMessagesInThreads(account, messages);
-            deleteMessagesSynchronous(account, folderId, messagesToDelete);
+            deleteMessagesSynchronous(account, folderId, messagesToDelete, skipTrashFolder);
         } catch (MessagingException e) {
             Timber.e(e, "Something went wrong while deleting threads");
         }
@@ -1946,14 +1954,18 @@ public class MessagingController {
     }
 
     public void deleteMessage(MessageReference message) {
-        deleteMessages(Collections.singletonList(message));
+        deleteMessages(Collections.singletonList(message), false);
     }
 
     public void deleteMessages(List<MessageReference> messages) {
+        deleteMessages(messages, false);
+    }
+
+    private void deleteMessages(List<MessageReference> messages, boolean skipTrashFolder) {
         actOnMessagesGroupedByAccountAndFolder(messages, (account, messageFolder, accountMessages) -> {
             suppressMessages(account, accountMessages);
             putBackground("deleteMessages", null, () ->
-                    deleteMessagesSynchronous(account, messageFolder.getDatabaseId(), accountMessages)
+                deleteMessagesSynchronous(account, messageFolder.getDatabaseId(), accountMessages, skipTrashFolder)
             );
         });
     }
@@ -1987,7 +1999,7 @@ public class MessagingController {
 
     }
 
-    private void deleteMessagesSynchronous(Account account, long folderId, List<LocalMessage> messages) {
+    private void deleteMessagesSynchronous(Account account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> localOnlyMessages = new ArrayList<>();
             List<LocalMessage> syncedMessages = new ArrayList<>();
@@ -2013,7 +2025,7 @@ public class MessagingController {
             Map<String, String> uidMap = null;
             Long trashFolderId = account.getTrashFolderId();
             LocalFolder localTrashFolder = null;
-            if (!account.hasTrashFolder() || folderId == trashFolderId ||
+            if (skipTrashFolder || !account.hasTrashFolder() || folderId == trashFolderId ||
                     (backend.getSupportsTrashFolder() && !backend.isDeleteMoveToTrash())) {
                 Timber.d("Not moving deleted messages to local Trash folder. Removing local copies.");
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1500,7 +1500,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             messagingController.sendMessage(account, message, plaintextSubject, null);
             if (draftId != null) {
                 // TODO set draft id to invalid in MessageCompose!
-                messagingController.deleteDraft(account, draftId);
+                messagingController.deleteDraftSkippingTrashFolder(account, draftId);
             }
 
             return null;


### PR DESCRIPTION
Add parameter in MessagingController delete message methods to force deletion of messages permanently. In case of sending a draft this permanent is set to true and fix #2261.
