### PR TITLE
Bump Android Gradle Plugin 7.4.0 -> 7.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Please don't open pull requests upgrading dependencies if you're a new contributor.
 
 [versions]
-androidGradlePlugin = "7.4.0"
+androidGradlePlugin = "7.4.2"
 ktlint = "0.48.2"
 
 kotlin = "1.8.0"


### PR DESCRIPTION
Follow up on Android Studio patch releases. See [changes](https://developer.android.com/studio/releases/gradle-plugin#7-4-0)