### PR TITLE
Change compose build plugins

### DIFF
--- a/build-plugin/src/main/kotlin/AndroidExtension.kt
+++ b/build-plugin/src/main/kotlin/AndroidExtension.kt
@@ -1,7 +1,8 @@
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.artifacts.dsl.DependencyHandler
 
-fun CommonExtension<*, *, *, *>.configureSharedConfig() {
+internal fun CommonExtension<*, *, *, *>.configureSharedConfig() {
     compileSdk = ThunderbirdProjectConfig.androidSdkCompile
 
     defaultConfig {
@@ -28,7 +29,9 @@ fun CommonExtension<*, *, *, *>.configureSharedConfig() {
     }
 }
 
-fun CommonExtension<*, *, *, *>.configureSharedComposeConfig(libs: LibrariesForLibs) {
+internal fun CommonExtension<*, *, *, *>.configureSharedComposeConfig(
+    libs: LibrariesForLibs,
+) {
     buildFeatures {
         compose = true
     }
@@ -47,4 +50,20 @@ fun CommonExtension<*, *, *, *>.configureSharedComposeConfig(libs: LibrariesForL
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+}
+
+internal fun DependencyHandler.configureSharedComposeDependencies(
+    libs: LibrariesForLibs,
+) {
+    val composeBom = platform(libs.androidx.compose.bom)
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation(libs.bundles.shared.jvm.android.compose)
+
+    debugImplementation(libs.bundles.shared.jvm.android.compose.debug)
+
+    testImplementation(libs.bundles.shared.jvm.test.compose)
+
+    androidTestImplementation(libs.bundles.shared.jvm.androidtest.compose)
 }

--- a/build-plugin/src/main/kotlin/DependencyHandlerExtension.kt
+++ b/build-plugin/src/main/kotlin/DependencyHandlerExtension.kt
@@ -1,0 +1,14 @@
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+internal fun DependencyHandler.implementation(dependencyNotation: Any): Dependency? =
+    add("implementation", dependencyNotation)
+
+internal fun DependencyHandler.debugImplementation(dependencyNotation: Any): Dependency? =
+    add("debugImplementation", dependencyNotation)
+
+internal fun DependencyHandler.testImplementation(dependencyNotation: Any): Dependency? =
+    add("testImplementation", dependencyNotation)
+
+internal fun DependencyHandler.androidTestImplementation(dependencyNotation: Any): Dependency? =
+    add("androidTestImplementation", dependencyNotation)

--- a/build-plugin/src/main/kotlin/ProjectExtension.kt
+++ b/build-plugin/src/main/kotlin/ProjectExtension.kt
@@ -1,6 +1,10 @@
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.getByName
 
-val Project.libs: LibrariesForLibs
+internal val Project.libs: LibrariesForLibs
     get() = extensions.getByName<LibrariesForLibs>("libs")
+
+internal fun Project.dependencies(configuration: DependencyHandlerScope.() -> Unit) =
+    DependencyHandlerScope.of(dependencies).configuration()

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
@@ -17,16 +17,7 @@ android {
 }
 
 dependencies {
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
+    configureSharedComposeDependencies(libs)
 
-    implementation(libs.bundles.shared.jvm.android.compose)
     implementation(libs.androidx.compose.activity)
-
-    debugImplementation(libs.bundles.shared.jvm.android.compose.debug)
-
-    testImplementation(libs.bundles.shared.jvm.test.compose)
-
-    androidTestImplementation(libs.bundles.shared.jvm.androidtest.compose)
 }

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
@@ -21,17 +21,12 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation(libs.androidx.compose.foundation)
-
-    // Android Studio Preview support
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-
-    // UI Tests
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-
-    implementation(libs.androidx.compose.lifecycle.viewmodel)
-
+    implementation(libs.bundles.shared.jvm.android.compose)
     implementation(libs.androidx.compose.activity)
+
+    debugImplementation(libs.bundles.shared.jvm.android.compose.debug)
+
+    testImplementation(libs.bundles.shared.jvm.test.compose)
+
+    androidTestImplementation(libs.bundles.shared.jvm.androidtest.compose)
 }

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
@@ -17,19 +17,19 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:${libs.versions.androidxComposeBom.get()}")
+    val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation("androidx.compose.foundation:foundation")
+    implementation(libs.androidx.compose.foundation)
 
     // Android Studio Preview support
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // UI Tests
-    debugImplementation("androidx.compose.ui:ui-test-manifest")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
     implementation(libs.androidx.compose.lifecycle.viewmodel)
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -7,15 +7,5 @@ android {
 }
 
 dependencies {
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
-    implementation(libs.bundles.shared.jvm.android.compose)
-
-    debugImplementation(libs.bundles.shared.jvm.android.compose.debug)
-
-    testImplementation(libs.bundles.shared.jvm.test.compose)
-
-    androidTestImplementation(libs.bundles.shared.jvm.androidtest.compose)
+    configureSharedComposeDependencies(libs)
 }

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -22,4 +22,6 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
     implementation(libs.androidx.compose.lifecycle.viewmodel)
+
+    testImplementation(libs.bundles.shared.jvm.test.compose)
 }

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -11,17 +11,11 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation(libs.androidx.compose.foundation)
+    implementation(libs.bundles.shared.jvm.android.compose)
 
-    // Android Studio Preview support
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-
-    // UI Tests
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-
-    implementation(libs.androidx.compose.lifecycle.viewmodel)
+    debugImplementation(libs.bundles.shared.jvm.android.compose.debug)
 
     testImplementation(libs.bundles.shared.jvm.test.compose)
+
+    androidTestImplementation(libs.bundles.shared.jvm.androidtest.compose)
 }

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -7,19 +7,19 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:${libs.versions.androidxComposeBom.get()}")
+    val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    implementation("androidx.compose.foundation:foundation")
+    implementation(libs.androidx.compose.foundation)
 
     // Android Studio Preview support
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // UI Tests
-    debugImplementation("androidx.compose.ui:ui-test-manifest")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
     implementation(libs.androidx.compose.lifecycle.viewmodel)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,6 +149,18 @@ shared-jvm-android = [
   "androidx-core-ktx",
   "koin-android",
 ]
+shared-jvm-android-compose = [
+  "androidx-compose-foundation",
+  "androidx-compose-ui-tooling-preview",
+  "androidx-compose-lifecycle-viewmodel",
+]
+shared-jvm-android-compose-debug = [
+  "androidx-compose-ui-tooling",
+  "androidx-compose-ui-test-manifest",
+]
+shared-jvm-androidtest-compose = [
+  "androidx-compose-ui-test-junit4",
+]
 shared-jvm-test = [
   "junit",
   "assertk",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -157,6 +157,11 @@ shared-jvm-test = [
   "koin-test",
   "koin-test-junit4",
 ]
+shared-jvm-test-compose = [
+  "robolectric",
+  "androidx-compose-ui-test-junit4",
+  "androidx-test-espresso-core",
+]
 shared-jvm-test-legacy = [
   "truth",
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,12 @@ androidx-localbroadcastmanager = "androidx.localbroadcastmanager:localbroadcastm
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-preference = { module = "androidx.preference:preference", version.ref = "androidxPreference" }
 androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-activity = "androidx.activity:activity-compose:1.6.1"
 androidx-compose-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
 androidx-compose-material = "androidx.compose.material:material:1.3.1"


### PR DESCRIPTION
Change app and library compose build plugins to share dependencies and add compose jUnit test dependencies. 

Also ensure that Gradle extensions are internal to avoid leaking into the rest of the project.