### PR TITLE
Add `ContactIntentHelper`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/contact/ContactIntentHelper.kt
+++ b/app/core/src/main/java/com/fsck/k9/contact/ContactIntentHelper.kt
@@ -1,0 +1,47 @@
+package com.fsck.k9.contact
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.ContactsContract
+import com.fsck.k9.mail.Address
+
+object ContactIntentHelper {
+    @JvmStatic
+    fun getContactPickerIntent(): Intent {
+        return Intent(Intent.ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI)
+    }
+
+    /**
+     * Get Intent to add information to an existing contact or add a new one.
+     *
+     * @param address An {@link Address} instance containing the email address
+     *              of the entity you want to add to the contacts. Optionally
+     *              the instance also contains the (display) name of that
+     *              entity.
+     */
+    fun getAddEmailContactIntent(address: Address): Intent {
+        return Intent(ContactsContract.Intents.SHOW_OR_CREATE_CONTACT).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            data = Uri.fromParts("mailto", address.address, null)
+            putExtra(ContactsContract.Intents.EXTRA_CREATE_DESCRIPTION, address.toString())
+
+            if (address.personal != null) {
+                putExtra(ContactsContract.Intents.Insert.NAME, address.personal)
+            }
+        }
+    }
+
+    /**
+     * Get Intent to add a phone number to an existing contact or add a new one.
+     *
+     * @param phoneNumber
+     *         The phone number to add to a contact, or to use when creating a new contact.
+     */
+    fun getAddPhoneContactIntent(phoneNumber: String): Intent {
+        return Intent(Intent.ACTION_INSERT_OR_EDIT).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            type = ContactsContract.Contacts.CONTENT_ITEM_TYPE
+            putExtra(ContactsContract.Intents.Insert.PHONE, Uri.decode(phoneNumber))
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -86,50 +86,6 @@ public class Contacts {
         mContentResolver = context.getContentResolver();
     }
 
-    /**
-     * Start the activity to add information to an existing contact or add a
-     * new one.
-     *
-     * @param email An {@link Address} instance containing the email address
-     *              of the entity you want to add to the contacts. Optionally
-     *              the instance also contains the (display) name of that
-     *              entity.
-     */
-    public void createContact(final Address email) {
-        final Uri contactUri = Uri.fromParts("mailto", email.getAddress(), null);
-
-        final Intent contactIntent = new Intent(ContactsContract.Intents.SHOW_OR_CREATE_CONTACT);
-        contactIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        contactIntent.setData(contactUri);
-
-        // Pass along full email string for possible create dialog
-        contactIntent.putExtra(ContactsContract.Intents.EXTRA_CREATE_DESCRIPTION,
-                email.toString());
-
-        // Only provide personal name hint if we have one
-        final String senderPersonal = email.getPersonal();
-        if (senderPersonal != null) {
-            contactIntent.putExtra(ContactsContract.Intents.Insert.NAME, senderPersonal);
-        }
-
-        mContext.startActivity(contactIntent);
-        clearCache();
-    }
-
-    /**
-     * Start the activity to add a phone number to an existing contact or add a new one.
-     *
-     * @param phoneNumber
-     *         The phone number to add to a contact, or to use when creating a new contact.
-     */
-    public void addPhoneContact(final String phoneNumber) {
-        Intent addIntent = new Intent(Intent.ACTION_INSERT_OR_EDIT);
-        addIntent.setType(ContactsContract.Contacts.CONTENT_ITEM_TYPE);
-        addIntent.putExtra(ContactsContract.Intents.Insert.PHONE, Uri.decode(phoneNumber));
-        addIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        mContext.startActivity(addIntent);
-        clearCache();
-    }
 
     /**
      * Check whether the provided email address belongs to one of the contacts.
@@ -228,14 +184,6 @@ public class Contacts {
         // auto-completion.
     }
 
-    /**
-     * Creates the intent necessary to open a contact picker.
-     *
-     * @return The intent necessary to open a contact picker.
-     */
-    public Intent contactPickerIntent() {
-        return new Intent(Intent.ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI);
-    }
 
     /**
      * Get URI to the picture of the contact with the supplied email address.

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -72,6 +72,7 @@ import com.fsck.k9.activity.compose.ReplyToView;
 import com.fsck.k9.activity.compose.SaveMessageTask;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.autocrypt.AutocryptDraftStateHeaderParser;
+import com.fsck.k9.contact.ContactIntentHelper;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
@@ -849,7 +850,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public void showContactPicker(int requestCode) {
         requestCode |= REQUEST_MASK_RECIPIENT_PRESENTER;
         isInSubActivity = true;
-        startActivityForResult(contacts.contactPickerIntent(), requestCode);
+        startActivityForResult(ContactIntentHelper.getContactPickerIntent(), requestCode);
     }
 
     @Override

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -17,7 +17,7 @@ import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.SendErrorState
 import com.fsck.k9.autocrypt.AutocryptDraftStateHeader
 import com.fsck.k9.autocrypt.AutocryptDraftStateHeaderParser
-import com.fsck.k9.helper.Contacts
+import com.fsck.k9.contact.ContactIntentHelper
 import com.fsck.k9.helper.MailTo
 import com.fsck.k9.helper.ReplyToParser
 import com.fsck.k9.mail.Address
@@ -608,8 +608,7 @@ class RecipientPresenter(
     }
 
     private fun isContactPickerAvailable(): Boolean {
-        val contacts = Contacts.getInstance(context)
-        val resolveInfoList = context.packageManager.queryIntentActivities(contacts.contactPickerIntent(), 0)
+        val resolveInfoList = context.packageManager.queryIntentActivities(ContactIntentHelper.getContactPickerIntent(), 0)
         return resolveInfoList.isNotEmpty()
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.kt
@@ -24,8 +24,8 @@ import android.widget.Toast
 import androidx.core.app.ShareCompat.IntentBuilder
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.fsck.k9.contact.ContactIntentHelper
 import com.fsck.k9.helper.ClipboardManager
-import com.fsck.k9.helper.Contacts
 import com.fsck.k9.helper.Utility
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mailstore.AttachmentResolver
@@ -252,8 +252,8 @@ class MessageContainerView(context: Context, attrs: AttributeSet?) :
                     startActivityIfAvailable(context, intent)
                 }
                 MENU_ITEM_PHONE_SAVE -> {
-                    val contacts = Contacts.getInstance(context)
-                    contacts.addPhoneContact(phoneNumber)
+                    val intent = ContactIntentHelper.getAddPhoneContactIntent(phoneNumber)
+                    startActivityIfAvailable(context, intent)
                 }
                 MENU_ITEM_PHONE_COPY -> {
                     val label = context.getString(R.string.webview_contextmenu_phone_clipboard_label)
@@ -298,8 +298,8 @@ class MessageContainerView(context: Context, attrs: AttributeSet?) :
                     startActivityIfAvailable(context, intent)
                 }
                 MENU_ITEM_EMAIL_SAVE -> {
-                    val contacts = Contacts.getInstance(context)
-                    contacts.createContact(Address(email))
+                    val intent = ContactIntentHelper.getAddEmailContactIntent(Address(email))
+                    startActivityIfAvailable(context, intent)
                 }
                 MENU_ITEM_EMAIL_COPY -> {
                     val label = context.getString(R.string.webview_contextmenu_email_clipboard_label)


### PR DESCRIPTION
Added `ContactIntentHelper` and remove functionality from `Contacts`, as it has mixed responsibilities.

This removes the `clearCache` call, as in it's current form, it is not helpfull. The long term goal is, to listen for changes to the contact provider and propagate changes from there. Short term goal is to use an expiring cache instead.
