### PR TITLE
Fix editor config import rule for aliases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 insert_final_newline = true
 
 [*.{kt,kts}]
-ij_kotlin_imports_layout = *,^*
+ij_kotlin_imports_layout = *,^
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 


### PR DESCRIPTION
The editor config rule had an error that didn't move alias imports to the end of the import statement when formatted in Android Studio. This caused issues with `ktlint` as it correctly expects them at the end.
