### PR TITLE
delete spam messages immediately without moving to trash folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2024,8 +2024,10 @@ public class MessagingController {
 
             Map<String, String> uidMap = null;
             Long trashFolderId = account.getTrashFolderId();
+            boolean isSpamFolder = account.hasSpamFolder() && account.getSpamFolderId() == folderId;
+
             LocalFolder localTrashFolder = null;
-            if (skipTrashFolder || !account.hasTrashFolder() || folderId == trashFolderId ||
+            if (skipTrashFolder || !account.hasTrashFolder() || folderId == trashFolderId || isSpamFolder ||
                     (backend.getSupportsTrashFolder() && !backend.isDeleteMoveToTrash())) {
                 Timber.d("Not moving deleted messages to local Trash folder. Removing local copies.");
 


### PR DESCRIPTION
Delete spam messages immediately without moving to trash folder.
 
fix #6298
