### PR TITLE
Changed spotless configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,30 +99,22 @@ allprojects {
 spotless {
     kotlin {
         ktlint(libs.versions.ktlint.get())
-            .setEditorConfigPath("$projectDir/.editorconfig")
         target("**/*.kt")
         targetExclude("**/build/", "**/resources/", "plugins/openpgp-api-lib/")
-        endWithNewline()
     }
     kotlinGradle {
         ktlint(libs.versions.ktlint.get())
-            .setEditorConfigPath("$projectDir/.editorconfig")
         target("**/*.gradle.kts")
         targetExclude("**/build/")
-        endWithNewline()
     }
     format("markdown") {
         prettier()
         target("**/*.md")
         targetExclude("plugins/openpgp-api-lib/")
-        trimTrailingWhitespace()
-        endWithNewline()
     }
     format("misc") {
         target("**/*.gradle", "**/.gitignore")
         trimTrailingWhitespace()
-        indentWithSpaces(4)
-        endWithNewline()
     }
 }
 


### PR DESCRIPTION
Review of #6630 showed that unnecessary spotless configuration is present and this cleans it up. Changed spotless configuration to remove all rules covered by .editorconfig or used formatters.
