### PR TITLE
Add spotless code formatter

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,22 +3,20 @@
 If the app is not behaving like it should, it's not necessarily a bug. Please consult the following resources before
 submitting a new issue.
 
-* [User Manual](https://docs.k9mail.app/)
-* [Frequently Asked Questions](https://forum.k9mail.app/c/faq)
-* [Support Forum](https://forum.k9mail.app/)
+- [User Manual](https://docs.k9mail.app/)
+- [Frequently Asked Questions](https://forum.k9mail.app/c/faq)
+- [Support Forum](https://forum.k9mail.app/)
 
 ### Bug report guidelines
 
-* The issue tracker is solely for bug reports and feature/enhancement requests. If you have a question of any kind,
-please use the [support forum](https://forum.k9mail.app/c/support) instead.
-* Search the [existing issues](https://github.com/thundernest/k-9/issues?q=) first to make sure your issue hasn't been
-reported before.
-
+- The issue tracker is solely for bug reports and feature/enhancement requests. If you have a question of any kind,
+  please use the [support forum](https://forum.k9mail.app/c/support) instead.
+- Search the [existing issues](https://github.com/thundernest/k-9/issues?q=) first to make sure your issue hasn't been
+  reported before.
 
 ## Translations
 
 We're using [Transifex](https://www.transifex.com/k-9/k9mail/) to manage translations.
-
 
 ## Contributing code
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Please ensure that your pull request meets the following requirements - thanks!
 - Does not contain merge commits. Rebase instead.
 - Contains commits with descriptive titles.
 - New code is written in Kotlin whenever possible.
-- Follows our existing codestyle (`gradlew ktlintCheck`; will be checked by CI).
+- Follows our existing codestyle (`gradlew spotlessCheck` to check and `gradlew spotlessFormat` to format your source code; will be checked by CI).
 - Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
 - Uses a descriptive title; don't put issue numbers in there.
 - Contains a reference to the issue that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_) in the body text.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 Please ensure that your pull request meets the following requirements - thanks!
 
-* Does not contain merge commits. Rebase instead.
-* Contains commits with descriptive titles.
-* New code is written in Kotlin whenever possible.
-* Follows our existing codestyle (`gradlew ktlintCheck`; will be checked by CI).
-* Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
-* Uses a descriptive title; don't put issue numbers in there.
-* Contains a reference to the issue that it fixes (e.g. *Closes #XXX* or *Fixes #XXX*) in the body text.
-* For cosmetic changes add one or multiple images, if possible.
+- Does not contain merge commits. Rebase instead.
+- Contains commits with descriptive titles.
+- New code is written in Kotlin whenever possible.
+- Follows our existing codestyle (`gradlew ktlintCheck`; will be checked by CI).
+- Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
+- Uses a descriptive title; don't put issue numbers in there.
+- Contains a reference to the issue that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_) in the body text.
+- For cosmetic changes add one or multiple images, if possible.
 
 Finally, please replace this template text with a description of the change and additional context if necessary.

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,4 +28,4 @@ jobs:
           distribution: 'zulu'
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - run: ./gradlew assembleDebug ktlintCheck testsOnCi
+      - run: ./gradlew assembleDebug spotlessCheck testsOnCi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # K-9 Mail
+
 [![Latest release](https://img.shields.io/github/release/thundernest/k-9.svg?style=flat-square)](https://github.com/thundernest/k-9/releases/latest)
 [![Latest beta release](https://img.shields.io/github/v/release/thundernest/k-9.svg?include_prereleases&style=flat-square)](https://github.com/thundernest/k-9/releases)
 
 K-9 Mail is an open-source email client for Android.
-
 
 ## Download
 
@@ -15,12 +15,10 @@ K-9 Mail can be downloaded from a couple of sources:
 
 You might also be interested in becoming a [tester](https://forum.k9mail.app/t/how-do-i-become-a-beta-tester/68) to get an early look at new versions.
 
-
 ## Release Notes
 
 Check out the [Release Notes](https://github.com/thundernest/k-9/wiki/ReleaseNotes) to find out what changed
 in each version of K-9 Mail.
-
 
 ## Need Help?
 
@@ -30,25 +28,21 @@ If the app is not behaving like it should, you might find these resources helpfu
 - [Frequently Asked Questions](https://forum.k9mail.app/c/faq)
 - [Support Forum](https://forum.k9mail.app/)
 
-
 ## Translations
 
 Interested in helping to translate K-9 Mail? Contribute here:
 
 https://www.transifex.com/projects/p/k9mail/
 
-
 ## Contributing
 
-Thank you for contributing! If you're unfamiliar with the code, 
-start by reading the [developer documentation](docs/DESIGN.md)
+Thank you for contributing! If you're unfamiliar with the code, start by reading the [developer documentation](docs/DESIGN.md)
 
 Please fork this repository and contribute back using [pull requests](https://github.com/thundernest/k-9/pulls).
 
 Any contributions, large or small, major features, bug fixes, unit/integration tests are welcomed and appreciated
 but will be thoroughly reviewed and discussed.
 Please make sure you read the [Code Style Guidelines](https://github.com/thundernest/k-9/wiki/CodeStyle).
-
 
 ## Communication
 
@@ -58,7 +52,6 @@ Aside from discussing changes in [pull requests](https://github.com/thundernest/
 - Matrix: [#k9mail:matrix.org](https://matrix.to/#/#tb-android:mozilla.org)
 - IRC: [#k9mail on Libera Chat](https://web.libera.chat/#k9mail)
 - [Developer mailing list](https://groups.google.com/forum/#!forum/k-9-dev)
-
 
 ## License
 

--- a/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -53,7 +53,7 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
 
         return OAuthConfigurationProvider(
             configurations = mapOf(
-                listOf("imap.gmail.com", "smtp.gmail.com") to googleConfig,
+                listOf("imap.gmail.com", "smtp.gmail.com") to googleConfig
             ),
             googleConfiguration = googleConfig
         )

--- a/app/core/src/main/java/com/fsck/k9/Account.kt
+++ b/app/core/src/main/java/com/fsck/k9/Account.kt
@@ -551,12 +551,14 @@ class Account(override val uuid: String) : BaseAccount {
 
             if (age < 28) {
                 now.add(Calendar.DATE, age * -1)
-            } else when (age) {
-                28 -> now.add(Calendar.MONTH, -1)
-                56 -> now.add(Calendar.MONTH, -2)
-                84 -> now.add(Calendar.MONTH, -3)
-                168 -> now.add(Calendar.MONTH, -6)
-                365 -> now.add(Calendar.YEAR, -1)
+            } else {
+                when (age) {
+                    28 -> now.add(Calendar.MONTH, -1)
+                    56 -> now.add(Calendar.MONTH, -2)
+                    84 -> now.add(Calendar.MONTH, -3)
+                    168 -> now.add(Calendar.MONTH, -6)
+                    365 -> now.add(Calendar.YEAR, -1)
+                }
             }
 
             return now.time

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -67,35 +67,40 @@ class AccountPreferenceSerializer(
 
             val draftsFolderId = storage.getString("$accountUuid.draftsFolderId", null)?.toLongOrNull()
             val draftsFolderSelection = getEnumStringPref<SpecialFolderSelection>(
-                storage, "$accountUuid.draftsFolderSelection",
+                storage,
+                "$accountUuid.draftsFolderSelection",
                 SpecialFolderSelection.AUTOMATIC
             )
             setDraftsFolderId(draftsFolderId, draftsFolderSelection)
 
             val sentFolderId = storage.getString("$accountUuid.sentFolderId", null)?.toLongOrNull()
             val sentFolderSelection = getEnumStringPref<SpecialFolderSelection>(
-                storage, "$accountUuid.sentFolderSelection",
+                storage,
+                "$accountUuid.sentFolderSelection",
                 SpecialFolderSelection.AUTOMATIC
             )
             setSentFolderId(sentFolderId, sentFolderSelection)
 
             val trashFolderId = storage.getString("$accountUuid.trashFolderId", null)?.toLongOrNull()
             val trashFolderSelection = getEnumStringPref<SpecialFolderSelection>(
-                storage, "$accountUuid.trashFolderSelection",
+                storage,
+                "$accountUuid.trashFolderSelection",
                 SpecialFolderSelection.AUTOMATIC
             )
             setTrashFolderId(trashFolderId, trashFolderSelection)
 
             val archiveFolderId = storage.getString("$accountUuid.archiveFolderId", null)?.toLongOrNull()
             val archiveFolderSelection = getEnumStringPref<SpecialFolderSelection>(
-                storage, "$accountUuid.archiveFolderSelection",
+                storage,
+                "$accountUuid.archiveFolderSelection",
                 SpecialFolderSelection.AUTOMATIC
             )
             setArchiveFolderId(archiveFolderId, archiveFolderSelection)
 
             val spamFolderId = storage.getString("$accountUuid.spamFolderId", null)?.toLongOrNull()
             val spamFolderSelection = getEnumStringPref<SpecialFolderSelection>(
-                storage, "$accountUuid.spamFolderSelection",
+                storage,
+                "$accountUuid.spamFolderSelection",
                 SpecialFolderSelection.AUTOMATIC
             )
             setSpamFolderId(spamFolderId, spamFolderSelection)
@@ -524,8 +529,11 @@ class AccountPreferenceSerializer(
                 java.lang.Enum.valueOf<T>(defaultEnum.declaringJavaClass, stringPref)
             } catch (ex: IllegalArgumentException) {
                 Timber.w(
-                    ex, "Unable to convert preference key [%s] value [%s] to enum of type %s",
-                    key, stringPref, defaultEnum.declaringJavaClass
+                    ex,
+                    "Unable to convert preference key [%s] value [%s] to enum of type %s",
+                    key,
+                    stringPref,
+                    defaultEnum.declaringJavaClass
                 )
 
                 defaultEnum

--- a/app/core/src/main/java/com/fsck/k9/Core.kt
+++ b/app/core/src/main/java/com/fsck/k9/Core.kt
@@ -65,10 +65,11 @@ object Core : EarlyInit {
             if (enabled != alreadyEnabled) {
                 pm.setComponentEnabledSetting(
                     ComponentName(context, clazz),
-                    if (enabled)
+                    if (enabled) {
                         PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                    else
-                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    } else {
+                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                    },
                     PackageManager.DONT_KILL_APP
                 )
             }

--- a/app/core/src/main/java/com/fsck/k9/autocrypt/AutocryptDraftStateHeader.kt
+++ b/app/core/src/main/java/com/fsck/k9/autocrypt/AutocryptDraftStateHeader.kt
@@ -49,13 +49,21 @@ data class AutocryptDraftStateHeader(
         fun fromCryptoStatus(cryptoStatus: CryptoStatus): AutocryptDraftStateHeader {
             if (cryptoStatus.isSignOnly) {
                 return AutocryptDraftStateHeader(
-                    false, true, cryptoStatus.isReplyToEncrypted,
-                    cryptoStatus.isUserChoice(), cryptoStatus.isPgpInlineModeEnabled, mapOf()
+                    false,
+                    true,
+                    cryptoStatus.isReplyToEncrypted,
+                    cryptoStatus.isUserChoice(),
+                    cryptoStatus.isPgpInlineModeEnabled,
+                    mapOf()
                 )
             }
             return AutocryptDraftStateHeader(
-                cryptoStatus.isEncryptionEnabled, false, cryptoStatus.isReplyToEncrypted,
-                cryptoStatus.isUserChoice(), cryptoStatus.isPgpInlineModeEnabled, mapOf()
+                cryptoStatus.isEncryptionEnabled,
+                false,
+                cryptoStatus.isReplyToEncrypted,
+                cryptoStatus.isUserChoice(),
+                cryptoStatus.isPgpInlineModeEnabled,
+                mapOf()
             )
         }
     }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettings.kt
@@ -9,5 +9,5 @@ data class FolderSettings(
     val notifyClass: FolderClass,
     val pushClass: FolderClass,
     val inTopGroup: Boolean,
-    val integrate: Boolean,
+    val integrate: Boolean
 )

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
@@ -19,7 +19,7 @@ class FolderSettingsProvider(val preferences: Preferences, val account: Account)
             notifyClass = storage.getString("$prefix.notifyMode", null).toFolderClass(FolderClass.INHERITED),
             pushClass = storage.getString("$prefix.pushMode", null).toFolderClass(FolderClass.SECOND_CLASS),
             inTopGroup = storage.getBoolean("$prefix.inTopGroup", false),
-            integrate = storage.getBoolean("$prefix.integrate", false),
+            integrate = storage.getBoolean("$prefix.integrate", false)
         ).also {
             removeImportedFolderSettings(prefix)
         }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageRepository.kt
@@ -63,7 +63,7 @@ class MessageRepository(private val messageStoreManager: MessageStoreManager) {
             "reply-to",
             "to",
             "cc",
-            "bcc",
+            "bcc"
         )
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/OutboxStateRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/OutboxStateRepository.kt
@@ -15,7 +15,10 @@ class OutboxStateRepository(private val database: LockableDatabase, private val 
                 TABLE_NAME,
                 COLUMNS,
                 "$COLUMN_MESSAGE_ID = ?",
-                arrayOf(messageId.toString()), null, null, null
+                arrayOf(messageId.toString()),
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (!cursor.moveToFirst()) {
                     throw IllegalStateException("No outbox_state entry for message with id $messageId")

--- a/app/core/src/main/java/com/fsck/k9/message/html/UriMatcher.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/UriMatcher.kt
@@ -10,7 +10,7 @@ object UriMatcher {
             "mailto:" to genericUriParser,
             "matrix:" to genericUriParser,
             "rtsp:" to httpUriParser,
-            "xmpp:" to genericUriParser,
+            "xmpp:" to genericUriParser
         )
     }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -120,7 +120,9 @@ val coreNotificationModule = module {
     }
     factory {
         NotificationSettingsUpdater(
-            preferences = get(), notificationChannelManager = get(), notificationConfigurationConverter = get()
+            preferences = get(),
+            notificationChannelManager = get(),
+            notificationConfigurationConverter = get()
         )
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
@@ -36,8 +36,8 @@ internal class SingleMessageNotificationDataCreator {
                 content = data.activeNotifications.first().content,
                 actions = createSingleNotificationActions(),
                 wearActions = createSingleNotificationWearActions(data.account),
-                addLockScreenNotification = false,
-            ),
+                addLockScreenNotification = false
+            )
         )
     }
 

--- a/app/core/src/main/java/com/fsck/k9/power/AndroidPowerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/power/AndroidPowerManager.kt
@@ -70,7 +70,10 @@ internal class AndroidPowerManager(private val systemPowerManager: SystemPowerMa
 
                 Timber.v(
                     "AndroidWakeLock for tag %s / id %d: releasing after %d ms, timeout = %d ms",
-                    tag, id, endTime - startTime, timeout
+                    tag,
+                    id,
+                    endTime - startTime,
+                    timeout
                 )
             } else {
                 Timber.v("AndroidWakeLock for tag %s / id %d, timeout = %d ms: releasing", tag, id, timeout)

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -105,7 +105,8 @@ class SettingsExporter(
                 } catch (e: InvalidSettingValueException) {
                     Timber.w(
                         "Global setting \"%s\" has invalid value \"%s\" in preference storage. This shouldn't happen!",
-                        key, valueString
+                        key,
+                        valueString
                     )
                 }
             } else {
@@ -271,7 +272,9 @@ class SettingsExporter(
                     Timber.w(
                         "Account setting \"%s\" (%s) has invalid value \"%s\" in preference storage. " +
                             "This shouldn't happen!",
-                        keyPart, account, valueString
+                        keyPart,
+                        account,
+                        valueString
                     )
                 }
             }
@@ -375,7 +378,8 @@ class SettingsExporter(
                         Timber.w(
                             "Identity setting \"%s\" has invalid value \"%s\" in preference storage. " +
                                 "This shouldn't happen!",
-                            identityKey, valueString
+                            identityKey,
+                            valueString
                         )
                     }
                 }
@@ -413,7 +417,8 @@ class SettingsExporter(
                 } catch (e: InvalidSettingValueException) {
                     Timber.w(
                         "Folder setting \"%s\" has invalid value \"%s\" in preference storage. This shouldn't happen!",
-                        key, value
+                        key,
+                        value
                     )
                 }
             }

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -25,7 +25,9 @@ fun LocalSearch.limitToDisplayableFolders(account: Account) {
 
             // TODO: Create a proper interface for creating arbitrary condition trees
             val searchCondition = SearchCondition(
-                SearchField.DISPLAY_CLASS, Attribute.EQUALS, FolderClass.SECOND_CLASS.name
+                SearchField.DISPLAY_CLASS,
+                Attribute.EQUALS,
+                FolderClass.SECOND_CLASS.name
             )
             val root = conditions
             if (root.mRight != null) {

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
@@ -86,7 +86,7 @@ internal fun createFolderSettingsProvider(): FolderSettingsProvider {
                 notifyClass = FolderClass.INHERITED,
                 pushClass = FolderClass.SECOND_CLASS,
                 inTopGroup = false,
-                integrate = false,
+                integrate = false
             )
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/MessageListRepositoryTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/MessageListRepositoryTest.kt
@@ -429,5 +429,5 @@ private data class MessageData(
     val isRead: Boolean = false,
     val isStarred: Boolean = false,
     val isAnswered: Boolean = false,
-    val isForwarded: Boolean = false,
+    val isForwarded: Boolean = false
 )

--- a/app/core/src/test/java/com/fsck/k9/message/html/DisplayHtmlTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/html/DisplayHtmlTest.kt
@@ -51,7 +51,8 @@ class DisplayHtmlTest {
         val numberOfFoundElements = document.select(cssQuery).size
         assertEquals(
             "Expected to find '$cssQuery' $numberOfExpectedOccurrences time(s) in:\n$html",
-            numberOfExpectedOccurrences, numberOfFoundElements
+            numberOfExpectedOccurrences,
+            numberOfFoundElements
         )
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
@@ -113,7 +113,9 @@ class CertificateErrorNotificationControllerTest : RobolectricTest() {
     }
 
     internal inner class TestCertificateErrorNotificationController : CertificateErrorNotificationController(
-        notificationHelper, mock(), resourceProvider
+        notificationHelper,
+        mock(),
+        resourceProvider
     ) {
         override fun createContentIntent(account: Account, incoming: Boolean): PendingIntent {
             return contentIntent

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
@@ -382,7 +382,10 @@ class NewMailNotificationManagerTest {
             on { createFromMessage(account, message) } doReturn
                 NotificationContent(
                     messageReference = createMessageReference(messageUid),
-                    sender, subject, preview, summary
+                    sender,
+                    subject,
+                    preview,
+                    summary
                 )
         }
 
@@ -407,7 +410,10 @@ class NewMailNotificationManagerTest {
             on { createFromMessage(account, message) } doReturn
                 NotificationContent(
                     messageReference = createMessageReference(messageUid),
-                    sender, subject, preview, summary
+                    sender,
+                    subject,
+                    preview,
+                    summary
                 )
         }
     }

--- a/app/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
@@ -41,9 +41,9 @@ class NotificationIdsTest {
     }
 
     @Test
-    // We avoid gaps. So this test failing is an indication that getGeneralNotificationIds() and/or
-    // getAccountNotificationIds() need to be updated.
     fun `no gaps between general and account notification IDs`() {
+        // We avoid gaps. So this test failing is an indication that getGeneralNotificationIds() and/or
+        // getAccountNotificationIds() need to be updated.
         val account = createAccount(0)
 
         val generalNotificationIds = getGeneralNotificationIds()
@@ -55,8 +55,8 @@ class NotificationIdsTest {
     }
 
     @Test
-    // We avoid gaps. So this test failing is an indication that getAccountNotificationIds() needs to be updated.
     fun `no gaps in notification IDs of an account`() {
+        // We avoid gaps. So this test failing is an indication that getAccountNotificationIds() needs to be updated.
         val account = createAccount(0)
 
         val notificationIds = getAccountNotificationIds(account)
@@ -68,8 +68,8 @@ class NotificationIdsTest {
     }
 
     @Test
-    // We avoid gaps. So this test failing is an indication that getAccountNotificationIds() needs to be updated.
     fun `no gap between notification IDs of adjacent accounts`() {
+        // We avoid gaps. So this test failing is an indication that getAccountNotificationIds() needs to be updated.
         val account1 = createAccount(1)
         val account2 = createAccount(2)
 
@@ -104,7 +104,7 @@ class NotificationIdsTest {
             NotificationIds.getAuthenticationErrorNotificationId(account, true),
             NotificationIds.getAuthenticationErrorNotificationId(account, false),
             NotificationIds.getFetchingMailNotificationId(account),
-            NotificationIds.getNewMailSummaryNotificationId(account),
+            NotificationIds.getNewMailSummaryNotificationId(account)
         ) + getNewMessageNotificationIds(account)
     }
 

--- a/app/html-cleaner/src/main/java/app/k9mail/html/cleaner/BodyCleaner.kt
+++ b/app/html-cleaner/src/main/java/app/k9mail/html/cleaner/BodyCleaner.kt
@@ -18,7 +18,13 @@ internal class BodyCleaner {
             .addAttributes("a", "name")
             .addAttributes("div", "align")
             .addAttributes(
-                "table", "align", "background", "bgcolor", "border", "cellpadding", "cellspacing",
+                "table",
+                "align",
+                "background",
+                "bgcolor",
+                "border",
+                "cellpadding",
+                "cellspacing",
                 "width"
             )
             .addAttributes("tr", "align", "background", "bgcolor", "valign")

--- a/app/k9mail/src/main/java/com/fsck/k9/App.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/App.kt
@@ -138,7 +138,7 @@ class App : Application(), WorkManagerConfiguration.Provider {
                 MessageCompose::class.java,
                 LauncherShortcuts::class.java,
                 UnreadWidgetProvider::class.java,
-                MessageListWidgetProvider::class.java,
+                MessageListWidgetProvider::class.java
             )
         )
     }

--- a/app/k9mail/src/main/java/com/fsck/k9/Dependencies.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/Dependencies.kt
@@ -22,7 +22,7 @@ private val mainAppModule = module {
     single {
         MessagingListenerProvider(
             listOf(
-                get<UnreadWidgetUpdateListener>(),
+                get<UnreadWidgetUpdateListener>()
             )
         )
     }

--- a/app/k9mail/src/main/java/com/fsck/k9/auth/OAuthConfigurations.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/auth/OAuthConfigurations.kt
@@ -39,7 +39,7 @@ fun createOAuthConfigurationProvider(): OAuthConfigurationProvider {
                 authorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
                 tokenEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/token",
                 redirectUri = BuildConfig.OAUTH_MICROSOFT_REDIRECT_URI
-            ),
+            )
         ),
         googleConfiguration = googleConfig
     )

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -50,7 +50,8 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun newMessagesTitle(newMessagesCount: Int): String =
         context.resources.getQuantityString(
             R.plurals.notification_new_messages_title,
-            newMessagesCount, newMessagesCount
+            newMessagesCount,
+            newMessagesCount
         )
 
     override fun additionalMessages(overflowMessagesCount: Int, accountName: String): String =

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -19,7 +19,6 @@ class K9NotificationStrategy(private val contacts: Contacts) : NotificationStrat
         message: LocalMessage,
         isOldMessage: Boolean
     ): Boolean {
-
         if (!K9.isNotificationDuringQuietTimeEnabled && K9.isQuietTime) {
             Timber.v("No notification: Quiet time is active")
             return false

--- a/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -29,14 +29,20 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     private val folderRepository = createFolderRepository()
     private val folderNameFormatterFactory = createFolderNameFormatterFactory()
     private val provider = UnreadWidgetDataProvider(
-        context, preferences, messageCountsProvider, defaultFolderStrategy,
-        folderRepository, folderNameFormatterFactory
+        context,
+        preferences,
+        messageCountsProvider,
+        defaultFolderStrategy,
+        folderRepository,
+        folderNameFormatterFactory
     )
 
     @Test
     fun unifiedInbox() {
         val configuration = UnreadWidgetConfiguration(
-            appWidgetId = 1, accountUuid = SearchAccount.UNIFIED_INBOX, folderId = null
+            appWidgetId = 1,
+            accountUuid = SearchAccount.UNIFIED_INBOX,
+            folderId = null
         )
 
         val widgetData = provider.loadUnreadWidgetData(configuration)
@@ -50,7 +56,9 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     @Test
     fun regularAccount() {
         val configuration = UnreadWidgetConfiguration(
-            appWidgetId = 3, accountUuid = ACCOUNT_UUID, folderId = null
+            appWidgetId = 3,
+            accountUuid = ACCOUNT_UUID,
+            folderId = null
         )
 
         val widgetData = provider.loadUnreadWidgetData(configuration)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/CheckFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/CheckFolderOperations.kt
@@ -13,7 +13,8 @@ internal class CheckFolderOperations(private val lockableDatabase: LockableDatab
             ) { selectionSet, selectionArguments ->
                 if (allIncludedInUnifiedInbox) {
                     database.rawQuery(
-                        "SELECT COUNT(id) FROM folders WHERE integrate = 1 AND id $selectionSet", selectionArguments
+                        "SELECT COUNT(id) FROM folders WHERE integrate = 1 AND id $selectionSet",
+                        selectionArguments
                     ).use { cursor ->
                         if (cursor.moveToFirst()) {
                             val count = cursor.getInt(0)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
@@ -236,7 +236,9 @@ ORDER BY message_parts.seq
             ),
             "id = ?",
             arrayOf(messageId.toString()),
-            null, null, null
+            null,
+            null,
+            null
         ).use { cursor ->
             if (!cursor.moveToNext()) error("Message with ID $messageId not found")
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/KeyValueStoreOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/KeyValueStoreOperations.kt
@@ -14,7 +14,9 @@ internal class KeyValueStoreOperations(private val lockableDatabase: LockableDat
                 arrayOf("value_text"),
                 "name = ?",
                 arrayOf(name),
-                null, null, null
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
                     cursor.getStringOrNull(0)
@@ -42,7 +44,9 @@ internal class KeyValueStoreOperations(private val lockableDatabase: LockableDat
                 arrayOf("value_integer"),
                 "name = ?",
                 arrayOf(name),
-                null, null, null
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
                     cursor.getLongOrNull(0)
@@ -70,7 +74,9 @@ internal class KeyValueStoreOperations(private val lockableDatabase: LockableDat
                 arrayOf("value_text"),
                 "name = ? AND folder_id = ?",
                 arrayOf(name, folderId.toString()),
-                null, null, null
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
                     cursor.getStringOrNull(0)
@@ -99,7 +105,9 @@ internal class KeyValueStoreOperations(private val lockableDatabase: LockableDat
                 arrayOf("value_integer"),
                 "name = ? AND folder_id = ?",
                 arrayOf(name, folderId.toString()),
-                null, null, null
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
                     cursor.getLongOrNull(0)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/MoveMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/MoveMessageOperations.kt
@@ -55,7 +55,9 @@ internal class MoveMessageOperations(
             ),
             "id = ?",
             arrayOf(messageId.toString()),
-            null, null, null
+            null,
+            null,
+            null
         ).use { cursor ->
             if (!cursor.moveToFirst()) {
                 error("Couldn't find local message [ID: $messageId]")

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
@@ -46,7 +46,7 @@ WHERE
   AND empty = 0 AND deleted = 0
 ORDER BY $sortOrder
                 """,
-                selectionArgs,
+                selectionArgs
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = false)
                 buildList {
@@ -171,7 +171,7 @@ WHERE
   AND empty = 0 AND deleted = 0
 ORDER BY $sortOrder
                 """,
-                arrayOf(threadId.toString()),
+                arrayOf(threadId.toString())
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = false)
                 buildList {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageListOperations.kt
@@ -126,7 +126,7 @@ JOIN folders ON (folders.id = messages.folder_id)
 GROUP BY threads.root
 ORDER BY $orderBy
                 """,
-                selectionArgs,
+                selectionArgs
             ).use { cursor ->
                 val cursorMessageAccessor = CursorMessageAccessor(cursor, includesThreadCount = true)
                 buildList {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveMessageOperations.kt
@@ -20,7 +20,9 @@ internal class RetrieveMessageOperations(private val lockableDatabase: LockableD
                 arrayOf("uid"),
                 "id = ?",
                 arrayOf(messageId.toString()),
-                null, null, null
+                null,
+                null,
+                null
             ).use { cursor ->
                 if (cursor.moveToFirst()) {
                     cursor.getString(0)
@@ -174,7 +176,7 @@ internal class RetrieveMessageOperations(private val lockableDatabase: LockableD
                 "SELECT message_parts.header FROM messages" +
                     " LEFT JOIN message_parts ON (messages.message_part_id = message_parts.id)" +
                     " WHERE messages.folder_id = ? AND messages.uid = ?",
-                arrayOf(folderId.toString(), messageServerId),
+                arrayOf(folderId.toString(), messageServerId)
             ).use { cursor ->
                 if (!cursor.moveToFirst()) throw MessageNotFoundException(folderId, messageServerId)
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
@@ -25,7 +25,7 @@ FROM messages
 LEFT JOIN message_parts ON (messages.message_part_id = message_parts.id) 
 WHERE messages.id = ?
             """,
-            arrayOf(messageId.toString()),
+            arrayOf(messageId.toString())
         ).use { cursor ->
             if (!cursor.moveToFirst()) error("Message not found: $messageId")
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo84.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo84.kt
@@ -17,7 +17,6 @@ internal class MigrationTo84(private val db: SQLiteDatabase) {
             null
         ).use { cursor ->
             cursor.map {
-
                 val messageId = it.getLong(0)
 
                 messageId to AddressSet(

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/FolderHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/FolderHelpers.kt
@@ -23,7 +23,7 @@ fun SQLiteDatabase.createFolder(
     visibleLimit: Int = 25,
     status: String? = null,
     flaggedCount: Int = 0,
-    moreMessages: String = "unknown",
+    moreMessages: String = "unknown"
 ): Long {
     val values = ContentValues().apply {
         put("name", name)

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/MessagePartDatabaseHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/MessagePartDatabaseHelpers.kt
@@ -71,7 +71,7 @@ fun SQLiteDatabase.readMessageParts(): List<MessagePartEntry> {
                 epilogue = cursor.getStringOrNull("epilogue"),
                 boundary = cursor.getStringOrNull("boundary"),
                 contentId = cursor.getStringOrNull("content_id"),
-                serverExtra = cursor.getStringOrNull("server_extra"),
+                serverExtra = cursor.getStringOrNull("server_extra")
             )
         }
     }

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
@@ -197,7 +197,7 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
         val (folderId1, folderId2, _) = listOf(
             sqliteDatabase.createFolder(name = "Folder 1", displayClass = "FIRST_CLASS"),
             sqliteDatabase.createFolder(name = "Folder 2", displayClass = "SECOND_CLASS"),
-            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS"),
+            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS")
         )
 
         val result = retrieveFolderOperations.getDisplayFolders(
@@ -215,7 +215,7 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
         val (folderId1, _, folderId3) = listOf(
             sqliteDatabase.createFolder(name = "Folder 1", displayClass = "FIRST_CLASS"),
             sqliteDatabase.createFolder(name = "Folder 2", displayClass = "SECOND_CLASS"),
-            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS"),
+            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS")
         )
 
         val result = retrieveFolderOperations.getDisplayFolders(
@@ -238,7 +238,7 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
         val (folderId1, folderId2, _) = listOf(
             sqliteDatabase.createFolder(name = "Folder 1", displayClass = "FIRST_CLASS"),
             sqliteDatabase.createFolder(name = "Folder 2", displayClass = "SECOND_CLASS"),
-            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS"),
+            sqliteDatabase.createFolder(name = "Folder 3", displayClass = "NO_CLASS")
         )
 
         val result = retrieveFolderOperations.getDisplayFolders(
@@ -292,7 +292,7 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
     fun `get folder id`() {
         val (_, folderId2) = listOf(
             sqliteDatabase.createFolder(serverId = "folder1"),
-            sqliteDatabase.createFolder(serverId = "folder2"),
+            sqliteDatabase.createFolder(serverId = "folder2")
         )
 
         val result = retrieveFolderOperations.getFolderId(folderServerId = "folder2")
@@ -311,7 +311,7 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
     fun `get folder server id`() {
         val (_, folderId2) = listOf(
             sqliteDatabase.createFolder(serverId = "folder1"),
-            sqliteDatabase.createFolder(serverId = "folder2"),
+            sqliteDatabase.createFolder(serverId = "folder2")
         )
 
         val result = retrieveFolderOperations.getFolderServerId(folderId2)

--- a/app/storage/src/test/java/com/fsck/k9/storage/notifications/NotificationsTableHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/notifications/NotificationsTableHelpers.kt
@@ -36,5 +36,5 @@ fun SQLiteDatabase.readNotifications(): List<NotificationEntry> {
 data class NotificationEntry(
     val messageId: Long?,
     val notificationId: Int?,
-    val timestamp: Long?,
+    val timestamp: Long?
 )

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/ThemeManager.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/ThemeManager.kt
@@ -21,7 +21,7 @@ class ThemeManager(
     private val context: Context,
     private val themeProvider: ThemeProvider,
     private val generalSettingsManager: GeneralSettingsManager,
-    private val appCoroutineScope: CoroutineScope,
+    private val appCoroutineScope: CoroutineScope
 ) {
 
     private val generalSettings: GeneralSettings

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/extensions/TextInputLayoutExtensions.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/extensions/TextInputLayoutExtensions.kt
@@ -32,7 +32,7 @@ fun TextInputLayout.configureAuthenticatedPasswordToggle(
     activity: FragmentActivity,
     title: String,
     subtitle: String,
-    needScreenLockMessage: String,
+    needScreenLockMessage: String
 ) {
     val viewModel = ViewModelProvider(activity).get<AuthenticatedPasswordToggleViewModel>()
     viewModel.textInputLayout = this

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
@@ -12,8 +12,11 @@ class FolderInfoHolder(
     account: Account
 ) {
     @JvmField val databaseId = localFolder.databaseId
+
     @JvmField val displayName = getDisplayName(account, localFolder)
+
     @JvmField var loading = false
+
     @JvmField var moreMessages = localFolder.hasMoreMessages()
 
     private fun getDisplayName(account: Account, localFolder: LocalFolder): String {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -274,7 +274,9 @@ open class MessageList :
         if (!hasMessageListFragment) {
             val fragmentTransaction = fragmentManager.beginTransaction()
             val messageListFragment = MessageListFragment.newInstance(
-                search!!, false, K9.isThreadedViewEnabled && !noThreading
+                search!!,
+                false,
+                K9.isThreadedViewEnabled && !noThreading
             )
             fragmentTransaction.add(R.id.message_list_container, messageListFragment)
             fragmentTransaction.commitNow()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
@@ -32,7 +32,7 @@ data class MessageListActivityConfig(
     val fontSizeMessageViewDate: Int,
     val fontSizeMessageViewContentAsPercent: Int,
     val swipeRightAction: SwipeAction,
-    val swipeLeftAction: SwipeAction,
+    val swipeLeftAction: SwipeAction
 ) {
 
     companion object {
@@ -64,7 +64,7 @@ data class MessageListActivityConfig(
                 fontSizeMessageViewDate = K9.fontSizes.messageViewDate,
                 fontSizeMessageViewContentAsPercent = K9.fontSizes.messageViewContentAsPercent,
                 swipeRightAction = K9.swipeRightAction,
-                swipeLeftAction = K9.swipeLeftAction,
+                swipeLeftAction = K9.swipeLeftAction
             )
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -580,7 +580,8 @@ class RecipientPresenter(
         if (currentCryptoMode == CryptoMode.NO_CHOICE) {
             if (currentCryptoStatus.hasAutocryptPendingIntent()) {
                 recipientMvpView.launchUserInteractionPendingIntent(
-                    currentCryptoStatus.autocryptPendingIntent, REQUEST_CODE_AUTOCRYPT
+                    currentCryptoStatus.autocryptPendingIntent,
+                    REQUEST_CODE_AUTOCRYPT
                 )
             } else if (isEncryptOnNoChoice) {
                 // TODO warning dialog if we override, especially from reply!

--- a/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
@@ -35,7 +35,8 @@ class ContactLetterBitmapCreator(
         canvas.drawText(
             letter,
             pictureSizeInPx / 2f - width / 2f,
-            pictureSizeInPx / 2f + rect.height() / 2f, paint
+            pictureSizeInPx / 2f + rect.height() / 2f,
+            paint
         )
 
         return bitmap

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -313,7 +313,10 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         swipeRefreshLayout.setOnRefreshListener {
             val accountToRefresh = if (headerView.selectionListShown) null else account
             messagingController.checkMail(
-                accountToRefresh, true, true, true,
+                accountToRefresh,
+                true,
+                true,
+                true,
                 object : SimpleMessagingListener() {
                     override fun checkMailFinished(context: Context?, account: Account?) {
                         swipeRefreshLayout.post {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageModelLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageModelLoader.kt
@@ -18,7 +18,7 @@ import java.security.MessageDigest
  */
 internal class AccountImageModelLoader(
     private val contactPhotoLoader: ContactPhotoLoader,
-    private val accountFallbackImageProvider: AccountFallbackImageProvider,
+    private val accountFallbackImageProvider: AccountFallbackImageProvider
 ) : ModelLoader<AccountImage, Bitmap> {
     override fun buildLoadData(
         accountImage: AccountImage,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/helper/ContextExtensions.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/helper/ContextExtensions.kt
@@ -1,4 +1,5 @@
 @file:JvmName("ContextHelper")
+
 package com.fsck.k9.ui.helper
 
 import android.app.Activity

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1156,7 +1156,8 @@ class MessageListFragment :
                 operation == FolderOperation.COPY && !messagingController.isCopyCapable(message)
             ) {
                 val toast = Toast.makeText(
-                    activity, R.string.move_copy_cannot_copy_unsynced_message,
+                    activity,
+                    R.string.move_copy_cannot_copy_unsynced_message,
                     Toast.LENGTH_LONG
                 )
                 toast.show()
@@ -2064,7 +2065,7 @@ class MessageListFragment :
                 arguments = bundleOf(
                     ARG_SEARCH to search,
                     ARG_IS_THREAD_DISPLAY to isThreadDisplay,
-                    ARG_THREADED_LIST to threadedList,
+                    ARG_THREADED_LIST to threadedList
                 )
             }
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -338,7 +338,9 @@ class MessageViewFragment :
         hideKeyboard()
 
         val handledByCryptoPresenter = messageCryptoPresenter.maybeHandleShowMessage(
-            messageTopView, account, messageViewInfo
+            messageTopView,
+            account,
+            messageViewInfo
         )
 
         if (!handledByCryptoPresenter) {
@@ -673,8 +675,11 @@ class MessageViewFragment :
                 val confirmText = getString(R.string.dialog_confirm_delete_confirm_button)
                 val cancelText = getString(R.string.dialog_confirm_delete_cancel_button)
                 ConfirmationDialogFragment.newInstance(
-                    dialogId, title, message,
-                    confirmText, cancelText
+                    dialogId,
+                    title,
+                    message,
+                    confirmText,
+                    cancelText
                 )
             }
             R.id.dialog_confirm_spam -> {
@@ -683,8 +688,11 @@ class MessageViewFragment :
                 val confirmText = getString(R.string.dialog_confirm_spam_confirm_button)
                 val cancelText = getString(R.string.dialog_confirm_spam_cancel_button)
                 ConfirmationDialogFragment.newInstance(
-                    dialogId, title, message,
-                    confirmText, cancelText
+                    dialogId,
+                    title,
+                    message,
+                    confirmText,
+                    cancelText
                 )
             }
             R.id.dialog_attachment_progress -> {
@@ -827,7 +835,12 @@ class MessageViewFragment :
 
             val maskedRequestCode = requestCode or REQUEST_MASK_CRYPTO_PRESENTER
             requireActivity().startIntentSenderForResult(
-                intentSender, maskedRequestCode, fillIntent, flagsMask, flagValues, extraFlags
+                intentSender,
+                maskedRequestCode,
+                fillIntent,
+                flagsMask,
+                flagValues,
+                extraFlags
             )
         }
 
@@ -917,7 +930,12 @@ class MessageViewFragment :
             try {
                 val maskedRequestCode = requestCode or REQUEST_MASK_LOADER_HELPER
                 requireActivity().startIntentSenderForResult(
-                    intentSender, maskedRequestCode, fillIntent, flagsMask, flagValues, extraFlags
+                    intentSender,
+                    maskedRequestCode,
+                    fillIntent,
+                    flagsMask,
+                    flagValues,
+                    extraFlags
                 )
             } catch (e: SendIntentException) {
                 Timber.e(e, "Irrecoverable error calling PendingIntent!")

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
@@ -75,7 +75,11 @@ class RecipientNamesView(context: Context, attrs: AttributeSet?) : ViewGroup(con
 
         if (isInEditMode) {
             recipientNames = listOf(
-                "Grace Hopper", "Katherine Johnson", "Margaret Hamilton", "Adele Goldberg", "Steve Shirley"
+                "Grace Hopper",
+                "Katherine Johnson",
+                "Margaret Hamilton",
+                "Adele Goldberg",
+                "Steve Shirley"
             )
             numberOfRecipients = 8
         }
@@ -116,7 +120,9 @@ class RecipientNamesView(context: Context, attrs: AttributeSet?) : ViewGroup(con
         val availableWidth = width
 
         val recipientLayoutData = recipientLayoutCreator.createRecipientLayout(
-            recipientNames, numberOfRecipients, availableWidth
+            recipientNames,
+            numberOfRecipients,
+            availableWidth
         )
 
         recipientNameTextView.text = recipientLayoutData.recipientNames

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 internal class SettingsViewModel(
     private val accountManager: AccountManager,
     private val coroutineScope: CoroutineScope = GlobalScope,
-    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -280,7 +280,7 @@ class AccountSettingsDataStore(
                 vibration = NotificationVibration(
                     isEnabled = isVibrationEnabled,
                     pattern = vibrationPattern,
-                    repeatCount = vibrationTimes,
+                    repeatCount = vibrationTimes
                 )
             )
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptPreference.kt
@@ -17,7 +17,8 @@ constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = TypedArrayUtils.getAttr(
-        context, androidx.preference.R.attr.preferenceStyle,
+        context,
+        androidx.preference.R.attr.preferenceStyle,
         android.R.attr.preferenceStyle
     ),
     defStyleRes: Int = 0
@@ -48,7 +49,8 @@ constructor(
     companion object {
         init {
             PreferenceFragmentCompat.registerPreferenceFragment(
-                AutocryptPreferEncryptPreference::class.java, AutocryptPreferEncryptDialogFragment::class.java
+                AutocryptPreferEncryptPreference::class.java,
+                AutocryptPreferEncryptDialogFragment::class.java
             )
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
@@ -25,7 +25,8 @@ constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = TypedArrayUtils.getAttr(
-        context, androidx.preference.R.attr.dialogPreferenceStyle,
+        context,
+        androidx.preference.R.attr.dialogPreferenceStyle,
         android.R.attr.dialogPreferenceStyle
     ),
     defStyleRes: Int = 0

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/NotificationsPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/NotificationsPreference.kt
@@ -23,7 +23,8 @@ constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = TypedArrayUtils.getAttr(
-        context, androidx.preference.R.attr.preferenceStyle,
+        context,
+        androidx.preference.R.attr.preferenceStyle,
         android.R.attr.preferenceStyle
     ),
     defStyleRes: Int = 0
@@ -49,7 +50,8 @@ constructor(
     companion object {
         init {
             PreferenceFragmentCompat.registerPreferenceFragment(
-                NotificationsPreference::class.java, DialogFragment::class.java
+                NotificationsPreference::class.java,
+                DialogFragment::class.java
             )
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/VibrationPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/VibrationPreference.kt
@@ -75,7 +75,8 @@ constructor(
 
         init {
             PreferenceFragmentCompat.registerPreferenceFragment(
-                VibrationPreference::class.java, VibrationDialogFragment::class.java
+                VibrationPreference::class.java,
+                VibrationDialogFragment::class.java
             )
         }
 

--- a/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
@@ -47,7 +47,10 @@ class AttachmentPresenterTest : K9RobolectricTest() {
     @Before
     fun setUp() {
         attachmentPresenter = AttachmentPresenter(
-            ApplicationProvider.getApplicationContext(), attachmentMvpView, loaderManager, listener
+            ApplicationProvider.getApplicationContext(),
+            attachmentMvpView,
+            loaderManager,
+            listener
         )
     }
 
@@ -57,8 +60,13 @@ class AttachmentPresenterTest : K9RobolectricTest() {
         val message = MimeMessage()
         MimeMessageHelper.setBody(message, TextBody(TEXT))
         val attachmentViewInfo = AttachmentViewInfo(
-            MIME_TYPE, ATTACHMENT_NAME, size, URI, false,
-            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size), true
+            MIME_TYPE,
+            ATTACHMENT_NAME,
+            size,
+            URI,
+            false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size),
+            true
         )
         val messageViewInfo = MessageViewInfo(
             message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,
@@ -85,8 +93,13 @@ class AttachmentPresenterTest : K9RobolectricTest() {
         val message = MimeMessage()
         MimeMessageHelper.setBody(message, TextBody(TEXT))
         val attachmentViewInfo = AttachmentViewInfo(
-            MIME_TYPE, ATTACHMENT_NAME, size, URI, false,
-            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size), false
+            MIME_TYPE,
+            ATTACHMENT_NAME,
+            size,
+            URI,
+            false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size),
+            false
         )
         val messageViewInfo = MessageViewInfo(
             message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,

--- a/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
@@ -155,7 +155,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withOpportunistic() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED, null
+            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)
@@ -170,7 +171,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withOpportunistic__confirmed() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.AVAILABLE_CONFIRMED, null
+            RecipientAutocryptStatusType.AVAILABLE_CONFIRMED,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)
@@ -185,7 +187,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withOpportunistic__missingKeys() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.UNAVAILABLE, null
+            RecipientAutocryptStatusType.UNAVAILABLE,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)
@@ -200,7 +203,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withOpportunistic__privateMissingKeys() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.UNAVAILABLE, null
+            RecipientAutocryptStatusType.UNAVAILABLE,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)
@@ -217,7 +221,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withModeDisabled() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED, null
+            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)
@@ -234,7 +239,8 @@ class RecipientPresenterTest : K9RobolectricTest() {
     @Test
     fun getCurrentCryptoStatus_withModePrivate() {
         val recipientAutocryptStatus = RecipientAutocryptStatus(
-            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED, null
+            RecipientAutocryptStatusType.AVAILABLE_UNCONFIRMED,
+            null
         )
 
         setupCryptoProvider(recipientAutocryptStatus)

--- a/app/ui/legacy/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.kt
@@ -192,7 +192,8 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
         `when`(
             openPgpApi.executeApi(
                 capturedApiIntent.capture(),
-                any<OpenPgpDataSource>(), anyOrNull()
+                any<OpenPgpDataSource>(),
+                anyOrNull()
             )
         ).thenReturn(returnIntent)
 
@@ -217,7 +218,8 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
         val contentBodyPart = multipart.getBodyPart(0)
         Assert.assertEquals(
             "first part must have content type text/plain",
-            "text/plain", MimeUtility.getHeaderParameter(contentBodyPart.contentType, null)
+            "text/plain",
+            MimeUtility.getHeaderParameter(contentBodyPart.contentType, null)
         )
         assertTrue("signed message body must be TextBody", contentBodyPart.body is TextBody)
         Assert.assertEquals(MimeUtil.ENC_QUOTED_PRINTABLE, (contentBodyPart.body as TextBody).encoding)
@@ -226,16 +228,19 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
         val signatureBodyPart = multipart.getBodyPart(1)
         val contentType = signatureBodyPart.contentType
         Assert.assertEquals(
-            "second part must be pgp signature", "application/pgp-signature",
+            "second part must be pgp signature",
+            "application/pgp-signature",
             MimeUtility.getHeaderParameter(contentType, null)
         )
         Assert.assertEquals(
-            "second part must be called signature.asc", "signature.asc",
+            "second part must be called signature.asc",
+            "signature.asc",
             MimeUtility.getHeaderParameter(contentType, "name")
         )
         assertContentOfBodyPartEquals(
             "content must match the supplied detached signature",
-            signatureBodyPart, byteArrayOf(1, 2, 3)
+            signatureBodyPart,
+            byteArrayOf(1, 2, 3)
         )
 
         assertMessageHasAutocryptHeader(message, SENDER_EMAIL, false, AUTOCRYPT_KEY_MATERIAL)
@@ -483,7 +488,8 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
 
         `when`(
             openPgpApi.executeApi(
-                capturedApiIntent.capture(), any(OpenPgpDataSource::class.java),
+                capturedApiIntent.capture(),
+                any(OpenPgpDataSource::class.java),
                 any(OutputStream::class.java)
             )
         ).thenReturn(returnIntent)
@@ -512,17 +518,20 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
         val dummyBodyPart = multipart.getBodyPart(0)
         Assert.assertEquals(
             "first part must be pgp encrypted dummy part",
-            "application/pgp-encrypted", dummyBodyPart.contentType
+            "application/pgp-encrypted",
+            dummyBodyPart.contentType
         )
         assertContentOfBodyPartEquals(
             "content must match the supplied detached signature",
-            dummyBodyPart, "Version: 1"
+            dummyBodyPart,
+            "Version: 1"
         )
 
         val encryptedBodyPart = multipart.getBodyPart(1)
         Assert.assertEquals(
             "second part must be octet-stream of encrypted data",
-            "application/octet-stream; name=\"encrypted.asc\"", encryptedBodyPart.contentType
+            "application/octet-stream; name=\"encrypted.asc\"",
+            encryptedBodyPart.contentType
         )
         assertTrue(
             "message body must be BinaryTempFileBody",
@@ -550,7 +559,8 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
 
         `when`(
             openPgpApi.executeApi(
-                capturedApiIntent.capture(), any(OpenPgpDataSource::class.java),
+                capturedApiIntent.capture(),
+                any(OpenPgpDataSource::class.java),
                 any(OutputStream::class.java)
             )
         ).thenReturn(returnIntent)
@@ -595,7 +605,8 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
 
         `when`(
             openPgpApi.executeApi(
-                capturedApiIntent.capture(), any(OpenPgpDataSource::class.java),
+                capturedApiIntent.capture(),
+                any(OpenPgpDataSource::class.java),
                 any(OutputStream::class.java)
             )
         ).thenReturn(returnIntent)
@@ -707,8 +718,11 @@ class PgpMessageBuilderTest : K9RobolectricTest() {
             resourceProvider: CoreResourceProvider
         ): PgpMessageBuilder {
             val builder = PgpMessageBuilder(
-                MessageIdGenerator.getInstance(), BoundaryGenerator.getInstance(),
-                AutocryptOperations.getInstance(), autocryptOpenPgpApiInteractor, resourceProvider
+                MessageIdGenerator.getInstance(),
+                BoundaryGenerator.getInstance(),
+                AutocryptOperations.getInstance(),
+                autocryptOpenPgpApiInteractor,
+                resourceProvider
             )
             builder.setOpenPgpApi(openPgpApi)
 

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItem.kt
@@ -18,5 +18,5 @@ internal data class MessageListItem(
     val sortMessageDate: Long,
     val sortInternalDate: Long,
     val sortIsStarred: Boolean,
-    val sortDatabaseId: Long,
+    val sortDatabaseId: Long
 )

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListItemMapper.kt
@@ -44,7 +44,7 @@ internal class MessageListItemMapper(
             sortMessageDate = message.messageDate,
             sortInternalDate = message.internalDate,
             sortIsStarred = message.isStarred,
-            sortDatabaseId = message.id,
+            sortDatabaseId = message.id
         )
     }
 

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
 class MessageListWidgetManager(
     private val context: Context,
     private val messageListRepository: MessageListRepository,
-    private val config: MessageListWidgetConfig,
+    private val config: MessageListWidgetConfig
 ) {
     private lateinit var appWidgetManager: AppWidgetManager
 

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.kt
@@ -48,7 +48,8 @@ internal class CommandMoveOrCopyMessages(private val imapStore: ImapStore) {
             remoteSrcFolder.open(OpenMode.READ_WRITE)
             if (remoteSrcFolder.mode != OpenMode.READ_WRITE) {
                 throw MessagingException(
-                    "moveOrCopyMessages: could not open remoteSrcFolder $srcFolder read/write", true
+                    "moveOrCopyMessages: could not open remoteSrcFolder $srcFolder read/write",
+                    true
                 )
             }
 
@@ -56,7 +57,10 @@ internal class CommandMoveOrCopyMessages(private val imapStore: ImapStore) {
 
             Timber.d(
                 "moveOrCopyMessages: source folder = %s, %d messages, destination folder = %s, isCopy = %s",
-                srcFolder, messages.size, destFolder, isCopy
+                srcFolder,
+                messages.size,
+                destFolder,
+                isCopy
             )
 
             remoteDestFolder = imapStore.getFolder(destFolder)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.kt
@@ -131,7 +131,9 @@ internal class ImapSync(
 
                 Timber.v(
                     "SYNC: About to get messages %d through %d for folder %s",
-                    remoteStart, remoteMessageCount, folder
+                    remoteStart,
+                    remoteMessageCount,
+                    folder
                 )
 
                 val headerProgress = AtomicInteger(0)
@@ -235,7 +237,9 @@ internal class ImapSync(
             listener.syncFailed(folder, rootMessage, e)
 
             Timber.e(
-                "Failed synchronizing folder %s:%s @ %tc", accountName, folder,
+                "Failed synchronizing folder %s:%s @ %tc",
+                accountName,
+                folder,
                 System.currentTimeMillis()
             )
         } finally {
@@ -337,7 +341,9 @@ internal class ImapSync(
 
         Timber.d(
             "SYNC: Have %d large messages and %d small messages out of %d unsynced messages",
-            largeMessages.size, smallMessages.size, unsyncedMessages.size
+            largeMessages.size,
+            smallMessages.size,
+            unsyncedMessages.size
         )
 
         unsyncedMessages.clear()
@@ -458,7 +464,9 @@ internal class ImapSync(
                         if (message.isSet(Flag.DELETED)) {
                             Timber.v(
                                 "Newly downloaded message %s:%s:%s was marked deleted on server, skipping",
-                                accountName, folder, message.uid
+                                accountName,
+                                folder,
+                                message.uid
                             )
 
                             if (isFirstResponse) {
@@ -521,7 +529,9 @@ internal class ImapSync(
                         val messageServerId = message.uid
                         Timber.v(
                             "About to notify listeners that we got a new small message %s:%s:%s",
-                            accountName, folder, messageServerId
+                            accountName,
+                            folder,
+                            messageServerId
                         )
 
                         // Update the listener with what we've found
@@ -569,7 +579,9 @@ internal class ImapSync(
             val messageServerId = message.uid
             Timber.v(
                 "About to notify listeners that we got a new large message %s:%s:%s",
-                accountName, folder, messageServerId
+                accountName,
+                folder,
+                messageServerId
             )
 
             // Update the listener with what we've found

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,12 @@ spotless {
         trimTrailingWhitespace()
         endWithNewline()
     }
+    format("markdown") {
+        prettier()
+        target("**/*.md")
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
 }
 
 tasks.register('testsOnCi') {

--- a/build.gradle
+++ b/build.gradle
@@ -101,13 +101,14 @@ spotless {
         ktlint(libs.versions.ktlint.get())
             .setEditorConfigPath("$projectDir/.editorconfig")
         target("**/*.kt")
-        targetExclude("**/build/", "**/resources/")
+        targetExclude("**/build/", "**/resources/", "plugins/openpgp-api-lib/")
         trimTrailingWhitespace()
         endWithNewline()
     }
     format("markdown") {
         prettier()
         target("**/*.md")
+        targetExclude("plugins/openpgp-api-lib/")
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.spotless)
 }
 
@@ -94,11 +93,6 @@ allprojects {
         compilerOptions {
             jvmTarget = jvmTargetVersion
         }
-    }
-
-    apply plugin: 'org.jlleitschuh.gradle.ktlint'
-    ktlint {
-        version = libs.versions.ktlint.get()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,6 @@ spotless {
             .setEditorConfigPath("$projectDir/.editorconfig")
         target("**/*.kt")
         targetExclude("**/build/", "**/resources/", "plugins/openpgp-api-lib/")
-        trimTrailingWhitespace()
         endWithNewline()
     }
     format("markdown") {

--- a/build.gradle
+++ b/build.gradle
@@ -104,11 +104,24 @@ spotless {
         targetExclude("**/build/", "**/resources/", "plugins/openpgp-api-lib/")
         endWithNewline()
     }
+    kotlinGradle {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("$projectDir/.editorconfig")
+        target("**/*.gradle.kts")
+        targetExclude("**/build/")
+        endWithNewline()
+    }
     format("markdown") {
         prettier()
         target("**/*.md")
         targetExclude("plugins/openpgp-api-lib/")
         trimTrailingWhitespace()
+        endWithNewline()
+    }
+    format("misc") {
+        target("**/*.gradle", "**/.gitignore")
+        trimTrailingWhitespace()
+        indentWithSpaces(4)
         endWithNewline()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.spotless)
 }
 
 project.ext {
@@ -98,6 +99,17 @@ allprojects {
     apply plugin: 'org.jlleitschuh.gradle.ktlint'
     ktlint {
         version = libs.versions.ktlint.get()
+    }
+}
+
+spotless {
+    kotlin {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("$projectDir/.editorconfig")
+        target("**/*.kt")
+        targetExclude("**/build/", "**/resources/")
+        trimTrailingWhitespace()
+        endWithNewline()
     }
 }
 

--- a/cli/html-cleaner-cli/README.md
+++ b/cli/html-cleaner-cli/README.md
@@ -12,6 +12,6 @@ Arguments:
   OUTPUT  Output file
 ```
 
-You can run this tool using the [html-cleaner](../../html-cleaner) script in the root directory of this repository. 
+You can run this tool using the [html-cleaner](../../html-cleaner) script in the root directory of this repository.
 It will compile the application and then run it using the given arguments. This allows you to make modifications to the
 [HTML cleaning code](../../app/html-cleaner/src/main/java/app/k9mail/html/cleaner) and test the changes right away.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -23,7 +23,7 @@ Additional, standalone, libraries used by K-9
 # Walkthrough
 
 To help you understand the design, the following sequence diagrams show typical flows through the
-classes. Each class is colour-coded by its top-level project. 
+classes. Each class is colour-coded by its top-level project.
 
 ## Reading email
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@
 
 [versions]
 androidGradlePlugin = "7.4.0"
-ktlint = "0.44.0"
+ktlint = "0.47.1"
+spotless = "6.14.0"
 
 kotlin = "1.8.0"
 kotlinCoroutines = "1.6.4"
@@ -39,6 +40,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = "org.jlleitschuh.gradle.ktlint:11.0.0"
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [libraries]
 desugar = "com.android.tools:desugar_jdk_libs:1.1.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ ksp = "com.google.devtools.ksp:1.8.0-1.0.8"
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-ktlint = "org.jlleitschuh.gradle.ktlint:11.0.0"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [libraries]

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
@@ -218,7 +218,12 @@ object MimeParameterDecoder {
                 parser.readExtendedParameterValueInto(data)
 
                 InitialExtendedValueParameterSection(
-                    newParameterName, parameterName, section, charsetName, language, data
+                    newParameterName,
+                    parameterName,
+                    section,
+                    charsetName,
+                    language,
+                    data
                 )
             } else {
                 val encodedParameterText = parameterText.substring(parser.position())

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/PartExtensions.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/PartExtensions.kt
@@ -1,4 +1,5 @@
 @file:JvmName("PartExtensions")
+
 package com.fsck.k9.mail.internet
 
 import com.fsck.k9.mail.Part

--- a/mail/common/src/main/java/com/fsck/k9/sasl/OAuthBearer.kt
+++ b/mail/common/src/main/java/com/fsck/k9/sasl/OAuthBearer.kt
@@ -1,4 +1,5 @@
 @file:JvmName("OAuthBearer")
+
 package com.fsck.k9.sasl
 
 import okio.ByteString.Companion.encodeUtf8

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
@@ -710,7 +710,10 @@ internal class RealImapConnection(
     ): List<ImapResponse> {
         val groupedIds = IdGrouper.groupIds(ids)
         val splitCommands = ImapCommandSplitter.splitCommand(
-            commandPrefix, commandSuffix, groupedIds, lineLengthLimit
+            commandPrefix,
+            commandSuffix,
+            groupedIds,
+            lineLengthLimit
         )
 
         return splitCommands.flatMap { splitCommand ->
@@ -831,7 +834,9 @@ internal class RealImapConnection(
                 } else {
                     Timber.w(
                         "After sending tag %s, got tag response from previous command %s for %s",
-                        tag, response, logId
+                        tag,
+                        response,
+                        logId
                     )
                 }
             }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -292,7 +292,8 @@ internal class RealImapFolder(
             if (K9MailLib.isDebug()) {
                 Timber.i(
                     "ImapFolder.copyMessages: couldn't find remote folder '%s' for %s",
-                    escapedDestinationFolderName, logId
+                    escapedDestinationFolderName,
+                    logId
                 )
             }
 
@@ -399,7 +400,8 @@ internal class RealImapFolder(
 
         val dateSearchString = getDateSearchString(earliestDate)
         val command = String.format(
-            Locale.US, "UID SEARCH %d:%d%s%s",
+            Locale.US,
+            "UID SEARCH %d:%d%s%s",
             start,
             end,
             dateSearchString,
@@ -448,8 +450,11 @@ internal class RealImapFolder(
     @Throws(MessagingException::class, IOException::class)
     private fun existsNonDeletedMessageInRange(startIndex: Int, endIndex: Int, dateSearchString: String): Boolean {
         val command = String.format(
-            Locale.US, "SEARCH %d:%d%s NOT DELETED",
-            startIndex, endIndex, dateSearchString
+            Locale.US,
+            "SEARCH %d:%d%s NOT DELETED",
+            startIndex,
+            endIndex,
+            dateSearchString
         )
         val imapResponses = executeSimpleCommand(command)
 
@@ -969,8 +974,11 @@ internal class RealImapFolder(
                     canCreateKeywords || internalImapStore.getPermanentFlagsIndex().contains(Flag.FORWARDED)
                 )
                 val command = String.format(
-                    Locale.US, "APPEND %s (%s) {%d}",
-                    escapedFolderName, combinedFlags, messageSize
+                    Locale.US,
+                    "APPEND %s (%s) {%d}",
+                    escapedFolderName,
+                    combinedFlags,
+                    messageSize
                 )
                 connection!!.sendCommand(command, false)
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/UidValidityResponse.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/UidValidityResponse.kt
@@ -11,7 +11,9 @@ internal class UidValidityResponse private constructor(val uidValidity: Long) {
             val responseTextList = response.getList(1)
             if (responseTextList.size < 2 || !equalsIgnoreCase(responseTextList[0], Responses.UIDVALIDITY) ||
                 !responseTextList.isLong(1)
-            ) return null
+            ) {
+                return null
+            }
 
             val uidValidity = responseTextList.getLong(1)
             if (uidValidity !in 0L..0xFFFFFFFFL) return null

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -697,7 +697,7 @@ class RealImapConnectionTest {
         }
         val imapConnection = startServerAndCreateImapConnection(
             server,
-            connectionSecurity = ConnectionSecurity.STARTTLS_REQUIRED,
+            connectionSecurity = ConnectionSecurity.STARTTLS_REQUIRED
         )
 
         try {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -1171,7 +1171,9 @@ class RealImapFolderTest {
         val commandSuffixCaptor = argumentCaptor<String>()
         val commandUidsCaptor = argumentCaptor<Set<Long>>()
         verify(imapConnection, atLeastOnce()).executeCommandWithIdSet(
-            commandPrefixCaptor.capture(), commandSuffixCaptor.capture(), commandUidsCaptor.capture()
+            commandPrefixCaptor.capture(),
+            commandSuffixCaptor.capture(),
+            commandUidsCaptor.capture()
         )
 
         val commandPrefixes = commandPrefixCaptor.allValues

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapStoreTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapStoreTest.kt
@@ -413,7 +413,10 @@ class RealImapStoreTest {
         trustedSocketFactory: TrustedSocketFactory,
         oauth2TokenProvider: OAuth2TokenProvider?
     ) : RealImapStore(
-        serverSettings, config, trustedSocketFactory, oauth2TokenProvider
+        serverSettings,
+        config,
+        trustedSocketFactory,
+        oauth2TokenProvider
     ) {
         private val imapConnections: Deque<ImapConnection> = ArrayDeque()
         private var testCombinedPrefix: String? = null

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -414,7 +414,8 @@ class SmtpTransport(
 
             val msgOut = EOLConvertingOutputStream(
                 LineWrapOutputStream(
-                    SmtpDataStuffing(outputStream), 1000
+                    SmtpDataStuffing(outputStream),
+                    1000
                 )
             )
 

--- a/plugins/openpgp-api-lib/CHANGELOG.md
+++ b/plugins/openpgp-api-lib/CHANGELOG.md
@@ -1,56 +1,48 @@
 # Version history
 
 ## Version 10
-
-- Retrieve whole public key via ACTION_GET_KEY
+  * Retrieve whole public key via ACTION_GET_KEY
 
 ## Version 9
-
-- AIDL Service has been changed from IOpenPgpService.aidl to IOpenPgpService2.aidl
-  This fixes truncated data streams (thanks to 'mgeier63').
-- Fix for OpenPgpKeyPreference: Properly execute pending user interactions
-- Charset moved to OpenPgpMetadata
+  * AIDL Service has been changed from IOpenPgpService.aidl to IOpenPgpService2.aidl  
+    This fixes truncated data streams (thanks to 'mgeier63').
+  * Fix for OpenPgpKeyPreference: Properly execute pending user interactions
+  * Charset moved to OpenPgpMetadata
 
 ## Version 8
-
-- OpenPgpSignatureResult:
-  method getStatus() renamed to getResult()
-  constants have been renamed for clarity
-  new constants: RESULT_NO_SIGNATURE, RESULT_INVALID_INSECURE
-  isSignatureOnly() has been deprecated
-- RESULT_TYPES have been removed
-- new OpenPgpDecryptionResult returned via RESULT_DECRYPTION
-- OpenPgpSignatureResult and OpenPgpDecryptionResult are never null, they are always returned.
+  * OpenPgpSignatureResult:  
+    method getStatus() renamed to getResult()  
+    constants have been renamed for clarity  
+    new constants: RESULT_NO_SIGNATURE, RESULT_INVALID_INSECURE  
+    isSignatureOnly() has been deprecated
+  * RESULT_TYPES have been removed
+  * new OpenPgpDecryptionResult returned via RESULT_DECRYPTION
+  * OpenPgpSignatureResult and OpenPgpDecryptionResult are never null, they are always returned.
 
 ## Version 7
-
-- Deprecation of ACCOUNT_NAME, please use ACTION_GET_SIGN_KEY_ID to get key id
-- Introduce EXTRA_SIGN_KEY_ID
-- New extra for ACTION_ENCRYPT and ACTION_SIGN_AND_ENCRYPT: EXTRA_ENABLE_COMPRESSION (default to true)
-- Return PendingIntent to view key for signatures
-- New result for ACTION_DECRYPT_VERIFY: RESULT_TYPE
-- New ACTION_GET_SIGN_KEY_ID
-- EXTRA_PASSPHRASE changed from String to char[]
+  * Deprecation of ACCOUNT_NAME, please use ACTION_GET_SIGN_KEY_ID to get key id
+  * Introduce EXTRA_SIGN_KEY_ID
+  * New extra for ACTION_ENCRYPT and ACTION_SIGN_AND_ENCRYPT: EXTRA_ENABLE_COMPRESSION (default to true)
+  * Return PendingIntent to view key for signatures
+  * New result for ACTION_DECRYPT_VERIFY: RESULT_TYPE
+  * New ACTION_GET_SIGN_KEY_ID
+  * EXTRA_PASSPHRASE changed from String to char[]
 
 ## Version 6
-
-- Deprecate ACTION_SIGN
-- Introduce ACTION_CLEARTEXT_SIGN and ACTION_DETACHED_SIGN
-- New extra for ACTION_DETACHED_SIGN: EXTRA_DETACHED_SIGNATURE
-- New result for ACTION_DECRYPT_VERIFY: RESULT_DETACHED_SIGNATURE
-- New result for ACTION_DECRYPT_VERIFY: RESULT_CHARSET
+  * Deprecate ACTION_SIGN
+  * Introduce ACTION_CLEARTEXT_SIGN and ACTION_DETACHED_SIGN
+  * New extra for ACTION_DETACHED_SIGN: EXTRA_DETACHED_SIGNATURE
+  * New result for ACTION_DECRYPT_VERIFY: RESULT_DETACHED_SIGNATURE
+  * New result for ACTION_DECRYPT_VERIFY: RESULT_CHARSET
 
 ## Version 5
-
-- OpenPgpSignatureResult: new consts RESULT_INVALID_KEY_REVOKED and RESULT_INVALID_KEY_EXPIRED
-- OpenPgpSignatureResult: ArrayList<String> userIds
+  * OpenPgpSignatureResult: new consts RESULT_INVALID_KEY_REVOKED and RESULT_INVALID_KEY_EXPIRED
+  * OpenPgpSignatureResult: ArrayList<String> userIds
 
 ## Version 4
-
-- No changes to existing methods -> backward compatible
-- Introduction of ACTION_DECRYPT_METADATA, RESULT_METADATA, EXTRA_ORIGINAL_FILENAME, and OpenPgpMetadata parcel
-- Introduction of internal NFC extras: EXTRA_NFC_SIGNED_HASH, EXTRA_NFC_SIG_CREATION_TIMESTAMP
+  * No changes to existing methods -> backward compatible
+  * Introduction of ACTION_DECRYPT_METADATA, RESULT_METADATA, EXTRA_ORIGINAL_FILENAME, and OpenPgpMetadata parcel
+  * Introduction of internal NFC extras: EXTRA_NFC_SIGNED_HASH, EXTRA_NFC_SIG_CREATION_TIMESTAMP
 
 ## Version 3
-
-- First public stable version
+  * First public stable version

--- a/plugins/openpgp-api-lib/CHANGELOG.md
+++ b/plugins/openpgp-api-lib/CHANGELOG.md
@@ -1,48 +1,56 @@
 # Version history
 
 ## Version 10
-  * Retrieve whole public key via ACTION_GET_KEY
+
+- Retrieve whole public key via ACTION_GET_KEY
 
 ## Version 9
-  * AIDL Service has been changed from IOpenPgpService.aidl to IOpenPgpService2.aidl  
-    This fixes truncated data streams (thanks to 'mgeier63').
-  * Fix for OpenPgpKeyPreference: Properly execute pending user interactions
-  * Charset moved to OpenPgpMetadata
+
+- AIDL Service has been changed from IOpenPgpService.aidl to IOpenPgpService2.aidl
+  This fixes truncated data streams (thanks to 'mgeier63').
+- Fix for OpenPgpKeyPreference: Properly execute pending user interactions
+- Charset moved to OpenPgpMetadata
 
 ## Version 8
-  * OpenPgpSignatureResult:  
-    method getStatus() renamed to getResult()  
-    constants have been renamed for clarity  
-    new constants: RESULT_NO_SIGNATURE, RESULT_INVALID_INSECURE  
-    isSignatureOnly() has been deprecated
-  * RESULT_TYPES have been removed
-  * new OpenPgpDecryptionResult returned via RESULT_DECRYPTION
-  * OpenPgpSignatureResult and OpenPgpDecryptionResult are never null, they are always returned.
+
+- OpenPgpSignatureResult:
+  method getStatus() renamed to getResult()
+  constants have been renamed for clarity
+  new constants: RESULT_NO_SIGNATURE, RESULT_INVALID_INSECURE
+  isSignatureOnly() has been deprecated
+- RESULT_TYPES have been removed
+- new OpenPgpDecryptionResult returned via RESULT_DECRYPTION
+- OpenPgpSignatureResult and OpenPgpDecryptionResult are never null, they are always returned.
 
 ## Version 7
-  * Deprecation of ACCOUNT_NAME, please use ACTION_GET_SIGN_KEY_ID to get key id
-  * Introduce EXTRA_SIGN_KEY_ID
-  * New extra for ACTION_ENCRYPT and ACTION_SIGN_AND_ENCRYPT: EXTRA_ENABLE_COMPRESSION (default to true)
-  * Return PendingIntent to view key for signatures
-  * New result for ACTION_DECRYPT_VERIFY: RESULT_TYPE
-  * New ACTION_GET_SIGN_KEY_ID
-  * EXTRA_PASSPHRASE changed from String to char[]
+
+- Deprecation of ACCOUNT_NAME, please use ACTION_GET_SIGN_KEY_ID to get key id
+- Introduce EXTRA_SIGN_KEY_ID
+- New extra for ACTION_ENCRYPT and ACTION_SIGN_AND_ENCRYPT: EXTRA_ENABLE_COMPRESSION (default to true)
+- Return PendingIntent to view key for signatures
+- New result for ACTION_DECRYPT_VERIFY: RESULT_TYPE
+- New ACTION_GET_SIGN_KEY_ID
+- EXTRA_PASSPHRASE changed from String to char[]
 
 ## Version 6
-  * Deprecate ACTION_SIGN
-  * Introduce ACTION_CLEARTEXT_SIGN and ACTION_DETACHED_SIGN
-  * New extra for ACTION_DETACHED_SIGN: EXTRA_DETACHED_SIGNATURE
-  * New result for ACTION_DECRYPT_VERIFY: RESULT_DETACHED_SIGNATURE
-  * New result for ACTION_DECRYPT_VERIFY: RESULT_CHARSET
+
+- Deprecate ACTION_SIGN
+- Introduce ACTION_CLEARTEXT_SIGN and ACTION_DETACHED_SIGN
+- New extra for ACTION_DETACHED_SIGN: EXTRA_DETACHED_SIGNATURE
+- New result for ACTION_DECRYPT_VERIFY: RESULT_DETACHED_SIGNATURE
+- New result for ACTION_DECRYPT_VERIFY: RESULT_CHARSET
 
 ## Version 5
-  * OpenPgpSignatureResult: new consts RESULT_INVALID_KEY_REVOKED and RESULT_INVALID_KEY_EXPIRED
-  * OpenPgpSignatureResult: ArrayList<String> userIds
+
+- OpenPgpSignatureResult: new consts RESULT_INVALID_KEY_REVOKED and RESULT_INVALID_KEY_EXPIRED
+- OpenPgpSignatureResult: ArrayList<String> userIds
 
 ## Version 4
-  * No changes to existing methods -> backward compatible
-  * Introduction of ACTION_DECRYPT_METADATA, RESULT_METADATA, EXTRA_ORIGINAL_FILENAME, and OpenPgpMetadata parcel
-  * Introduction of internal NFC extras: EXTRA_NFC_SIGNED_HASH, EXTRA_NFC_SIG_CREATION_TIMESTAMP
+
+- No changes to existing methods -> backward compatible
+- Introduction of ACTION_DECRYPT_METADATA, RESULT_METADATA, EXTRA_ORIGINAL_FILENAME, and OpenPgpMetadata parcel
+- Introduction of internal NFC extras: EXTRA_NFC_SIGNED_HASH, EXTRA_NFC_SIG_CREATION_TIMESTAMP
 
 ## Version 3
-  * First public stable version
+
+- First public stable version

--- a/plugins/openpgp-api-lib/README.md
+++ b/plugins/openpgp-api-lib/README.md
@@ -5,11 +5,13 @@ The OpenPGP API provides methods to execute OpenPGP operations, such as sign, en
 ### News
 
 #### Version 10
-  * Retrieve whole public key via ACTION_GET_KEY
+
+- Retrieve whole public key via ACTION_GET_KEY
 
 [Full changelog here…](https://github.com/open-keychain/openpgp-api/blob/master/CHANGELOG.md)
 
 ### License
+
 While OpenKeychain itself is GPLv3+, the API library is licensed under Apache License v2.
 Thus, you are allowed to also use it in closed source applications as long as you respect the [Apache License v2](https://github.com/open-keychain/openpgp-api/blob/master/LICENSE).
 
@@ -28,7 +30,8 @@ dependencies {
 ```
 
 ### Full example
-A full working example is available in the [example project](https://github.com/open-keychain/openpgp-api/blob/master/example). The [``OpenPgpApiActivity.java``](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) contains most relevant sourcecode.
+
+A full working example is available in the [example project](https://github.com/open-keychain/openpgp-api/blob/master/example). The [`OpenPgpApiActivity.java`](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) contains most relevant sourcecode.
 
 ### API
 
@@ -38,21 +41,24 @@ A full working example is available in the [example project](https://github.com/
 
 **This tutorial only covers the basics, please consult the full example for a complete overview over all methods**
 
-The API is **not** designed around ``Intents`` which are started via ``startActivityForResult``. These Intent actions typically start an activity for user interaction, so they are not suitable for background tasks. Most API design decisions are explained at [the bottom of this wiki page](https://github.com/open-keychain/open-keychain/wiki/OpenPGP-API#internal-design-decisions).
+The API is **not** designed around `Intents` which are started via `startActivityForResult`. These Intent actions typically start an activity for user interaction, so they are not suitable for background tasks. Most API design decisions are explained at [the bottom of this wiki page](https://github.com/open-keychain/open-keychain/wiki/OpenPGP-API#internal-design-decisions).
 
 We will go through the basic steps to understand how this API works, following this (greatly simplified) sequence diagram:
 ![](https://github.com/open-keychain/open-keychain/raw/master/Resources/docs/openpgp_api_1.jpg)
 
 In this diagram the client app is depicted on the left side, the OpenPGP provider (in this case OpenKeychain) is depicted on the right.
-The remote service is defined via the [AIDL](http://developer.android.com/guide/components/aidl.html) file [``IOpenPgpService``](https://github.com/open-keychain/openpgp-api/blob/master/openpgp-api/src/main/aidl/org/openintents/openpgp/IOpenPgpService.aidl).
+The remote service is defined via the [AIDL](http://developer.android.com/guide/components/aidl.html) file [`IOpenPgpService`](https://github.com/open-keychain/openpgp-api/blob/master/openpgp-api/src/main/aidl/org/openintents/openpgp/IOpenPgpService.aidl).
 It contains only one exposed method which can be invoked remotely:
+
 ```java
 interface IOpenPgpService {
     Intent execute(in Intent data, in ParcelFileDescriptor input, in ParcelFileDescriptor output);
 }
 ```
+
 The interaction between the apps is done by binding from your client app to the remote service of OpenKeychain.
-``OpenPgpServiceConnection`` is a helper class from the library to ease this step:
+`OpenPgpServiceConnection` is a helper class from the library to ease this step:
+
 ```java
 OpenPgpServiceConnection mServiceConnection;
 
@@ -72,36 +78,38 @@ public void onDestroy() {
 
 Following the sequence diagram, these steps are executed:
 
-1.  Define an ``Intent`` containing the actual PGP instructions which should be done, e.g.
-    ```java
+1.  Define an `Intent` containing the actual PGP instructions which should be done, e.g.
+    `java
 Intent data = new Intent();
 data.setAction(OpenPgpApi.ACTION_ENCRYPT);
 data.putExtra(OpenPgpApi.EXTRA_USER_IDS, new String[]{"dominik@dominikschuermann.de"});
 data.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
-    ```
-    Define an ``InputStream`` currently holding the plaintext, and an ``OutputStream`` where you want the ciphertext to be written by OpenKeychain's remote service:
-    ```java
+    `
+    Define an `InputStream` currently holding the plaintext, and an `OutputStream` where you want the ciphertext to be written by OpenKeychain's remote service:
+    `java
 InputStream is = new ByteArrayInputStream("Hello world!".getBytes("UTF-8"));
 ByteArrayOutputStream os = new ByteArrayOutputStream();
-    ```
-    Using a helper class from the library, ``is`` and ``os`` are passed via ``ParcelFileDescriptors`` as ``input`` and ``output`` together with ``Intent data``, as depicted in the sequence diagram, from the client to the remote service.
+    `
+    Using a helper class from the library, `is` and `os` are passed via `ParcelFileDescriptors` as `input` and `output` together with `Intent data`, as depicted in the sequence diagram, from the client to the remote service.
     Programmatically, this can be done with:
-    ```java
+    `java
 OpenPgpApi api = new OpenPgpApi(this, mServiceConnection.getService());
 Intent result = api.executeApi(data, is, os);
-    ```
+    `
 
-2.  The PGP operation is executed by OpenKeychain and the produced ciphertext is written into ``os`` which can then be accessed by the client app.
+2.  The PGP operation is executed by OpenKeychain and the produced ciphertext is written into `os` which can then be accessed by the client app.
 
 3.  A result Intent is returned containing one of these result codes:
-    * ``OpenPgpApi.RESULT_CODE_ERROR``
-    * ``OpenPgpApi.RESULT_CODE_SUCCESS``
-    * ``OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED``
 
-    If ``RESULT_CODE_USER_INTERACTION_REQUIRED`` is returned, an additional ``PendingIntent`` is returned to the client, which must be used to get user input required to process the request.
-    A ``PendingIntent`` is executed with ``startIntentSenderForResult``, which starts an activity, originally belonging to OpenKeychain, on the [task stack](http://developer.android.com/guide/components/tasks-and-back-stack.html) of the client.
-    Only if ``RESULT_CODE_SUCCESS`` is returned, ``os`` actually contains data.
+    - `OpenPgpApi.RESULT_CODE_ERROR`
+    - `OpenPgpApi.RESULT_CODE_SUCCESS`
+    - `OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED`
+
+    If `RESULT_CODE_USER_INTERACTION_REQUIRED` is returned, an additional `PendingIntent` is returned to the client, which must be used to get user input required to process the request.
+    A `PendingIntent` is executed with `startIntentSenderForResult`, which starts an activity, originally belonging to OpenKeychain, on the [task stack](http://developer.android.com/guide/components/tasks-and-back-stack.html) of the client.
+    Only if `RESULT_CODE_SUCCESS` is returned, `os` actually contains data.
     A nearly complete example looks like this:
+
     ```java
     switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
         case OpenPgpApi.RESULT_CODE_SUCCESS: {
@@ -135,10 +143,10 @@ Intent result = api.executeApi(data, is, os);
     }
     ```
 
-4.  Results from a ``PendingIntent`` are returned in ``onActivityResult`` of the activity, which executed ``startIntentSenderForResult``.
-    The returned ``Intent data`` in ``onActivityResult`` contains the original PGP operation definition and new values acquired from the user interaction.
-    Thus, you can now execute the ``Intent`` again, like done in step 1.
-    This time it should return with ``RESULT_CODE_SUCCESS`` because all required information has been obtained by the previous user interaction stored in this ``Intent``.
+4.  Results from a `PendingIntent` are returned in `onActivityResult` of the activity, which executed `startIntentSenderForResult`.
+    The returned `Intent data` in `onActivityResult` contains the original PGP operation definition and new values acquired from the user interaction.
+    Thus, you can now execute the `Intent` again, like done in step 1.
+    This time it should return with `RESULT_CODE_SUCCESS` because all required information has been obtained by the previous user interaction stored in this `Intent`.
     ```java
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         [...]
@@ -154,16 +162,17 @@ Intent result = api.executeApi(data, is, os);
     }
     ```
 
-
 ### Tipps
-*   ``api.executeApi(data, is, os);`` is a blocking call. If you want a convenient asynchronous call, use ``api.executeApiAsync(data, is, os, new MyCallback([... ]));``, where ``MyCallback`` is an private class implementing ``OpenPgpApi.IOpenPgpCallback``.
-    See [``OpenPgpApiActivity.java``](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) for an example.
-*   Using
 
-    ```java
-    mServiceConnection = new OpenPgpServiceConnection(this, "org.sufficientlysecure.keychain");
-    ```
-    connects to OpenKeychain directly.
-    If you want to let the user choose between OpenPGP providers, you can implement the [``OpenPgpAppPreference.java``](https://github.com/open-keychain/openpgp-api/tree/master/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpAppPreference.java) like done in the example app.
+- `api.executeApi(data, is, os);` is a blocking call. If you want a convenient asynchronous call, use `api.executeApiAsync(data, is, os, new MyCallback([... ]));`, where `MyCallback` is an private class implementing `OpenPgpApi.IOpenPgpCallback`.
+  See [`OpenPgpApiActivity.java`](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) for an example.
+- Using
 
-*    To enable installing a debug and release version at the same time, the `debug` build of OpenKeychain uses `org.sufficientlysecure.keychain.debug` as a package name. Make sure you connect to the right one during development!
+  ```java
+  mServiceConnection = new OpenPgpServiceConnection(this, "org.sufficientlysecure.keychain");
+  ```
+
+  connects to OpenKeychain directly.
+  If you want to let the user choose between OpenPGP providers, you can implement the [`OpenPgpAppPreference.java`](https://github.com/open-keychain/openpgp-api/tree/master/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpAppPreference.java) like done in the example app.
+
+- To enable installing a debug and release version at the same time, the `debug` build of OpenKeychain uses `org.sufficientlysecure.keychain.debug` as a package name. Make sure you connect to the right one during development!

--- a/plugins/openpgp-api-lib/README.md
+++ b/plugins/openpgp-api-lib/README.md
@@ -5,13 +5,11 @@ The OpenPGP API provides methods to execute OpenPGP operations, such as sign, en
 ### News
 
 #### Version 10
-
-- Retrieve whole public key via ACTION_GET_KEY
+  * Retrieve whole public key via ACTION_GET_KEY
 
 [Full changelog here…](https://github.com/open-keychain/openpgp-api/blob/master/CHANGELOG.md)
 
 ### License
-
 While OpenKeychain itself is GPLv3+, the API library is licensed under Apache License v2.
 Thus, you are allowed to also use it in closed source applications as long as you respect the [Apache License v2](https://github.com/open-keychain/openpgp-api/blob/master/LICENSE).
 
@@ -30,8 +28,7 @@ dependencies {
 ```
 
 ### Full example
-
-A full working example is available in the [example project](https://github.com/open-keychain/openpgp-api/blob/master/example). The [`OpenPgpApiActivity.java`](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) contains most relevant sourcecode.
+A full working example is available in the [example project](https://github.com/open-keychain/openpgp-api/blob/master/example). The [``OpenPgpApiActivity.java``](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) contains most relevant sourcecode.
 
 ### API
 
@@ -41,24 +38,21 @@ A full working example is available in the [example project](https://github.com/
 
 **This tutorial only covers the basics, please consult the full example for a complete overview over all methods**
 
-The API is **not** designed around `Intents` which are started via `startActivityForResult`. These Intent actions typically start an activity for user interaction, so they are not suitable for background tasks. Most API design decisions are explained at [the bottom of this wiki page](https://github.com/open-keychain/open-keychain/wiki/OpenPGP-API#internal-design-decisions).
+The API is **not** designed around ``Intents`` which are started via ``startActivityForResult``. These Intent actions typically start an activity for user interaction, so they are not suitable for background tasks. Most API design decisions are explained at [the bottom of this wiki page](https://github.com/open-keychain/open-keychain/wiki/OpenPGP-API#internal-design-decisions).
 
 We will go through the basic steps to understand how this API works, following this (greatly simplified) sequence diagram:
 ![](https://github.com/open-keychain/open-keychain/raw/master/Resources/docs/openpgp_api_1.jpg)
 
 In this diagram the client app is depicted on the left side, the OpenPGP provider (in this case OpenKeychain) is depicted on the right.
-The remote service is defined via the [AIDL](http://developer.android.com/guide/components/aidl.html) file [`IOpenPgpService`](https://github.com/open-keychain/openpgp-api/blob/master/openpgp-api/src/main/aidl/org/openintents/openpgp/IOpenPgpService.aidl).
+The remote service is defined via the [AIDL](http://developer.android.com/guide/components/aidl.html) file [``IOpenPgpService``](https://github.com/open-keychain/openpgp-api/blob/master/openpgp-api/src/main/aidl/org/openintents/openpgp/IOpenPgpService.aidl).
 It contains only one exposed method which can be invoked remotely:
-
 ```java
 interface IOpenPgpService {
     Intent execute(in Intent data, in ParcelFileDescriptor input, in ParcelFileDescriptor output);
 }
 ```
-
 The interaction between the apps is done by binding from your client app to the remote service of OpenKeychain.
-`OpenPgpServiceConnection` is a helper class from the library to ease this step:
-
+``OpenPgpServiceConnection`` is a helper class from the library to ease this step:
 ```java
 OpenPgpServiceConnection mServiceConnection;
 
@@ -78,38 +72,36 @@ public void onDestroy() {
 
 Following the sequence diagram, these steps are executed:
 
-1.  Define an `Intent` containing the actual PGP instructions which should be done, e.g.
-    `java
+1.  Define an ``Intent`` containing the actual PGP instructions which should be done, e.g.
+    ```java
 Intent data = new Intent();
 data.setAction(OpenPgpApi.ACTION_ENCRYPT);
 data.putExtra(OpenPgpApi.EXTRA_USER_IDS, new String[]{"dominik@dominikschuermann.de"});
 data.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
-    `
-    Define an `InputStream` currently holding the plaintext, and an `OutputStream` where you want the ciphertext to be written by OpenKeychain's remote service:
-    `java
+    ```
+    Define an ``InputStream`` currently holding the plaintext, and an ``OutputStream`` where you want the ciphertext to be written by OpenKeychain's remote service:
+    ```java
 InputStream is = new ByteArrayInputStream("Hello world!".getBytes("UTF-8"));
 ByteArrayOutputStream os = new ByteArrayOutputStream();
-    `
-    Using a helper class from the library, `is` and `os` are passed via `ParcelFileDescriptors` as `input` and `output` together with `Intent data`, as depicted in the sequence diagram, from the client to the remote service.
+    ```
+    Using a helper class from the library, ``is`` and ``os`` are passed via ``ParcelFileDescriptors`` as ``input`` and ``output`` together with ``Intent data``, as depicted in the sequence diagram, from the client to the remote service.
     Programmatically, this can be done with:
-    `java
+    ```java
 OpenPgpApi api = new OpenPgpApi(this, mServiceConnection.getService());
 Intent result = api.executeApi(data, is, os);
-    `
+    ```
 
-2.  The PGP operation is executed by OpenKeychain and the produced ciphertext is written into `os` which can then be accessed by the client app.
+2.  The PGP operation is executed by OpenKeychain and the produced ciphertext is written into ``os`` which can then be accessed by the client app.
 
 3.  A result Intent is returned containing one of these result codes:
+    * ``OpenPgpApi.RESULT_CODE_ERROR``
+    * ``OpenPgpApi.RESULT_CODE_SUCCESS``
+    * ``OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED``
 
-    - `OpenPgpApi.RESULT_CODE_ERROR`
-    - `OpenPgpApi.RESULT_CODE_SUCCESS`
-    - `OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED`
-
-    If `RESULT_CODE_USER_INTERACTION_REQUIRED` is returned, an additional `PendingIntent` is returned to the client, which must be used to get user input required to process the request.
-    A `PendingIntent` is executed with `startIntentSenderForResult`, which starts an activity, originally belonging to OpenKeychain, on the [task stack](http://developer.android.com/guide/components/tasks-and-back-stack.html) of the client.
-    Only if `RESULT_CODE_SUCCESS` is returned, `os` actually contains data.
+    If ``RESULT_CODE_USER_INTERACTION_REQUIRED`` is returned, an additional ``PendingIntent`` is returned to the client, which must be used to get user input required to process the request.
+    A ``PendingIntent`` is executed with ``startIntentSenderForResult``, which starts an activity, originally belonging to OpenKeychain, on the [task stack](http://developer.android.com/guide/components/tasks-and-back-stack.html) of the client.
+    Only if ``RESULT_CODE_SUCCESS`` is returned, ``os`` actually contains data.
     A nearly complete example looks like this:
-
     ```java
     switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
         case OpenPgpApi.RESULT_CODE_SUCCESS: {
@@ -143,10 +135,10 @@ Intent result = api.executeApi(data, is, os);
     }
     ```
 
-4.  Results from a `PendingIntent` are returned in `onActivityResult` of the activity, which executed `startIntentSenderForResult`.
-    The returned `Intent data` in `onActivityResult` contains the original PGP operation definition and new values acquired from the user interaction.
-    Thus, you can now execute the `Intent` again, like done in step 1.
-    This time it should return with `RESULT_CODE_SUCCESS` because all required information has been obtained by the previous user interaction stored in this `Intent`.
+4.  Results from a ``PendingIntent`` are returned in ``onActivityResult`` of the activity, which executed ``startIntentSenderForResult``.
+    The returned ``Intent data`` in ``onActivityResult`` contains the original PGP operation definition and new values acquired from the user interaction.
+    Thus, you can now execute the ``Intent`` again, like done in step 1.
+    This time it should return with ``RESULT_CODE_SUCCESS`` because all required information has been obtained by the previous user interaction stored in this ``Intent``.
     ```java
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         [...]
@@ -162,17 +154,16 @@ Intent result = api.executeApi(data, is, os);
     }
     ```
 
+
 ### Tipps
+*   ``api.executeApi(data, is, os);`` is a blocking call. If you want a convenient asynchronous call, use ``api.executeApiAsync(data, is, os, new MyCallback([... ]));``, where ``MyCallback`` is an private class implementing ``OpenPgpApi.IOpenPgpCallback``.
+    See [``OpenPgpApiActivity.java``](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) for an example.
+*   Using
 
-- `api.executeApi(data, is, os);` is a blocking call. If you want a convenient asynchronous call, use `api.executeApiAsync(data, is, os, new MyCallback([... ]));`, where `MyCallback` is an private class implementing `OpenPgpApi.IOpenPgpCallback`.
-  See [`OpenPgpApiActivity.java`](https://github.com/open-keychain/openpgp-api/blob/master/example/src/main/java/org/openintents/openpgp/example/OpenPgpApiActivity.java) for an example.
-- Using
+    ```java
+    mServiceConnection = new OpenPgpServiceConnection(this, "org.sufficientlysecure.keychain");
+    ```
+    connects to OpenKeychain directly.
+    If you want to let the user choose between OpenPGP providers, you can implement the [``OpenPgpAppPreference.java``](https://github.com/open-keychain/openpgp-api/tree/master/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpAppPreference.java) like done in the example app.
 
-  ```java
-  mServiceConnection = new OpenPgpServiceConnection(this, "org.sufficientlysecure.keychain");
-  ```
-
-  connects to OpenKeychain directly.
-  If you want to let the user choose between OpenPGP providers, you can implement the [`OpenPgpAppPreference.java`](https://github.com/open-keychain/openpgp-api/tree/master/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpAppPreference.java) like done in the example app.
-
-- To enable installing a debug and release version at the same time, the `debug` build of OpenKeychain uses `org.sufficientlysecure.keychain.debug` as a package name. Make sure you connect to the right one during development!
+*    To enable installing a debug and release version at the same time, the `debug` build of OpenKeychain uses `org.sufficientlysecure.keychain.debug` as a package name. Make sure you connect to the right one during development!


### PR DESCRIPTION
This changes the ktlint plugin to the [Spotless](https://github.com/diffplug/spotless) [Gradle plugin](https://github.com/diffplug/spotless/tree/main/plugin-gradle) with ktlint support. Spotless also allows to run other formatters, so this comes with Markdown, KTS and misc rules configured.

This spares the Java formatter due to it's massive changeset. A simple rule matching most of current Java code style is:

```
spotless {
    java {
        googleJavaFormat().aosp()
        target("**/*.java")
        targetExclude("plugins/openpgp-api-lib/", "ui-utils/")
    }
}
```

Due to some issues with ktlint 0.48.x it is still using 0.47.1. Problems expected to be fixed in ktlint 0.49.0
- [Formatting enum class](https://github.com/pinterest/ktlint/issues/1786)
- [Formatting with no-semi rule removes semicolons in enum](https://github.com/pinterest/ktlint/issues/1733)

Closes #6605
