### PR TITLE
Add WindowSizeInfo

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClass.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClass.kt
@@ -1,0 +1,37 @@
+package app.k9mail.core.ui.compose.common.window
+
+/**
+ * WindowSizeClass as defined by supporting different screen sizes.
+ *
+ * See: https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#window_size_classes
+ */
+enum class WindowSizeClass {
+    Compact,
+    Medium,
+    Expanded,
+    ;
+
+    companion object {
+        private const val COMPACT_MAX_WIDTH = 600
+        private const val COMPACT_MAX_HEIGHT = 480
+
+        private const val MEDIUM_MAX_WIDTH = 840
+        private const val MEDIUM_MAX_HEIGHT = 900
+
+        fun fromWidth(width: Int): WindowSizeClass {
+            return when {
+                width < COMPACT_MAX_WIDTH -> Compact
+                width < MEDIUM_MAX_WIDTH -> Medium
+                else -> Expanded
+            }
+        }
+
+        fun fromHeight(height: Int): WindowSizeClass {
+            return when {
+                height < COMPACT_MAX_HEIGHT -> Compact
+                height < MEDIUM_MAX_HEIGHT -> Medium
+                else -> Expanded
+            }
+        }
+    }
+}

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeInfo.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeInfo.kt
@@ -1,0 +1,30 @@
+package app.k9mail.core.ui.compose.common.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Returns the current window size info based on current Configuration.
+ */
+@Composable
+fun getWindowSizeInfo(): WindowSizeInfo {
+    val configuration = LocalConfiguration.current
+
+    return WindowSizeInfo(
+        screenWidthSizeClass = WindowSizeClass.fromWidth(configuration.screenWidthDp),
+        screenHeightSizeClass = WindowSizeClass.fromHeight(configuration.screenHeightDp),
+        screenWidth = configuration.screenWidthDp.dp,
+        screenHeight = configuration.screenHeightDp.dp,
+    )
+}
+
+@Immutable
+data class WindowSizeInfo(
+    val screenWidthSizeClass: WindowSizeClass,
+    val screenHeightSizeClass: WindowSizeClass,
+    val screenWidth: Dp,
+    val screenHeight: Dp,
+)

--- a/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClassTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClassTest.kt
@@ -1,0 +1,80 @@
+package app.k9mail.core.ui.compose.common.window
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+class WindowSizeClassTest {
+
+    @Test
+    fun `should return compact when width is less than 600`() {
+        val width = 599
+
+        val windowSizeClass = WindowSizeClass.fromWidth(width)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Compact)
+    }
+
+    @Test
+    fun `should return medium when width is 600`() {
+        val width = 600
+
+        val windowSizeClass = WindowSizeClass.fromWidth(width)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Medium)
+    }
+
+    @Test
+    fun `should return medium when width is less than 840`() {
+        val width = 839
+
+        val windowSizeClass = WindowSizeClass.fromWidth(width)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Medium)
+    }
+
+    @Test
+    fun `should return expanded when width is 840`() {
+        val width = 840
+
+        val windowSizeClass = WindowSizeClass.fromWidth(width)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Expanded)
+    }
+
+    @Test
+    fun `should return compact when height is less than 480`() {
+        val height = 479
+
+        val windowSizeClass = WindowSizeClass.fromHeight(height)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Compact)
+    }
+
+    @Test
+    fun `should return medium when height is 480`() {
+        val height = 480
+
+        val windowSizeClass = WindowSizeClass.fromHeight(height)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Medium)
+    }
+
+    @Test
+    fun `should return medium when height is less than 900`() {
+        val height = 899
+
+        val windowSizeClass = WindowSizeClass.fromHeight(height)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Medium)
+    }
+
+    @Test
+    fun `should return expanded when height is 900`() {
+        val height = 900
+
+        val windowSizeClass = WindowSizeClass.fromHeight(height)
+
+        assertThat(windowSizeClass).isEqualTo(WindowSizeClass.Expanded)
+    }
+}


### PR DESCRIPTION
This adds WindowSizeInfo to `:core:ui:compose:common` to determine the WindowSizeClasses and current height and width. WindowSizeClasses follow [Support different screen sizes](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#window_size_classes)
