### PR TITLE
Add core common modules

### DIFF
--- a/app/core/build.gradle.kts
+++ b/app/core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(projects.mail.common)
     api(projects.backend.api)
     api(projects.app.htmlCleaner)
+    api(projects.core.android.common)
 
     implementation(projects.plugins.openpgpApiLib.openpgpApi)
 

--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9
 
 import android.content.Context
+import app.k9mail.core.android.common.coreCommonAndroidModule
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.helper.DefaultTrustedSocketFactory
 import com.fsck.k9.mail.ssl.LocalKeyStore
@@ -15,6 +16,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val mainModule = module {
+    includes(coreCommonAndroidModule)
     single<CoroutineScope>(named("AppCoroutineScope")) { GlobalScope }
     single {
         Preferences(

--- a/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import android.Manifest;
 import android.content.ContentResolver;
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
@@ -15,6 +14,7 @@ import android.provider.ContactsContract.CommonDataKinds.Photo;
 
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import app.k9mail.core.android.common.database.EmptyCursor;
 import com.fsck.k9.mail.Address;
 import timber.log.Timber;
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -23,7 +23,7 @@ import androidx.annotation.Nullable;
 import androidx.loader.content.AsyncTaskLoader;
 import androidx.core.content.ContextCompat;
 
-import com.fsck.k9.helper.EmptyCursor;
+import app.k9mail.core.android.common.database.EmptyCursor;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.view.RecipientSelectView.Recipient;

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -27,5 +27,6 @@ android {
 
 dependencies {
     implementation(libs.bundles.shared.jvm.main)
+    implementation(libs.bundles.shared.jvm.android)
     testImplementation(libs.bundles.shared.jvm.test)
 }

--- a/core/android/common/build.gradle.kts
+++ b/core/android/common/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id(ThunderbirdPlugins.Library.android)
+}
+
+android {
+    namespace = "app.k9mail.core.android.common"
+}
+
+dependencies {
+    api(projects.core.common)
+    testImplementation(projects.core.testing)
+}

--- a/core/android/common/src/main/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModule.kt
+++ b/core/android/common/src/main/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModule.kt
@@ -1,0 +1,9 @@
+package app.k9mail.core.android.common
+
+import app.k9mail.core.common.coreCommonModule
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val coreCommonAndroidModule: Module = module {
+    includes(coreCommonModule)
+}

--- a/core/android/common/src/main/kotlin/app/k9mail/core/android/common/database/EmptyCursor.kt
+++ b/core/android/common/src/main/kotlin/app/k9mail/core/android/common/database/EmptyCursor.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.helper
+package app.k9mail.core.android.common.database
 
 import android.database.AbstractCursor
 

--- a/core/android/common/src/test/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModuleTest.kt
+++ b/core/android/common/src/test/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModuleTest.kt
@@ -1,0 +1,16 @@
+package app.k9mail.core.android.common
+
+import org.junit.Test
+import org.koin.dsl.koinApplication
+import org.koin.test.check.checkModules
+
+internal class CoreCommonAndroidModuleTest {
+
+    @Test
+    fun `should have a valid di module`() {
+        koinApplication {
+            modules(coreCommonAndroidModule)
+            checkModules()
+        }
+    }
+}

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+}
+
+dependencies {
+    testImplementation(projects.core.testing)
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/CoreCommonModule.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/CoreCommonModule.kt
@@ -1,0 +1,9 @@
+package app.k9mail.core.common
+
+import kotlinx.datetime.Clock
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val coreCommonModule: Module = module {
+    single<Clock> { Clock.System }
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/cache/Cache.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/cache/Cache.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
 interface Cache<KEY : Any, VALUE : Any> {
 

--- a/core/common/src/main/kotlin/app/k9mail/core/common/cache/ExpiringCache.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/cache/ExpiringCache.kt
@@ -1,9 +1,9 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
-internal class ExpiringCache<KEY : Any, VALUE : Any>(
+class ExpiringCache<KEY : Any, VALUE : Any>(
     private val clock: Clock,
     private val delegateCache: Cache<KEY, VALUE> = InMemoryCache(),
     private var lastClearTime: Instant = clock.now(),

--- a/core/common/src/main/kotlin/app/k9mail/core/common/cache/InMemoryCache.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/cache/InMemoryCache.kt
@@ -1,6 +1,6 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
-internal class InMemoryCache<KEY : Any, VALUE : Any>(
+class InMemoryCache<KEY : Any, VALUE : Any>(
     private val cache: MutableMap<KEY, VALUE> = mutableMapOf(),
 ) : Cache<KEY, VALUE> {
     override fun get(key: KEY): VALUE? {

--- a/core/common/src/main/kotlin/app/k9mail/core/common/cache/SynchronizedCache.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/cache/SynchronizedCache.kt
@@ -1,6 +1,6 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
-internal class SynchronizedCache<KEY : Any, VALUE : Any>(
+class SynchronizedCache<KEY : Any, VALUE : Any>(
     private val delegateCache: Cache<KEY, VALUE>,
 ) : Cache<KEY, VALUE> {
 

--- a/core/common/src/test/kotlin/app/k9mail/core/common/CoreCommonModuleTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/CoreCommonModuleTest.kt
@@ -1,0 +1,16 @@
+package app.k9mail.core.common
+
+import org.junit.Test
+import org.koin.dsl.koinApplication
+import org.koin.test.check.checkModules
+
+internal class CoreCommonModuleTest {
+
+    @Test
+    fun `should have a valid di module`() {
+        koinApplication {
+            modules(coreCommonModule)
+            checkModules()
+        }
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/cache/CacheTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/cache/CacheTest.kt
@@ -1,8 +1,12 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
 import app.k9mail.core.testing.TestClock
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 

--- a/core/common/src/test/kotlin/app/k9mail/core/common/cache/ExpiringCacheTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/cache/ExpiringCacheTest.kt
@@ -1,7 +1,10 @@
-package com.fsck.k9.cache
+package app.k9mail.core.common.cache
 
 import app.k9mail.core.testing.TestClock
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-work-ktx = "androidx.work:work-runtime-ktx:2.7.1"
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidxFragment" }
 androidx-localbroadcastmanager = "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
-androidx-core = { module = "androidx.core:core", version.ref = "androidxCore" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-preference = { module = "androidx.preference:preference", version.ref = "androidxPreference" }
 androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
@@ -139,6 +138,9 @@ detekt-plugin-compose = "io.nlopez.compose.rules:detekt:0.1.1"
 shared-jvm-main = [
   "koin-core",
   "kotlinx-datetime",
+]
+shared-jvm-android = [
+  "androidx-core-ktx",
 ]
 shared-jvm-test = [
   "junit",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,7 @@ detekt-plugin-compose = "io.nlopez.compose.rules:detekt:0.1.1"
 
 [bundles]
 shared-jvm-main = [
+  "koin-core",
   "kotlinx-datetime",
 ]
 shared-jvm-test = [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ include(
     ":core:ui:compose:demo",
     ":core:ui:compose:designsystem",
     ":core:ui:compose:theme",
+    ":core:common",
     ":core:testing",
 )
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,11 +39,12 @@ include(
 )
 
 include(
+    ":core:common",
+    ":core:testing",
+    ":core:android:common",
     ":core:ui:compose:demo",
     ":core:ui:compose:designsystem",
     ":core:ui:compose:theme",
-    ":core:common",
-    ":core:testing",
 )
 
 include(


### PR DESCRIPTION
Add `:core:common` module for JVM only components and `:core:android:common` module for components that have a hard Android dependency