### PR TITLE
Refactoring: Message counts

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/CoreKoinModules.kt
+++ b/app/core/src/main/java/com/fsck/k9/CoreKoinModules.kt
@@ -15,14 +15,12 @@ import com.fsck.k9.network.connectivityModule
 import com.fsck.k9.notification.coreNotificationModule
 import com.fsck.k9.power.powerModule
 import com.fsck.k9.preferences.preferencesModule
-import com.fsck.k9.search.searchModule
 
 val coreModules = listOf(
     mainModule,
     openPgpModule,
     autocryptModule,
     mailStoreModule,
-    searchModule,
     extractorModule,
     htmlModule,
     quoteModule,

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -30,7 +30,6 @@ val controllerModule = module {
     single<MessageCountsProvider> {
         DefaultMessageCountsProvider(
             preferences = get(),
-            accountSearchConditions = get(),
             messageStoreManager = get()
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -19,7 +19,6 @@ val controllerModule = module {
             get<NotificationController>(),
             get<NotificationStrategy>(),
             get<LocalStoreProvider>(),
-            get<MessageCountsProvider>(),
             get<BackendManager>(),
             get<Preferences>(),
             get<MessageStoreManager>(),

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -31,7 +31,6 @@ val controllerModule = module {
         DefaultMessageCountsProvider(
             preferences = get(),
             accountSearchConditions = get(),
-            localStoreProvider = get(),
             messageStoreManager = get()
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -31,7 +31,8 @@ val controllerModule = module {
         DefaultMessageCountsProvider(
             preferences = get(),
             accountSearchConditions = get(),
-            localStoreProvider = get()
+            localStoreProvider = get(),
+            messageStoreManager = get()
         )
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
@@ -13,6 +13,7 @@ import timber.log.Timber
 interface MessageCountsProvider {
     fun getMessageCounts(account: Account): MessageCounts
     fun getMessageCounts(searchAccount: SearchAccount): MessageCounts
+    fun getUnreadMessageCount(account: Account, folderId: Long): Int
 }
 
 data class MessageCounts(val unread: Int, val starred: Int)
@@ -50,6 +51,18 @@ internal class DefaultMessageCountsProvider(
         }
 
         return MessageCounts(unreadCount, starredCount)
+    }
+
+    override fun getUnreadMessageCount(account: Account, folderId: Long): Int {
+        return try {
+            val localStore = localStoreProvider.getInstance(account)
+            val localFolder = localStore.getFolder(folderId)
+
+            localFolder.unreadMessageCount
+        } catch (e: MessagingException) {
+            Timber.e(e, "Unable to getUnreadMessageCount for account: %s, folder: %d", account, folderId)
+            0
+        }
     }
 
     private fun getMessageCountsWithLocalSearch(account: Account, search: LocalSearch): MessageCounts {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
@@ -3,11 +3,12 @@ package com.fsck.k9.controller
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.mailstore.MessageStoreManager
-import com.fsck.k9.search.AccountSearchConditions
 import com.fsck.k9.search.ConditionsTreeNode
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
+import com.fsck.k9.search.excludeSpecialFolders
 import com.fsck.k9.search.getAccounts
+import com.fsck.k9.search.limitToDisplayableFolders
 import timber.log.Timber
 
 interface MessageCountsProvider {
@@ -20,13 +21,13 @@ data class MessageCounts(val unread: Int, val starred: Int)
 
 internal class DefaultMessageCountsProvider(
     private val preferences: Preferences,
-    private val accountSearchConditions: AccountSearchConditions,
     private val messageStoreManager: MessageStoreManager
 ) : MessageCountsProvider {
     override fun getMessageCounts(account: Account): MessageCounts {
-        val search = LocalSearch()
-        accountSearchConditions.excludeSpecialFolders(account, search)
-        accountSearchConditions.limitToDisplayableFolders(account, search)
+        val search = LocalSearch().apply {
+            excludeSpecialFolders(account)
+            limitToDisplayableFolders(account)
+        }
 
         return getMessageCounts(account, search.conditions)
     }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -29,7 +29,6 @@ import androidx.core.database.CursorKt;
 import com.fsck.k9.Account;
 import com.fsck.k9.Clock;
 import com.fsck.k9.DI;
-import com.fsck.k9.controller.MessageCounts;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
 import com.fsck.k9.controller.PendingCommandSerializer;
@@ -1003,72 +1002,6 @@ public class LocalStore {
         }, UID_CHECK_BATCH_SIZE);
 
         return folderMap;
-    }
-
-    public int getUnreadMessageCount(LocalSearch search) throws MessagingException {
-        StringBuilder whereBuilder = new StringBuilder();
-        List<String> queryArgs = new ArrayList<>();
-        SqlQueryBuilder.buildWhereClause(search.getConditions(), whereBuilder, queryArgs);
-
-        String where = whereBuilder.toString();
-        final String[] selectionArgs = queryArgs.toArray(new String[queryArgs.size()]);
-
-        final String sqlQuery = "SELECT SUM(read=0) " +
-                "FROM messages " +
-                "JOIN folders ON (folders.id = messages.folder_id) " +
-                "WHERE (messages.empty = 0 AND messages.deleted = 0)" +
-                (!TextUtils.isEmpty(where) ? " AND (" + where + ")" : "");
-
-        return database.execute(false, new DbCallback<Integer>() {
-            @Override
-            public Integer doDbWork(SQLiteDatabase db) {
-                Cursor cursor = db.rawQuery(sqlQuery, selectionArgs);
-                try {
-                    if (cursor.moveToFirst()) {
-                        return cursor.getInt(0);
-                    } else {
-                        return 0;
-                    }
-                } finally {
-                    cursor.close();
-                }
-            }
-        });
-    }
-
-    private int getStarredMessageCount(LocalSearch search) throws MessagingException {
-        StringBuilder whereBuilder = new StringBuilder();
-        List<String> queryArgs = new ArrayList<>();
-        SqlQueryBuilder.buildWhereClause(search.getConditions(), whereBuilder, queryArgs);
-
-        String where = whereBuilder.toString();
-        final String[] selectionArgs = queryArgs.toArray(new String[queryArgs.size()]);
-
-        final String sqlQuery = "SELECT SUM(flagged=1) " +
-                "FROM messages " +
-                "JOIN folders ON (folders.id = messages.folder_id) " +
-                "WHERE (messages.empty = 0 AND messages.deleted = 0)" +
-                (!TextUtils.isEmpty(where) ? " AND (" + where + ")" : "");
-
-        return database.execute(false, new DbCallback<Integer>() {
-            @Override
-            public Integer doDbWork(SQLiteDatabase db) {
-                Cursor cursor = db.rawQuery(sqlQuery, selectionArgs);
-                try {
-                    if (cursor.moveToFirst()) {
-                        return cursor.getInt(0);
-                    } else {
-                        return 0;
-                    }
-                } finally {
-                    cursor.close();
-                }
-            }
-        });
-    }
-
-    public MessageCounts getMessageCounts(LocalSearch search) throws MessagingException {
-        return new MessageCounts(getUnreadMessageCount(search), getStarredMessageCount(search));
     }
 
     public List<NotificationMessage> getNotificationMessages() throws MessagingException {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -355,7 +355,7 @@ public class LocalStore {
     public List<LocalMessage> searchForMessages(LocalSearch search) throws MessagingException {
         StringBuilder query = new StringBuilder();
         List<String> queryArgs = new ArrayList<>();
-        SqlQueryBuilder.buildWhereClause(account, search.getConditions(), query, queryArgs);
+        SqlQueryBuilder.buildWhereClause(search.getConditions(), query, queryArgs);
 
         // Avoid "ambiguous column name" error by prefixing "id" with the message table name
         String where = SqlQueryBuilder.addPrefixToSelection(new String[] { "id" },
@@ -1008,7 +1008,7 @@ public class LocalStore {
     public int getUnreadMessageCount(LocalSearch search) throws MessagingException {
         StringBuilder whereBuilder = new StringBuilder();
         List<String> queryArgs = new ArrayList<>();
-        SqlQueryBuilder.buildWhereClause(account, search.getConditions(), whereBuilder, queryArgs);
+        SqlQueryBuilder.buildWhereClause(search.getConditions(), whereBuilder, queryArgs);
 
         String where = whereBuilder.toString();
         final String[] selectionArgs = queryArgs.toArray(new String[queryArgs.size()]);
@@ -1039,7 +1039,7 @@ public class LocalStore {
     private int getStarredMessageCount(LocalSearch search) throws MessagingException {
         StringBuilder whereBuilder = new StringBuilder();
         List<String> queryArgs = new ArrayList<>();
-        SqlQueryBuilder.buildWhereClause(account, search.getConditions(), whereBuilder, queryArgs);
+        SqlQueryBuilder.buildWhereClause(search.getConditions(), whereBuilder, queryArgs);
 
         String where = whereBuilder.toString();
         final String[] selectionArgs = queryArgs.toArray(new String[queryArgs.size()]);

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -222,6 +222,11 @@ interface MessageStore {
     fun getMessageCount(folderId: Long): Int
 
     /**
+     * Retrieve the number of unread messages in a folder.
+     */
+    fun getUnreadMessageCount(folderId: Long): Int
+
+    /**
      * Update a folder's name and type.
      */
     fun changeFolder(folderServerId: String, name: String, type: FolderType)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -5,6 +5,7 @@ import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.mail.FolderType
 import com.fsck.k9.mail.Header
+import com.fsck.k9.search.ConditionsTreeNode
 import java.util.Date
 
 /**
@@ -225,6 +226,16 @@ interface MessageStore {
      * Retrieve the number of unread messages in a folder.
      */
     fun getUnreadMessageCount(folderId: Long): Int
+
+    /**
+     * Retrieve the number of unread messages matching [conditions].
+     */
+    fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int
+
+    /**
+     * Retrieve the number of starred messages matching [conditions].
+     */
+    fun getStarredMessageCount(conditions: ConditionsTreeNode): Int
 
     /**
      * Update a folder's name and type.

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -79,30 +79,6 @@ class AccountSearchConditions {
         }
     }
 
-    /**
-     * Modify the supplied [LocalSearch] instance to exclude "unwanted" folders.
-     *
-     * Currently the following folders are excluded:
-     *
-     *  * Trash
-     *  * Spam
-     *  * Outbox
-     *
-     * The Inbox will always be included even if one of the special folders is configured to point
-     * to the Inbox.
-     *
-     * @param search
-     * The `LocalSearch` instance to modify.
-     */
-    fun excludeUnwantedFolders(account: Account, search: LocalSearch) {
-        excludeSpecialFolder(search, account.trashFolderId)
-        excludeSpecialFolder(search, account.spamFolderId)
-        excludeSpecialFolder(search, account.outboxFolderId)
-        account.inboxFolderId?.let { inboxFolderId ->
-            search.or(SearchCondition(SearchField.FOLDER, Attribute.EQUALS, inboxFolderId.toString()))
-        }
-    }
-
     private fun excludeSpecialFolder(search: LocalSearch, folderId: Long?) {
         if (folderId != null) {
             search.and(SearchField.FOLDER, folderId.toString(), Attribute.NOT_EQUALS)

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -7,81 +7,69 @@ import com.fsck.k9.search.SearchSpecification.Attribute
 import com.fsck.k9.search.SearchSpecification.SearchCondition
 import com.fsck.k9.search.SearchSpecification.SearchField
 
-class AccountSearchConditions {
-    /**
-     * Modify the supplied [LocalSearch] instance to limit the search to displayable folders.
-     *
-     * This method uses the current folder display mode to decide what folders to include/exclude.
-     *
-     * @param search
-     * The `LocalSearch` instance to modify.
-     *
-     * @see .getFolderDisplayMode
-     */
-    fun limitToDisplayableFolders(account: Account, search: LocalSearch) {
-        val displayMode = account.folderDisplayMode
+/**
+ * Modify the supplied [LocalSearch] instance to limit the search to displayable folders.
+ *
+ * This method uses the current [folder display mode][Account.folderDisplayMode] to decide what folders to
+ * include/exclude.
+ */
+fun LocalSearch.limitToDisplayableFolders(account: Account) {
+    when (account.folderDisplayMode) {
+        FolderMode.FIRST_CLASS -> {
+            // Count messages in the INBOX and non-special first class folders
+            and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
+        }
+        FolderMode.FIRST_AND_SECOND_CLASS -> {
+            // Count messages in the INBOX and non-special first and second class folders
+            and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
 
-        when (displayMode) {
-            FolderMode.FIRST_CLASS -> {
-                // Count messages in the INBOX and non-special first class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
+            // TODO: Create a proper interface for creating arbitrary condition trees
+            val searchCondition = SearchCondition(
+                SearchField.DISPLAY_CLASS, Attribute.EQUALS, FolderClass.SECOND_CLASS.name
+            )
+            val root = conditions
+            if (root.mRight != null) {
+                root.mRight.or(searchCondition)
+            } else {
+                or(searchCondition)
             }
-            FolderMode.FIRST_AND_SECOND_CLASS -> {
-                // Count messages in the INBOX and non-special first and second class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
-
-                // TODO: Create a proper interface for creating arbitrary condition trees
-                val searchCondition = SearchCondition(
-                    SearchField.DISPLAY_CLASS, Attribute.EQUALS, FolderClass.SECOND_CLASS.name
-                )
-                val root = search.conditions
-                if (root.mRight != null) {
-                    root.mRight.or(searchCondition)
-                } else {
-                    search.or(searchCondition)
-                }
-            }
-            FolderMode.NOT_SECOND_CLASS -> {
-                // Count messages in the INBOX and non-special non-second-class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.SECOND_CLASS.name, Attribute.NOT_EQUALS)
-            }
-            FolderMode.ALL, FolderMode.NONE -> {
-                // Count messages in the INBOX and non-special folders
-            }
+        }
+        FolderMode.NOT_SECOND_CLASS -> {
+            // Count messages in the INBOX and non-special non-second-class folders
+            and(SearchField.DISPLAY_CLASS, FolderClass.SECOND_CLASS.name, Attribute.NOT_EQUALS)
+        }
+        FolderMode.ALL, FolderMode.NONE -> {
+            // Count messages in the INBOX and non-special folders
         }
     }
+}
 
-    /**
-     * Modify the supplied [LocalSearch] instance to exclude special folders.
-     *
-     * Currently the following folders are excluded:
-     *
-     *  * Trash
-     *  * Drafts
-     *  * Spam
-     *  * Outbox
-     *  * Sent
-     *
-     * The Inbox will always be included even if one of the special folders is configured to point
-     * to the Inbox.
-     *
-     * @param search
-     * The `LocalSearch` instance to modify.
-     */
-    fun excludeSpecialFolders(account: Account, search: LocalSearch) {
-        excludeSpecialFolder(search, account.trashFolderId)
-        excludeSpecialFolder(search, account.draftsFolderId)
-        excludeSpecialFolder(search, account.spamFolderId)
-        excludeSpecialFolder(search, account.outboxFolderId)
-        excludeSpecialFolder(search, account.sentFolderId)
-        account.inboxFolderId?.let { inboxFolderId ->
-            search.or(SearchCondition(SearchField.FOLDER, Attribute.EQUALS, inboxFolderId.toString()))
-        }
+/**
+ * Modify the supplied [LocalSearch] instance to exclude special folders.
+ *
+ * Currently the following folders are excluded:
+ *  - Trash
+ *  - Drafts
+ *  - Spam
+ *  - Outbox
+ *  - Sent
+ *
+ * The Inbox will always be included even if one of the special folders is configured to point to the Inbox.
+ */
+fun LocalSearch.excludeSpecialFolders(account: Account) {
+    this.excludeSpecialFolder(account.trashFolderId)
+    this.excludeSpecialFolder(account.draftsFolderId)
+    this.excludeSpecialFolder(account.spamFolderId)
+    this.excludeSpecialFolder(account.outboxFolderId)
+    this.excludeSpecialFolder(account.sentFolderId)
+
+    account.inboxFolderId?.let { inboxFolderId ->
+        or(SearchCondition(SearchField.FOLDER, Attribute.EQUALS, inboxFolderId.toString()))
     }
+}
 
-    private fun excludeSpecialFolder(search: LocalSearch, folderId: Long?) {
-        if (folderId != null) {
-            search.and(SearchField.FOLDER, folderId.toString(), Attribute.NOT_EQUALS)
-        }
+private fun LocalSearch.excludeSpecialFolder(folderId: Long?) {
+    if (folderId != null) {
+        and(SearchField.FOLDER, folderId.toString(), Attribute.NOT_EQUALS)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/search/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/KoinModule.kt
@@ -1,7 +1,0 @@
-package com.fsck.k9.search
-
-import org.koin.dsl.module
-
-val searchModule = module {
-    single { AccountSearchConditions() }
-}

--- a/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
@@ -71,8 +71,7 @@ public interface SearchSpecification extends Parcelable {
         NEW_MESSAGE,
         READ,
         FLAGGED,
-        DISPLAY_CLASS,
-        SEARCHABLE
+        DISPLAY_CLASS
     }
 
 

--- a/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -2,85 +2,45 @@ package com.fsck.k9.search;
 
 import java.util.List;
 
-import com.fsck.k9.DI;
 import timber.log.Timber;
 
-import com.fsck.k9.Account;
 import com.fsck.k9.search.SearchSpecification.Attribute;
 import com.fsck.k9.search.SearchSpecification.SearchCondition;
 import com.fsck.k9.search.SearchSpecification.SearchField;
 
 
 public class SqlQueryBuilder {
-    public static void buildWhereClause(Account account, ConditionsTreeNode node,
-            StringBuilder query, List<String> selectionArgs) {
-        buildWhereClauseInternal(account, node, query, selectionArgs);
+    public static void buildWhereClause(ConditionsTreeNode node, StringBuilder query, List<String> selectionArgs) {
+        buildWhereClauseInternal(node, query, selectionArgs);
     }
 
-    private static void buildWhereClauseInternal(Account account, ConditionsTreeNode node,
-            StringBuilder query, List<String> selectionArgs) {
+    private static void buildWhereClauseInternal(ConditionsTreeNode node, StringBuilder query,
+        List<String> selectionArgs) {
+
         if (node == null) {
             query.append("1");
             return;
         }
 
         if (node.mLeft == null && node.mRight == null) {
-            AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
             SearchCondition condition = node.mCondition;
-            switch (condition.field) {
-                case SEARCHABLE: {
-                    switch (account.getSearchableFolders()) {
-                        case ALL: {
-                            // Create temporary LocalSearch object so we can use...
-                            LocalSearch tempSearch = new LocalSearch();
-                            // ...the helper methods in Account to create the necessary conditions
-                            // to exclude "unwanted" folders.
-                            accountSearchConditions.excludeUnwantedFolders(account, tempSearch);
-
-                            buildWhereClauseInternal(account, tempSearch.getConditions(), query,
-                                    selectionArgs);
-                            break;
-                        }
-                        case DISPLAYABLE: {
-                            // Create temporary LocalSearch object so we can use...
-                            LocalSearch tempSearch = new LocalSearch();
-                            // ...the helper methods in Account to create the necessary conditions
-                            // to limit the selection to displayable, non-special folders.
-                            accountSearchConditions.excludeSpecialFolders(account, tempSearch);
-                            accountSearchConditions.limitToDisplayableFolders(account, tempSearch);
-
-                            buildWhereClauseInternal(account, tempSearch.getConditions(), query,
-                                    selectionArgs);
-                            break;
-                        }
-                        case NONE: {
-                            // Dummy condition, never select
-                            query.append("0");
-                            break;
-                        }
-                    }
-                    break;
+            if (condition.field == SearchField.MESSAGE_CONTENTS) {
+                String fulltextQueryString = condition.value;
+                if (condition.attribute != Attribute.CONTAINS) {
+                    Timber.e("message contents can only be matched!");
                 }
-                case MESSAGE_CONTENTS: {
-                    String fulltextQueryString = condition.value;
-                    if (condition.attribute != Attribute.CONTAINS) {
-                        Timber.e("message contents can only be matched!");
-                    }
-                    query.append("messages.id IN (SELECT docid FROM messages_fulltext WHERE fulltext MATCH ?)");
-                    selectionArgs.add(fulltextQueryString);
-                    break;
-                }
-                default: {
-                    appendCondition(condition, query, selectionArgs);
-                }
+                query.append("messages.id IN (SELECT docid FROM messages_fulltext WHERE fulltext MATCH ?)");
+                selectionArgs.add(fulltextQueryString);
+            } else {
+                appendCondition(condition, query, selectionArgs);
             }
         } else {
             query.append("(");
-            buildWhereClauseInternal(account, node.mLeft, query, selectionArgs);
+            buildWhereClauseInternal(node.mLeft, query, selectionArgs);
             query.append(") ");
             query.append(node.mValue.name());
             query.append(" (");
-            buildWhereClauseInternal(account, node.mRight, query, selectionArgs);
+            buildWhereClauseInternal(node.mRight, query, selectionArgs);
             query.append(")");
         }
     }
@@ -170,9 +130,8 @@ public class SqlQueryBuilder {
                 columnName = "threads.root";
                 break;
             }
-            case MESSAGE_CONTENTS:
-            case SEARCHABLE: {
-                // Special cases handled in buildWhereClauseInternal()
+            case MESSAGE_CONTENTS: {
+                // Special case handled in buildWhereClauseInternal()
                 break;
             }
         }

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -34,8 +34,6 @@ import com.fsck.k9.mailstore.SpecialLocalFoldersCreator;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.notification.NotificationStrategy;
 import com.fsck.k9.preferences.Protocols;
-import com.fsck.k9.search.SearchAccount;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -108,18 +106,6 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private LocalMessage localMessageToSend1;
     private volatile boolean hasFetchedMessage = false;
 
-    private MessageCountsProvider messageCountsProvider = new MessageCountsProvider() {
-        @Override
-        public MessageCounts getMessageCounts(@NotNull SearchAccount searchAccount) {
-            return new MessageCounts(0, 0);
-        }
-
-        @Override
-        public MessageCounts getMessageCounts(@NotNull Account account) {
-            return new MessageCounts(0, 0);
-        }
-    };
-
     private Preferences preferences;
     private String accountUuid;
 
@@ -133,7 +119,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         preferences = Preferences.getPreferences();
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
-                localStoreProvider, messageCountsProvider, backendManager, preferences, messageStoreManager,
+                localStoreProvider, backendManager, preferences, messageStoreManager,
                 saveMessageDataCreator, specialLocalFoldersCreator, Collections.<ControllerExtension>emptyList());
 
         configureAccount();

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
@@ -8,7 +8,7 @@ val unreadWidgetModule = module {
         UnreadWidgetDataProvider(
             context = get(),
             preferences = get(),
-            messagingController = get(),
+            messageCountsProvider = get(),
             defaultFolderProvider = get(),
             folderRepository = get(),
             folderNameFormatterFactory = get()

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.MessageList
-import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.controller.MessageCountsProvider
 import com.fsck.k9.mailstore.FolderRepository
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
@@ -17,13 +17,12 @@ import com.fsck.k9.ui.R as UiR
 class UnreadWidgetDataProvider(
     private val context: Context,
     private val preferences: Preferences,
-    private val messagingController: MessagingController,
+    private val messageCountsProvider: MessageCountsProvider,
     private val defaultFolderProvider: DefaultFolderProvider,
     private val folderRepository: FolderRepository,
     private val folderNameFormatterFactory: FolderNameFormatterFactory
 ) {
     fun loadUnreadWidgetData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? = with(configuration) {
-        @Suppress("CascadeIf")
         if (SearchAccount.UNIFIED_INBOX == accountUuid) {
             loadSearchAccountData(configuration)
         } else if (folderId != null) {
@@ -36,7 +35,7 @@ class UnreadWidgetDataProvider(
     private fun loadSearchAccountData(configuration: UnreadWidgetConfiguration): UnreadWidgetData {
         val searchAccount = getSearchAccount(configuration.accountUuid)
         val title = searchAccount.name
-        val unreadCount = messagingController.getUnreadMessageCount(searchAccount)
+        val unreadCount = messageCountsProvider.getMessageCounts(searchAccount).unread
         val clickIntent = MessageList.intentDisplaySearch(context, searchAccount.relatedSearch, false, true, true)
 
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
@@ -50,7 +49,7 @@ class UnreadWidgetDataProvider(
     private fun loadAccountData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? {
         val account = preferences.getAccount(configuration.accountUuid) ?: return null
         val title = account.displayName
-        val unreadCount = messagingController.getUnreadMessageCount(account)
+        val unreadCount = messageCountsProvider.getMessageCounts(account).unread
         val clickIntent = getClickIntentForAccount(account)
 
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
@@ -70,7 +69,7 @@ class UnreadWidgetDataProvider(
         val folderDisplayName = getFolderDisplayName(account, folderId)
         val title = context.getString(UiR.string.unread_widget_title, accountName, folderDisplayName)
 
-        val unreadCount = messagingController.getFolderUnreadMessageCount(account, folderId)
+        val unreadCount = messageCountsProvider.getUnreadMessageCount(account, folderId)
 
         val clickIntent = getClickIntentForFolder(account, folderId)
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -176,6 +176,10 @@ class K9MessageStore(
         return retrieveFolderOperations.getMessageCount(folderId)
     }
 
+    override fun getUnreadMessageCount(folderId: Long): Int {
+        return retrieveFolderOperations.getUnreadMessageCount(folderId)
+    }
+
     override fun getSize(): Long {
         return databaseOperations.getSize()
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -15,6 +15,7 @@ import com.fsck.k9.mailstore.MoreMessages
 import com.fsck.k9.mailstore.SaveMessageData
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.message.extractors.BasicPartInfoExtractor
+import com.fsck.k9.search.ConditionsTreeNode
 import java.util.Date
 
 class K9MessageStore(
@@ -178,6 +179,14 @@ class K9MessageStore(
 
     override fun getUnreadMessageCount(folderId: Long): Int {
         return retrieveFolderOperations.getUnreadMessageCount(folderId)
+    }
+
+    override fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int {
+        return retrieveFolderOperations.getUnreadMessageCount(conditions)
+    }
+
+    override fun getStarredMessageCount(conditions: ConditionsTreeNode): Int {
+        return retrieveFolderOperations.getStarredMessageCount(conditions)
     }
 
     override fun getSize(): Long {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
@@ -159,6 +159,17 @@ $displayModeSelection
         }
     }
 
+    fun getUnreadMessageCount(folderId: Long): Int {
+        return lockableDatabase.execute(false) { db ->
+            db.rawQuery(
+                "SELECT COUNT(id) FROM messages WHERE empty = 0 AND deleted = 0 AND read = 0 AND folder_id = ?",
+                arrayOf(folderId.toString())
+            ).use { cursor ->
+                if (cursor.moveToFirst()) cursor.getInt(0) else 0
+            }
+        }
+    }
+
     fun hasMoreMessages(folderId: Long): MoreMessages {
         return getFolder(folderId) { it.moreMessages } ?: throw FolderNotFoundException(folderId)
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
@@ -12,6 +12,8 @@ import com.fsck.k9.mailstore.FolderNotFoundException
 import com.fsck.k9.mailstore.LockableDatabase
 import com.fsck.k9.mailstore.MoreMessages
 import com.fsck.k9.mailstore.toFolderType
+import com.fsck.k9.search.ConditionsTreeNode
+import com.fsck.k9.search.SqlQueryBuilder
 
 internal class RetrieveFolderOperations(private val lockableDatabase: LockableDatabase) {
     fun <T> getFolder(folderId: Long, mapper: FolderMapper<T>): T? {
@@ -165,6 +167,37 @@ $displayModeSelection
                 "SELECT COUNT(id) FROM messages WHERE empty = 0 AND deleted = 0 AND read = 0 AND folder_id = ?",
                 arrayOf(folderId.toString())
             ).use { cursor ->
+                if (cursor.moveToFirst()) cursor.getInt(0) else 0
+            }
+        }
+    }
+
+    fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int {
+        return getMessageCount(condition = "messages.read = 0", conditions)
+    }
+
+    fun getStarredMessageCount(conditions: ConditionsTreeNode): Int {
+        return getMessageCount(condition = "messages.flagged = 1", conditions)
+    }
+
+    private fun getMessageCount(condition: String, extraConditions: ConditionsTreeNode): Int {
+        val whereBuilder = StringBuilder()
+        val queryArgs = mutableListOf<String>()
+        SqlQueryBuilder.buildWhereClause(extraConditions, whereBuilder, queryArgs)
+
+        val where = if (whereBuilder.isNotEmpty()) "AND ($whereBuilder)" else ""
+        val selectionArgs = queryArgs.toTypedArray()
+
+        val query =
+            """
+SELECT COUNT(messages.id) 
+FROM messages 
+JOIN folders ON (folders.id = messages.folder_id) 
+WHERE (messages.empty = 0 AND messages.deleted = 0 AND $condition) $where
+            """
+
+        return lockableDatabase.execute(false) { db ->
+            db.rawQuery(query, selectionArgs).use { cursor ->
                 if (cursor.moveToFirst()) cursor.getInt(0) else 0
             }
         }

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
@@ -352,6 +352,34 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
     }
 
     @Test
+    fun `get unread message count from empty folder`() {
+        val folderId = sqliteDatabase.createFolder()
+
+        val result = retrieveFolderOperations.getUnreadMessageCount(folderId)
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `get unread message count from non-existent folder`() {
+        val result = retrieveFolderOperations.getUnreadMessageCount(23)
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `get unread message count from non-empty folder`() {
+        val folderId = sqliteDatabase.createFolder()
+        sqliteDatabase.createMessage(folderId = folderId, read = false)
+        sqliteDatabase.createMessage(folderId = folderId, read = false)
+        sqliteDatabase.createMessage(folderId = folderId, read = true)
+
+        val result = retrieveFolderOperations.getUnreadMessageCount(folderId)
+
+        assertThat(result).isEqualTo(2)
+    }
+
+    @Test
     fun `get 'more messages' value from non-existent folder`() {
         try {
             retrieveFolderOperations.hasMoreMessages(23)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -77,7 +77,7 @@ class MessageListLoader(
             queryArgs.add(activeMessage.folderId.toString())
         }
 
-        SqlQueryBuilder.buildWhereClause(account, config.search.conditions, query, queryArgs)
+        SqlQueryBuilder.buildWhereClause(config.search.conditions, query, queryArgs)
 
         if (selectActive) {
             query.append(')')

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListLoader.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListLoader.kt
@@ -56,7 +56,7 @@ internal class MessageListLoader(
         val query = StringBuilder()
         val queryArgs = mutableListOf<String>()
 
-        SqlQueryBuilder.buildWhereClause(account, config.search.conditions, query, queryArgs)
+        SqlQueryBuilder.buildWhereClause(config.search.conditions, query, queryArgs)
 
         val selection = query.toString()
         val selectionArgs = queryArgs.toTypedArray()


### PR DESCRIPTION
- move functionality from `LocalStore` to `MessageStore`
- remove unnecessary indirection via `MessagingController`
- remove unused functionality from `SqlQueryBuilder`
- make using `AccountSearchConditions` less annoying
