### PR TITLE
SMTP: Log "sensitive" responses when "Log sensitive information" is enabled

### DIFF
--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -283,8 +283,9 @@ class SmtpTransport(
         logResponse(smtpResponse)
     }
 
-    private fun logResponse(smtpResponse: SmtpResponse, omitText: Boolean = false) {
+    private fun logResponse(smtpResponse: SmtpResponse, sensitive: Boolean = false) {
         if (K9MailLib.isDebug()) {
+            val omitText = sensitive && !K9MailLib.isDebugSensitive()
             Timber.v("%s", smtpResponse.toLogString(omitText, linePrefix = "SMTP <<< "))
         }
     }
@@ -532,7 +533,7 @@ class SmtpTransport(
 
         repeat(pipelinedCommands.size) {
             val response = responseParser.readResponse(isEnhancedStatusCodesProvided)
-            logResponse(response, omitText = false)
+            logResponse(response)
 
             if (response.isNegativeResponse && firstException == null) {
                 firstException = buildNegativeSmtpReplyException(response)


### PR DESCRIPTION
Responses to sensitive commands weren't logged even when "log sensitive information" was enabled.