### PR TITLE
Don't crash when K9WorkerFactory gets called for an unknown class

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/job/K9WorkerFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/K9WorkerFactory.kt
@@ -12,8 +12,8 @@ class K9WorkerFactory : WorkerFactory() {
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters
-    ): ListenableWorker {
+    ): ListenableWorker? {
         val workerClass = Class.forName(workerClassName).kotlin
-        return getKoin().get(workerClass) { parametersOf(workerParameters) }
+        return getKoin().getOrNull(workerClass) { parametersOf(workerParameters) }
     }
 }


### PR DESCRIPTION
Fixes #6558