### PR TITLE
Avoid crash when opening drafts from the message list widget

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -953,6 +953,7 @@ open class MessageList :
 
         val draftsFolderId = account.draftsFolderId
         if (draftsFolderId != null && folderId == draftsFolderId) {
+            displayMode = DisplayMode.MESSAGE_LIST
             MessageActions.actionEditDraft(this, messageReference)
         } else {
             val fragment = MessageViewContainerFragment.newInstance(messageReference)


### PR DESCRIPTION
This is more of a quick hack than a proper fix. Really, we want the behavior described in #4163.

Fixes #6607