### PR TITLE
Display error message when folder couldn't be found

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1351,11 +1351,6 @@ open class MessageList :
         permissionUiHelper.requestPermission(permission)
     }
 
-    override fun onFolderNotFoundError() {
-        val defaultFolderId = defaultFolderProvider.getDefaultFolder(account!!)
-        openFolderImmediately(defaultFolderId)
-    }
-
     private enum class DisplayMode {
         MESSAGE_LIST, MESSAGE_VIEW, SPLIT_VIEW
     }

--- a/app/ui/legacy/src/main/res/layout/message_list_error.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_error.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/message_list_error"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/message_list_error_icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_error"
+        app:layout_constraintBottom_toTopOf="@+id/message_list_error_message"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <TextView
+        android:id="@+id/message_list_error_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:textAppearance="?attr/textAppearanceBody1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/message_list_error_icon"
+        tools:text="@string/message_list_error_folder_not_found" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1295,4 +1295,9 @@ You can keep this message and use it as a backup for your secret key. If you wan
 
     <!-- Name of setting to configure whether to show a "compose" floating action button on top of the message list -->
     <string name="general_settings_show_compose_button_title">Show compose button</string>
+
+    <!-- Displayed in the toolbar when there was an error loading the message list, e.g. because the folder no longer exists. -->
+    <string name="message_list_error_title">Error</string>
+    <!-- Displayed instead of the message list when a folder couldn't be found, e.g. due to an outdated home screen shortcut. -->
+    <string name="message_list_error_folder_not_found">Folder not found</string>
 </resources>


### PR DESCRIPTION
The app crashed when trying to display the message list of a folder that no longer existed (e.g. by using an outdated launcher shortcut).
In case of an error we attempted to display the default folder. Now, we display an error message instead.

<img src="https://user-images.githubusercontent.com/218061/210852078-9a04b630-03b7-48b3-85cf-f84994e712c3.png" alt="image" width=300>


Fixes #6552