### PR TITLE
Mark recent changes as read when dismissing snackbar

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/changelog/RecentChangesViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/changelog/RecentChangesViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.map
 @OptIn(ExperimentalCoroutinesApi::class)
 class RecentChangesViewModel(
     private val generalSettingsManager: GeneralSettingsManager,
-    changeLogManager: ChangeLogManager
+    private val changeLogManager: ChangeLogManager
 ) : ViewModel() {
     val shouldShowRecentChangesHint = changeLogManager.changeLogFlow.flatMapLatest { changeLog ->
         if (changeLog.isFirstRun && !changeLog.isFirstRunEver) {
@@ -27,5 +27,9 @@ class RecentChangesViewModel(
         return generalSettingsManager.getSettingsFlow()
             .map { generalSettings -> generalSettings.showRecentChanges }
             .distinctUntilChanged()
+    }
+
+    fun onRecentChangesHintDismissed() {
+        changeLogManager.writeCurrentVersion()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -57,6 +57,7 @@ import com.fsck.k9.ui.folders.FolderNameFormatterFactory
 import com.fsck.k9.ui.helper.RelativeDateTimeFormatter
 import com.fsck.k9.ui.messagelist.MessageListFragment.MessageListFragmentListener.Companion.MAX_PROGRESS
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import com.google.android.material.snackbar.BaseTransientBottomBar.BaseCallback
 import com.google.android.material.snackbar.Snackbar
 import java.util.concurrent.Future
 import net.jcip.annotations.GuardedBy
@@ -369,6 +370,11 @@ class MessageListFragment :
         recentChangesSnackbar = Snackbar
             .make(coordinatorLayout, R.string.changelog_snackbar_text, Snackbar.LENGTH_INDEFINITE)
             .setAction(R.string.okay_action) { launchRecentChangesActivity() }
+            .addCallback(object : BaseCallback<Snackbar>() {
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    recentChangesViewModel.onRecentChangesHintDismissed()
+                }
+            })
 
         recentChangesViewModel.shouldShowRecentChangesHint
             .observe(viewLifecycleOwner, shouldShowRecentChangesHintObserver)


### PR DESCRIPTION
Previously, swiping to dismiss the snackbar would not mark the recent changes as read and the snackbar was displayed again when the message list screen was opened again.