### PR TITLE
Only mark recent changes as read when dismissing snackbar via swipe

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -372,7 +372,9 @@ class MessageListFragment :
             .setAction(R.string.okay_action) { launchRecentChangesActivity() }
             .addCallback(object : BaseCallback<Snackbar>() {
                 override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                    recentChangesViewModel.onRecentChangesHintDismissed()
+                    if (event == DISMISS_EVENT_SWIPE) {
+                        recentChangesViewModel.onRecentChangesHintDismissed()
+                    }
                 }
             })
 


### PR DESCRIPTION
Fixes an issue in #6564.