### PR TITLE
Change truth testing library to legacy

### DIFF
--- a/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -1,12 +1,15 @@
 package com.fsck.k9.autodiscovery.providersxml
 
 import androidx.test.core.app.ApplicationProvider
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.oauth.OAuthConfiguration
 import com.fsck.k9.oauth.OAuthConfigurationProvider
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class ProvidersXmlDiscoveryTest : RobolectricTest() {

--- a/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
+++ b/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
@@ -1,10 +1,12 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import com.fsck.k9.autodiscovery.api.DiscoveredServerSettings
 import com.fsck.k9.autodiscovery.api.DiscoveryResults
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class ThunderbirdAutoconfigTest {

--- a/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProviderTest.kt
+++ b/app/autodiscovery/thunderbird/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigUrlProviderTest.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.containsExactly
 import org.junit.Test
 
 class ThunderbirdAutoconfigUrlProviderTest {

--- a/app/core/build.gradle.kts
+++ b/app/core/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     testImplementation(projects.app.storage)
     testImplementation(projects.app.testing)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.reflect)
     testImplementation(libs.robolectric)

--- a/app/html-cleaner/src/test/java/app/k9mail/html/cleaner/HtmlSanitizerTest.kt
+++ b/app/html-cleaner/src/test/java/app/k9mail/html/cleaner/HtmlSanitizerTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.html.cleaner
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.jsoup.nodes.Document
 import org.junit.Test
 

--- a/app/k9mail/build.gradle.kts
+++ b/app/k9mail/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
         debugImplementation(libs.leakcanary.android)
     }
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
+
     // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager
     testImplementation(projects.plugins.openpgpApiLib.openpgpApi)
 

--- a/app/storage/build.gradle.kts
+++ b/app/storage/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.commons.io)
     implementation(libs.moshi)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(projects.app.testing)
     testImplementation(libs.robolectric)

--- a/app/ui/legacy/build.gradle.kts
+++ b/app/ui/legacy/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.glide)
     annotationProcessor(libs.glide.compiler)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.core.testing)
     testImplementation(projects.mail.testing)
     testImplementation(projects.app.storage)

--- a/backend/imap/build.gradle.kts
+++ b/backend/imap/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines.core)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(projects.backend.testing)
     testImplementation(libs.mime4j.dom)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,10 +145,12 @@ shared-jvm-android = [
 ]
 shared-jvm-test = [
   "junit",
-  "truth",
   "assertk",
   "mockito-inline",
   "mockito-kotlin",
   "koin-test",
   "koin-test-junit4",
+]
+shared-jvm-test-legacy = [
+  "truth",
 ]

--- a/mail/common/build.gradle.kts
+++ b/mail/common/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     // We're only using this for its DefaultHostnameVerifier
     implementation(libs.apache.httpclient5)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(libs.icu4j.charset)
 }

--- a/mail/protocols/imap/build.gradle.kts
+++ b/mail/protocols/imap/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.commons.io)
     implementation(libs.okio)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(libs.okio)
     testImplementation(libs.mime4j.core)

--- a/mail/protocols/pop3/build.gradle.kts
+++ b/mail/protocols/pop3/build.gradle.kts
@@ -12,6 +12,7 @@ if (testCoverageEnabled) {
 dependencies {
     api(projects.mail.common)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(libs.okio)
     testImplementation(libs.jzlib)

--- a/mail/protocols/smtp/build.gradle.kts
+++ b/mail/protocols/smtp/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.commons.io)
     implementation(libs.okio)
 
+    testImplementation(libs.bundles.shared.jvm.test.legacy)
     testImplementation(projects.mail.testing)
     testImplementation(libs.okio)
     testImplementation(libs.jzlib)


### PR DESCRIPTION
Change truth testing library to legacy and only allow usage in old modules. 

This changes some small modules to [assertk](https://github.com/willowtreeapps/assertk) already.
