### PR TITLE
Disable more Android components by default

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -175,6 +175,9 @@
             </intent-filter>
         </activity>
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically after an account has been set up.
+        -->
         <activity
             android:name=".activity.MessageCompose"
             android:configChanges="locale"
@@ -224,6 +227,9 @@
                 android:resource="@xml/searchable"/>
         </activity>
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically after an account has been set up.
+        -->
         <activity
             android:name=".activity.LauncherShortcuts"
             android:configChanges="locale"
@@ -288,6 +294,9 @@
             android:name=".activity.setup.OAuthFlowActivity"
             android:label="@string/account_setup_basics_title" />
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically after an account has been set up.
+        -->
         <receiver
             android:name=".provider.UnreadWidgetProvider"
             android:icon="@drawable/ic_launcher"
@@ -302,6 +311,9 @@
                 android:resource="@xml/unread_widget_info"/>
         </receiver>
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically after an account has been set up.
+        -->
         <receiver
             android:name=".widget.list.MessageListWidgetProvider"
             android:icon="@drawable/message_list_widget_preview"
@@ -316,6 +328,9 @@
                 android:resource="@xml/message_list_widget_info" />
         </receiver>
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically if necessary.
+        -->
         <receiver
             android:name=".controller.push.BootCompleteReceiver"
             android:exported="false"

--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -228,6 +228,7 @@
             android:name=".activity.LauncherShortcuts"
             android:configChanges="locale"
             android:label="@string/shortcuts_title"
+            android:enabled="false"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT"/>
@@ -291,6 +292,7 @@
             android:name=".provider.UnreadWidgetProvider"
             android:icon="@drawable/ic_launcher"
             android:label="@string/unread_widget_label"
+            android:enabled="false"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -304,6 +306,7 @@
             android:name=".widget.list.MessageListWidgetProvider"
             android:icon="@drawable/message_list_widget_preview"
             android:label="@string/mail_list_widget_text"
+            android:enabled="false"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/k9mail/src/main/java/com/fsck/k9/App.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/App.kt
@@ -4,12 +4,15 @@ import android.app.Application
 import android.content.res.Configuration
 import android.content.res.Resources
 import app.k9mail.ui.widget.list.MessageListWidgetManager
+import com.fsck.k9.activity.LauncherShortcuts
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.notification.NotificationChannelManager
+import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.ui.base.AppLanguageManager
 import com.fsck.k9.ui.base.ThemeManager
 import com.fsck.k9.ui.base.extensions.currentLocale
+import com.fsck.k9.widget.list.MessageListWidgetProvider
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -123,7 +126,12 @@ class App : Application() {
 
     companion object {
         val appConfig = AppConfig(
-            componentsToDisable = listOf(MessageCompose::class.java)
+            componentsToDisable = listOf(
+                MessageCompose::class.java,
+                LauncherShortcuts::class.java,
+                UnreadWidgetProvider::class.java,
+                MessageListWidgetProvider::class.java,
+            )
         )
     }
 }

--- a/app/ui/base/src/main/AndroidManifest.xml
+++ b/app/ui/base/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <application>
 
+        <!--
+        This component is disabled by default. It will be enabled programmatically by SystemLocaleManager if necessary.
+        -->
         <receiver
             android:name=".locale.LocaleBroadcastReceiver"
             android:exported="false"


### PR DESCRIPTION
Only enable launcher shortcuts and home screen widgets after an account has been set up.