### PR TITLE
Don't disable home screen widgets on Android versions prior to 12

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -294,14 +294,12 @@
             android:name=".activity.setup.OAuthFlowActivity"
             android:label="@string/account_setup_basics_title" />
 
-        <!--
-        This component is disabled by default. It will be enabled programmatically after an account has been set up.
-        -->
+        <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->
         <receiver
             android:name=".provider.UnreadWidgetProvider"
             android:icon="@drawable/ic_launcher"
             android:label="@string/unread_widget_label"
-            android:enabled="false"
+            android:enabled="@bool/home_screen_widgets_enabled"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -311,14 +309,12 @@
                 android:resource="@xml/unread_widget_info"/>
         </receiver>
 
-        <!--
-        This component is disabled by default. It will be enabled programmatically after an account has been set up.
-        -->
+        <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->
         <receiver
             android:name=".widget.list.MessageListWidgetProvider"
             android:icon="@drawable/message_list_widget_preview"
             android:label="@string/mail_list_widget_text"
-            android:enabled="false"
+            android:enabled="@bool/home_screen_widgets_enabled"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -328,9 +324,7 @@
                 android:resource="@xml/message_list_widget_info" />
         </receiver>
 
-        <!--
-        This component is disabled by default. It will be enabled programmatically if necessary.
-        -->
+        <!-- This component is disabled by default. It will be enabled programmatically if necessary. -->
         <receiver
             android:name=".controller.push.BootCompleteReceiver"
             android:exported="false"

--- a/app/k9mail/src/main/res/values-v31/manifest_values.xml
+++ b/app/k9mail/src/main/res/values-v31/manifest_values.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Home screen widgets should be disabled by default. They will be enabled programmatically if necessary. -->
+    <bool name="home_screen_widgets_enabled">false</bool>
+</resources>

--- a/app/k9mail/src/main/res/values/manifest_values.xml
+++ b/app/k9mail/src/main/res/values/manifest_values.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+    We'd like to disable this component by default. However, due to a bug in Android versions prior to 12, users then
+    wouldn't be able to use the home screen widget.
+    See https://android.googlesource.com/platform/frameworks/base/+/85be035336af8d83eb24980026418207c85991cb%5E%21/#F0
+    -->
+    <bool name="home_screen_widgets_enabled">true</bool>
+</resources>


### PR DESCRIPTION
Due to a bug in older Android versions home screen widgets that are disabled by default won't be available even after the component has been enabled dynamically.

See [the commit that fixes this bug in AOSP](https://android.googlesource.com/platform/frameworks/base/+/85be035336af8d83eb24980026418207c85991cb%5E%21/#F0).

Fixes #6562