### PR TITLE
Add JVM build plugin

### DIFF
--- a/app/autodiscovery/api/build.gradle
+++ b/app/autodiscovery/api/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 

--- a/app/autodiscovery/srvrecords/build.gradle
+++ b/app/autodiscovery/srvrecords/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -8,9 +7,4 @@ dependencies {
     api project(":app:autodiscovery:api")
 
     implementation libs.minidns.hla
-
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.inline
-    testImplementation libs.mockito.kotlin
 }

--- a/app/autodiscovery/thunderbird/build.gradle
+++ b/app/autodiscovery/thunderbird/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -10,9 +9,5 @@ dependencies {
     compileOnly libs.xmlpull
     implementation libs.okhttp
 
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.inline
-    testImplementation libs.mockito.kotlin
     testImplementation libs.kxml2
 }

--- a/app/html-cleaner/build.gradle
+++ b/app/html-cleaner/build.gradle
@@ -1,12 +1,8 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
 dependencies {
     implementation libs.jsoup
-
-    testImplementation libs.junit
-    testImplementation libs.truth
 }

--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 

--- a/backend/demo/build.gradle
+++ b/backend/demo/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.ksp)
     alias(libs.plugins.android.lint)
 }
@@ -13,7 +12,4 @@ dependencies {
     ksp libs.moshi.kotlin.codegen
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.mockito.core
-    testImplementation libs.truth
 }

--- a/backend/imap/build.gradle
+++ b/backend/imap/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -13,9 +12,5 @@ dependencies {
 
     testImplementation project(":mail:testing")
     testImplementation project(":backend:testing")
-    testImplementation libs.junit
-    testImplementation libs.mockito.inline
-    testImplementation libs.mockito.kotlin
-    testImplementation libs.truth
     testImplementation libs.mime4j.dom
 }

--- a/backend/jmap/build.gradle
+++ b/backend/jmap/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.ksp)
     alias(libs.plugins.android.lint)
 }
@@ -15,6 +14,5 @@ dependencies {
 
     testImplementation project(":mail:testing")
     testImplementation project(':backend:testing')
-    testImplementation libs.mockito.core
     testImplementation libs.okhttp.mockwebserver
 }

--- a/backend/pop3/build.gradle
+++ b/backend/pop3/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -10,6 +9,4 @@ dependencies {
     api project(":mail:protocols:smtp")
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.mockito.core
 }

--- a/backend/testing/build.gradle
+++ b/backend/testing/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 

--- a/backend/webdav/build.gradle
+++ b/backend/webdav/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -9,6 +8,4 @@ dependencies {
     api project(":mail:protocols:webdav")
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.mockito.core
 }

--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
+    implementation(plugin(libs.plugins.kotlin.jvm))
+
     implementation(plugin(libs.plugins.spotless))
 }
 

--- a/build-plugin/src/main/kotlin/ThunderbirdPlugins.kt
+++ b/build-plugin/src/main/kotlin/ThunderbirdPlugins.kt
@@ -1,0 +1,6 @@
+object ThunderbirdPlugins {
+
+    object Library {
+        const val jvm = "thunderbird.library.jvm"
+    }
+}

--- a/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
+++ b/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
@@ -1,0 +1,6 @@
+import org.gradle.api.JavaVersion
+
+object ThunderbirdProjectConfig {
+
+    val javaVersion = JavaVersion.VERSION_11
+}

--- a/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    `java-library`
+    id("org.jetbrains.kotlin.jvm")
+}
+
+java {
+    sourceCompatibility = ThunderbirdProjectConfig.javaVersion
+    targetCompatibility = ThunderbirdProjectConfig.javaVersion
+}
+
+dependencies {
+    testImplementation(libs.bundles.library.jvm.test)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,3 +121,11 @@ jdom2 = "org.jdom:jdom2:2.0.6.1"
 icu4j-charset = "com.ibm.icu:icu4j-charset:72.1"
 
 leakcanary-android = "com.squareup.leakcanary:leakcanary-android:2.9.1"
+
+[bundles]
+library-jvm-test = [
+  "junit",
+  "truth",
+  "mockito-inline",
+  "mockito-kotlin",
+]

--- a/mail/common/build.gradle
+++ b/mail/common/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -21,9 +20,5 @@ dependencies {
     implementation libs.apache.httpclient5
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.inline
-    testImplementation libs.mockito.kotlin
     testImplementation libs.icu4j.charset
 }

--- a/mail/protocols/imap/build.gradle
+++ b/mail/protocols/imap/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -17,10 +16,6 @@ dependencies {
     implementation libs.okio
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.core
-    testImplementation libs.mockito.kotlin
     testImplementation libs.okio
     testImplementation libs.mime4j.core
 }

--- a/mail/protocols/pop3/build.gradle
+++ b/mail/protocols/pop3/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -12,10 +11,6 @@ dependencies {
     api project(":mail:common")
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.core
-    testImplementation libs.mockito.kotlin
     testImplementation libs.okio
     testImplementation libs.jzlib
     testImplementation libs.commons.io

--- a/mail/protocols/smtp/build.gradle
+++ b/mail/protocols/smtp/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -15,9 +14,6 @@ dependencies {
     implementation libs.okio
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.kotlin
     testImplementation libs.okio
     testImplementation libs.jzlib
 }

--- a/mail/protocols/webdav/build.gradle
+++ b/mail/protocols/webdav/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 
@@ -14,8 +14,5 @@ dependencies {
     compileOnly libs.apache.httpclient
 
     testImplementation project(":mail:testing")
-    testImplementation libs.junit
-    testImplementation libs.truth
-    testImplementation libs.mockito.inline
     testImplementation libs.apache.httpclient
 }

--- a/mail/testing/build.gradle
+++ b/mail/testing/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id "thunderbird.library.jvm"
     alias(libs.plugins.android.lint)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,8 @@ dependencyResolutionManagement {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+rootProject.name = "k-9"
+
 includeBuild("build-plugin")
 
 include(


### PR DESCRIPTION
This adds a JVM build plugin with default configuration for all JVM libraries in the project.

The `com.android.lint` plugin is left out, as it prevents test execution when used within the build plugin.

Gradle version catalog bundles are used to streamline test dependency setup.

