### PR TITLE
Add unidirectional viewmodel

### DIFF
--- a/app-feature-preview/src/main/AndroidManifest.xml
+++ b/app-feature-preview/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Thunderbird.Splashscreen"
+        android:name=".FeatureApplication"
         >
 
         <activity

--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/FeatureApplication.kt
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/FeatureApplication.kt
@@ -1,0 +1,18 @@
+package app.k9mail.feature.preview
+
+import android.app.Application
+import app.k9mail.feature.account.setup.featureAccountSetupModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+
+class FeatureApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        startKoin {
+            androidContext(this@FeatureApplication)
+            modules(featureAccountSetupModule)
+        }
+    }
+}

--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/navigation/FeatureNavHost.kt
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/navigation/FeatureNavHost.kt
@@ -21,8 +21,8 @@ fun FeatureNavHost(
         modifier = modifier,
     ) {
         onboardingScreen(
-            onStartClick = { navController.navigateToAccountSetup() },
-            onImportClick = { /* TODO */ },
+            onStart = { navController.navigateToAccountSetup() },
+            onImport = { /* TODO */ },
         )
         accountSetupScreen(
             onBack = navController::popBackStack,

--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/navigation/FeatureNavHost.kt
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/navigation/FeatureNavHost.kt
@@ -25,8 +25,8 @@ fun FeatureNavHost(
             onImportClick = { /* TODO */ },
         )
         accountSetupScreen(
-            onBackClick = navController::popBackStack,
-            onFinishClick = { /* TODO */ },
+            onBack = navController::popBackStack,
+            onFinish = { /* TODO */ },
         )
     }
 }

--- a/core/ui/compose/common/build.gradle.kts
+++ b/core/ui/compose/common/build.gradle.kts
@@ -6,3 +6,7 @@ android {
     namespace = "app.k9mail.core.ui.compose.common"
     resourcePrefix = "core_ui_common_"
 }
+
+dependencies {
+    testImplementation(projects.core.ui.compose.testing)
+}

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModel.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModel.kt
@@ -1,0 +1,57 @@
+package app.k9mail.core.ui.compose.common.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * An abstract base ViewModel that implements [UnidirectionalViewModel] and provides basic
+ * functionality for managing state and effects.
+ *
+ * @param STATE The type that represents the state of the ViewModel. For example, the UI state of a screen can be
+ * represented as a state.
+ * @param EVENT The type that represents user actions that can occur and should be handled by the ViewModel. For
+ * example, a button click can be represented as an event.
+ * @param EFFECT The  type that represents side-effects that can occur in response to the state changes. For example,
+ * a navigation event can be represented as an effect.
+ *
+ * @property initialState The initial [STATE] of the ViewModel.
+ */
+abstract class BaseViewModel<STATE, EVENT, EFFECT>(
+    initialState: STATE,
+) : ViewModel(),
+    UnidirectionalViewModel<STATE, EVENT, EFFECT> {
+
+    private val _state = MutableStateFlow(initialState)
+    override val state: StateFlow<STATE> = _state.asStateFlow()
+
+    private val _effect = MutableSharedFlow<EFFECT>()
+    override val effect: SharedFlow<EFFECT> = _effect.asSharedFlow()
+
+    /**
+     * Updates the [STATE] of the ViewModel.
+     *
+     * @param update A function that takes the current [STATE] and produces a new [STATE].
+     */
+    protected fun updateState(update: (STATE) -> STATE) {
+        _state.update(update)
+    }
+
+    /**
+     * Emits a side effect.
+     *
+     * @param effect The [EFFECT] to emit.
+     */
+    protected fun emitEffect(effect: EFFECT) {
+        viewModelScope.launch {
+            _effect.emit(effect)
+        }
+    }
+}

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/UnidirectionalViewModel.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/UnidirectionalViewModel.kt
@@ -1,0 +1,104 @@
+package app.k9mail.core.ui.compose.common.mvi
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+
+/**
+ * Interface for a unidirectional view model with side-effects ([EFFECT]). It has a [STATE] and can handle [EVENT]'s.
+ *
+ * @param STATE The type that represents the state of the ViewModel. For example, the UI state of a screen can be
+ * represented as a state.
+ * @param EVENT The type that represents user actions that can occur and should be handled by the ViewModel. For
+ * example, a button click can be represented as an event.
+ * @param EFFECT The  type that represents side-effects that can occur in response to the state changes. For example,
+ * a navigation event can be represented as an effect.
+ */
+interface UnidirectionalViewModel<STATE, EVENT, EFFECT> {
+    /**
+     * The current [STATE] of the view model.
+     */
+    val state: StateFlow<STATE>
+
+    /**
+     * The side-effects ([EFFECT]) produced by the view model.
+     */
+    val effect: SharedFlow<EFFECT>
+
+    /**
+     * Handles an [EVENT] and updates the [STATE] of the view model.
+     *
+     * @param event The [EVENT] to handle.
+     */
+    fun event(event: EVENT)
+}
+
+/**
+ * Data class representing a state and a dispatch function, used for destructuring in [observe].
+ */
+data class StateDispatch<STATE, EVENT>(
+    val state: State<STATE>,
+    val dispatch: (EVENT) -> Unit,
+)
+
+/**
+ * Composable function that observes a UnidirectionalViewModel and handles its side effects.
+ *
+ * Example usage:
+ * ```
+ * @Composable
+ * fun MyScreen(
+ *    onNavigateNext: () -> Unit,
+ *    onNavigateBack: () -> Unit,
+ *    viewModel: MyUnidirectionalViewModel<MyState, MyEvent, MyEffect>,
+ * ) {
+ *    val (state, dispatch) = viewModel.observe { effect ->
+ *      when (effect) {
+ *          MyEffect.OnBackPressed -> onNavigateBack()
+ *          MyEffect.OnNextPressed -> onNavigateNext()
+ *      }
+ *    }
+ *
+ *    MyContent(
+ *      onNextClick = {
+ *          dispatch(MyEvent.OnNext)
+ *      },
+ *      onBackClick = {
+ *          dispatch(MyEvent.OnBack)
+ *      },
+ *      state = state.value,
+ *    )
+ * }
+ * ```
+ *
+ * @param STATE The type that represents the state of the ViewModel.
+ * @param EVENT The type that represents user actions that can occur and should be handled by the ViewModel.
+ * @param EFFECT The  type that represents side-effects that can occur in response to the state changes.
+ *
+ * @param handleEffect A function to handle side effects ([EFFECT]).
+ *
+ * @return A [StateDispatch] containing the state and a dispatch function.
+ */
+@Composable
+inline fun <reified STATE, EVENT, EFFECT> UnidirectionalViewModel<STATE, EVENT, EFFECT>.observe(
+    crossinline handleEffect: (EFFECT) -> Unit,
+): StateDispatch<STATE, EVENT> {
+    val collectedState = state.collectAsStateWithLifecycle()
+
+    val dispatch: (EVENT) -> Unit = { event(it) }
+
+    LaunchedEffect(key1 = effect) {
+        effect.collectLatest {
+            handleEffect(it)
+        }
+    }
+
+    return StateDispatch(
+        state = collectedState,
+        dispatch = dispatch,
+    )
+}

--- a/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModelTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModelTest.kt
@@ -1,0 +1,56 @@
+package app.k9mail.core.ui.compose.common.mvi
+
+import app.cash.turbine.test
+import app.k9mail.core.ui.compose.testing.MainDispatcherRule
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class BaseViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `should emit initial state`() = runTest {
+        val viewModel = TestBaseViewModel()
+        assertThat(viewModel.state.value).isEqualTo("Initial state")
+    }
+
+    @Test
+    fun `should update state`() = runTest {
+        val viewModel = TestBaseViewModel()
+
+        viewModel.event("Test event")
+
+        assertThat(viewModel.state.value).isEqualTo("Test event")
+
+        viewModel.event("Another test event")
+
+        assertThat(viewModel.state.value).isEqualTo("Another test event")
+    }
+
+    @Test
+    fun `should emit effects`() = runTest {
+        val viewModel = TestBaseViewModel()
+
+        viewModel.effect.test {
+            viewModel.event("Test effect")
+
+            assertThat(awaitItem()).isEqualTo("Test effect")
+
+            viewModel.event("Another test effect")
+
+            assertThat(awaitItem()).isEqualTo("Another test effect")
+        }
+    }
+
+    private class TestBaseViewModel : BaseViewModel<String, String, String>("Initial state") {
+        override fun event(event: String) {
+            updateState { event }
+            emitEffect(event)
+        }
+    }
+}

--- a/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/mvi/UnidirectionalViewModelKtTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/mvi/UnidirectionalViewModelKtTest.kt
@@ -1,0 +1,78 @@
+package app.k9mail.core.ui.compose.common.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.MainDispatcherRule
+import app.k9mail.core.ui.compose.testing.setContent
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class UnidirectionalViewModelKtTest : ComposeTest() {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `observe should emit state changes, allow event dispatch and expose effects`() = runTest {
+        val viewModel = TestViewModel()
+        val effects = mutableListOf<TestEffect>()
+        lateinit var stateDispatch: StateDispatch<TestState, TestEvent>
+
+        setContent {
+            stateDispatch = viewModel.observe { effect ->
+                effects.add(effect)
+            }
+        }
+
+        val (state, dispatch) = stateDispatch
+
+        // Initial state
+        assertThat(state.value.data).isEqualTo("TestState: Initial")
+
+        // Dispatch an event
+        dispatch(TestEvent("Event 1"))
+
+        assertThat(state.value.data).isEqualTo("TestState: Event 1")
+        assertThat(effects.last().result).isEqualTo("TestEffect: Event 1")
+
+        // Dispatch another event
+        dispatch(TestEvent("Event 2"))
+
+        assertThat(state.value.data).isEqualTo("TestState: Event 2")
+        assertThat(effects.last().result).isEqualTo("TestEffect: Event 2")
+    }
+
+    private data class TestState(val data: String)
+    private data class TestEvent(val action: String)
+    private data class TestEffect(val result: String)
+
+    private class TestViewModel(
+        initialState: TestState = TestState("TestState: Initial"),
+    ) : ViewModel(), UnidirectionalViewModel<TestState, TestEvent, TestEffect> {
+
+        private val _state = MutableStateFlow(initialState)
+        override val state: StateFlow<TestState> = _state.asStateFlow()
+
+        private val _effect = MutableSharedFlow<TestEffect>()
+        override val effect: SharedFlow<TestEffect> = _effect.asSharedFlow()
+
+        override fun event(event: TestEvent) {
+            _state.update { it.copy(data = "TestState: ${event.action}") }
+            viewModelScope.launch {
+                _effect.emit(TestEffect(result = "TestEffect: ${event.action}"))
+            }
+        }
+    }
+}

--- a/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/ComposeTest.kt
+++ b/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/ComposeTest.kt
@@ -1,8 +1,16 @@
 package app.k9mail.core.ui.compose.testing
 
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,3 +28,45 @@ open class ComposeTest {
         testContent()
     }
 }
+
+fun ComposeTest.setContent(content: @Composable () -> Unit) = composeTestRule.setContent(content)
+
+fun ComposeTest.onNodeWithTag(
+    tag: String,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onNodeWithTag(tag, useUnmergedTree)
+
+fun ComposeTest.onAllNodesWithTag(
+    tag: String,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onAllNodesWithTag(tag, useUnmergedTree)
+
+fun ComposeTest.onNodeWithContentDescription(
+    label: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onNodeWithContentDescription(label, substring, ignoreCase, useUnmergedTree)
+
+fun ComposeTest.onNodeWithText(
+    text: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onNodeWithText(text, substring, ignoreCase, useUnmergedTree)
+
+fun ComposeTest.onAllNodesWithText(
+    text: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onAllNodesWithText(text, substring, ignoreCase, useUnmergedTree)
+
+fun ComposeTest.onAllNodesWithContentDescription(
+    label: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+    useUnmergedTree: Boolean = false,
+) = composeTestRule.onAllNodesWithContentDescription(label, substring, ignoreCase, useUnmergedTree)
+
+fun ComposeTest.onRoot(useUnmergedTree: Boolean = false) = composeTestRule.onRoot(useUnmergedTree)

--- a/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/MainDispatcherRule.kt
+++ b/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package app.k9mail.core.ui.compose.testing
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+
+/**
+ * A JUnit rule that swaps the [Dispatchers.Main] dispatcher with a [TestDispatcher] for the duration of the test.
+ */
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: org.junit.runner.Description?) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: org.junit.runner.Description?) {
+        Dispatchers.resetMain()
+    }
+}

--- a/feature/account/setup/build.gradle.kts
+++ b/feature/account/setup/build.gradle.kts
@@ -9,4 +9,6 @@ android {
 
 dependencies {
     implementation(projects.core.ui.compose.designsystem)
+
+    testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.account.setup
+
+import app.k9mail.feature.account.setup.ui.AccountSetupViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val featureAccountSetupModule: Module = module {
+    viewModel { AccountSetupViewModel() }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
@@ -13,13 +13,13 @@ fun NavController.navigateToAccountSetup(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.accountSetupScreen(
-    onBackClick: () -> Unit,
-    onFinishClick: () -> Unit,
+    onBack: () -> Unit,
+    onFinish: () -> Unit,
 ) {
     composable(route = NAVIGATION_ROUTE_ACCOUNT_SETUP) {
         AccountSetupScreen(
-            onBackClick = onBackClick,
-            onFinishClick = onFinishClick,
+            onBack = onBack,
+            onFinish = onFinish,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupContract.kt
@@ -1,0 +1,28 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+
+interface AccountSetupContract {
+
+    enum class SetupStep {
+        AUTO_CONFIG,
+        MANUAL_CONFIG,
+        OPTIONS,
+    }
+
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
+
+    data class State(
+        val setupStep: SetupStep = SetupStep.AUTO_CONFIG,
+    )
+
+    sealed interface Event {
+        object OnNext : Event
+        object OnBack : Event
+    }
+
+    sealed interface Effect {
+        object NavigateNext : Effect
+        object NavigateBack : Effect
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
@@ -1,65 +1,59 @@
 package app.k9mail.feature.account.setup.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.common.mvi.observe
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Event
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.ViewModel
 import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigScreen
 import app.k9mail.feature.account.setup.ui.manualconfig.AccountManualConfigScreen
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsScreen
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun AccountSetupScreen(
-    onFinishClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onFinish: () -> Unit,
+    onBack: () -> Unit,
+    viewModel: ViewModel = koinViewModel<AccountSetupViewModel>(),
 ) {
-    val accountSetupSteps = remember { mutableStateOf(AccountSetupSteps.AUTO_CONFIG) }
+    val (state, dispatch) = viewModel.observe { effect ->
+        when (effect) {
+            Effect.NavigateBack -> onBack()
+            Effect.NavigateNext -> onFinish()
+        }
+    }
 
-    when (accountSetupSteps.value) {
-        AccountSetupSteps.AUTO_CONFIG -> {
+    when (state.value.setupStep) {
+        SetupStep.AUTO_CONFIG -> {
             AccountAutoConfigScreen(
-                onNextClick = {
-                    // TODO validate config
-                    accountSetupSteps.value = AccountSetupSteps.MANUAL_CONFIG
-                },
-                onBackClick = onBackClick,
+                onNextClick = { dispatch(Event.OnNext) },
+                onBackClick = { dispatch(Event.OnBack) },
             )
         }
 
-        AccountSetupSteps.MANUAL_CONFIG -> {
+        SetupStep.MANUAL_CONFIG -> {
             AccountManualConfigScreen(
-                onNextClick = {
-                    accountSetupSteps.value = AccountSetupSteps.OPTIONS
-                },
-                onBackClick = {
-                    accountSetupSteps.value = AccountSetupSteps.AUTO_CONFIG
-                },
+                onNextClick = { dispatch(Event.OnNext) },
+                onBackClick = { dispatch(Event.OnBack) },
             )
         }
 
-        AccountSetupSteps.OPTIONS -> {
+        SetupStep.OPTIONS -> {
             AccountOptionsScreen(
-                // validate account
-                onFinishClick = onFinishClick,
-                onBackClick = {
-                    accountSetupSteps.value = AccountSetupSteps.MANUAL_CONFIG
-                },
+                onFinishClick = { dispatch(Event.OnNext) },
+                onBackClick = { dispatch(Event.OnBack) },
             )
         }
     }
-}
-
-enum class AccountSetupSteps {
-    AUTO_CONFIG,
-    MANUAL_CONFIG,
-    OPTIONS,
 }
 
 @Preview(showBackground = true)
 @Composable
 internal fun AccountSetupScreenPreview() {
     AccountSetupScreen(
-        onFinishClick = {},
-        onBackClick = {},
+        onFinish = {},
+        onBack = {},
     )
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModel.kt
@@ -1,5 +1,52 @@
 package app.k9mail.feature.account.setup.ui
 
-import androidx.lifecycle.ViewModel
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Event
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.ViewModel
 
-class AccountSetupViewModel : ViewModel()
+class AccountSetupViewModel(
+    initialState: State = State(),
+) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
+
+    override fun event(event: Event) {
+        when (event) {
+            Event.OnBack -> onBack()
+            Event.OnNext -> onNext()
+        }
+    }
+
+    private fun onBack() {
+        when (state.value.setupStep) {
+            SetupStep.AUTO_CONFIG -> navigateBack()
+            SetupStep.MANUAL_CONFIG -> changeToSetupStep(SetupStep.AUTO_CONFIG)
+            SetupStep.OPTIONS -> changeToSetupStep(SetupStep.MANUAL_CONFIG)
+        }
+    }
+
+    private fun onNext() {
+        when (state.value.setupStep) {
+            SetupStep.AUTO_CONFIG -> changeToSetupStep(SetupStep.MANUAL_CONFIG)
+            SetupStep.MANUAL_CONFIG -> changeToSetupStep(SetupStep.OPTIONS)
+            SetupStep.OPTIONS -> navigateNext()
+        }
+    }
+
+    private fun changeToSetupStep(setupStep: SetupStep) {
+        updateState {
+            it.copy(
+                setupStep = setupStep,
+            )
+        }
+    }
+
+    private fun navigateNext() {
+        // TODO: validate account
+
+        emitEffect(Effect.NavigateNext)
+    }
+
+    private fun navigateBack() = emitEffect(Effect.NavigateBack)
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
@@ -32,7 +33,9 @@ internal fun AccountAutoConfigContent(
     modifier: Modifier = Modifier,
 ) {
     ResponsiveContentWithBackground(
-        modifier = modifier,
+        modifier = Modifier
+            .testTag("AccountAutoConfigContent")
+            .then(modifier),
     ) {
         LazyColumnWithHeaderFooter(
             modifier = Modifier.fillMaxSize(),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/manualconfig/AccountManualConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/manualconfig/AccountManualConfigContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
@@ -27,7 +28,9 @@ internal fun AccountManualConfigContent(
     modifier: Modifier = Modifier,
 ) {
     ResponsiveContentWithBackground(
-        modifier = modifier,
+        modifier = Modifier
+            .testTag("AccountManualConfigContent")
+            .then(modifier),
     ) {
         LazyColumnWithHeaderFooter(
             modifier = Modifier.fillMaxSize(),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
@@ -27,7 +28,9 @@ internal fun AccountOptionsContent(
     modifier: Modifier = Modifier,
 ) {
     ResponsiveContentWithBackground(
-        modifier = modifier,
+        modifier = Modifier
+            .testTag("AccountOptionsContent")
+            .then(modifier),
     ) {
         LazyColumnWithHeaderFooter(
             modifier = Modifier.fillMaxSize(),

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -1,0 +1,22 @@
+package app.k9mail.feature.account.setup
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.koinApplication
+import org.koin.test.check.checkModules
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class AccountSetupModuleKtTest {
+
+    @Test
+    fun `should have a valid di module`() {
+        koinApplication {
+            modules(featureAccountSetupModule)
+            androidContext(RuntimeEnvironment.getApplication())
+            checkModules()
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreenKtTest.kt
@@ -1,0 +1,69 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.onNodeWithTag
+import app.k9mail.core.ui.compose.testing.setContent
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AccountSetupScreenKtTest : ComposeTest() {
+
+    @Test
+    fun `should display correct screen for every setup step`() = runTest {
+        val viewModel = FakeAccountSetupViewModel()
+
+        setContent {
+            AccountSetupScreen(
+                onFinish = { },
+                onBack = { },
+                viewModel = viewModel,
+            )
+        }
+
+        for (step in SetupStep.values()) {
+            viewModel.mutableState.update { it.copy(setupStep = step) }
+            onNodeWithTag(getTagForStep(step)).assertExists()
+        }
+    }
+
+    @Test
+    fun `should delegate navigation effects`() = runTest {
+        val initialState = State()
+        val viewModel = FakeAccountSetupViewModel(initialState)
+        var onFinishCounter = 0
+        var onBackCounter = 0
+
+        setContent {
+            AccountSetupScreen(
+                onFinish = { onFinishCounter++ },
+                onBack = { onBackCounter++ },
+                viewModel = viewModel,
+            )
+        }
+
+        assertThat(onFinishCounter).isEqualTo(0)
+        assertThat(onBackCounter).isEqualTo(0)
+
+        viewModel.mutableEffect.emit(Effect.NavigateNext)
+
+        assertThat(onFinishCounter).isEqualTo(1)
+        assertThat(onBackCounter).isEqualTo(0)
+
+        viewModel.mutableEffect.emit(Effect.NavigateBack)
+
+        assertThat(onFinishCounter).isEqualTo(1)
+        assertThat(onBackCounter).isEqualTo(1)
+    }
+
+    private fun getTagForStep(step: SetupStep): String = when (step) {
+        SetupStep.AUTO_CONFIG -> "AccountAutoConfigContent"
+        SetupStep.MANUAL_CONFIG -> "AccountManualConfigContent"
+        SetupStep.OPTIONS -> "AccountOptionsContent"
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupStateTest.kt
@@ -1,0 +1,20 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import org.junit.Test
+
+class AccountSetupStateTest {
+
+    @Test
+    fun `should set default values`() {
+        val state = State()
+
+        assertThat(state).all {
+            prop(State::setupStep).isEqualTo(AccountSetupContract.SetupStep.AUTO_CONFIG)
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModelTest.kt
@@ -1,0 +1,122 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.testIn
+import app.k9mail.core.ui.compose.testing.MainDispatcherRule
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect.NavigateBack
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect.NavigateNext
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class AccountSetupViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `should forward step state on next event`() = runTest {
+        val viewModel = AccountSetupViewModel()
+        val stateTurbine = viewModel.state.testIn(backgroundScope)
+        val effectTurbine = viewModel.effect.testIn(backgroundScope)
+        val turbines = listOf(stateTurbine, effectTurbine)
+
+        // Initial state
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.AUTO_CONFIG)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnNext)
+
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.MANUAL_CONFIG)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnNext)
+
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.OPTIONS)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnNext)
+
+        assertThatAndAllEventsConsumed(
+            actual = effectTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(NavigateNext)
+        }
+    }
+
+    @Test
+    fun `should rewind step state on back event`() = runTest {
+        val initialState = State(setupStep = SetupStep.OPTIONS)
+        val viewModel = AccountSetupViewModel(initialState)
+        val stateTurbine = viewModel.state.testIn(backgroundScope)
+        val effectTurbine = viewModel.effect.testIn(backgroundScope)
+        val turbines = listOf(stateTurbine, effectTurbine)
+
+        // Initial state
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.OPTIONS)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnBack)
+
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.MANUAL_CONFIG)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnBack)
+
+        assertThatAndAllEventsConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            prop(State::setupStep).isEqualTo(SetupStep.AUTO_CONFIG)
+        }
+
+        viewModel.event(AccountSetupContract.Event.OnBack)
+
+        assertThatAndAllEventsConsumed(
+            actual = effectTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(NavigateBack)
+        }
+    }
+
+    private fun <T> assertThatAndAllEventsConsumed(
+        actual: T,
+        turbines: List<ReceiveTurbine<*>>,
+        assertion: Assert<T>.() -> Unit,
+    ) {
+        assertThat(actual).all {
+            assertion()
+        }
+
+        turbines.forEach { it.ensureAllEventsConsumed() }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAccountSetupViewModel.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAccountSetupViewModel.kt
@@ -1,0 +1,26 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.Event
+import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class FakeAccountSetupViewModel(
+    initialState: State = State(),
+) : AccountSetupContract.ViewModel {
+
+    val mutableState = MutableStateFlow(initialState)
+    val mutableEffect = MutableSharedFlow<Effect>()
+    val events = mutableListOf<Event>()
+
+    override val state: StateFlow<State> = mutableState.asStateFlow()
+    override val effect: SharedFlow<Effect> = mutableEffect.asSharedFlow()
+    override fun event(event: Event) {
+        events.add(event)
+    }
+}

--- a/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
@@ -15,13 +15,13 @@ fun NavController.navigateToOnboarding(
 }
 
 fun NavGraphBuilder.onboardingScreen(
-    onStartClick: () -> Unit,
-    onImportClick: () -> Unit,
+    onStart: () -> Unit,
+    onImport: () -> Unit,
 ) {
     composable(route = NAVIGATION_ROUTE_ONBOARDING) {
         OnboardingScreen(
-            onStartClick = onStartClick,
-            onImportClick = onImportClick,
+            onStartClick = onStart,
+            onImportClick = onImport,
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 timber = "com.jakewharton.timber:timber:5.0.1"
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koinAndroid" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinAndroid" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koinCore" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koinCore" }
 commons-io = "commons-io:commons-io:2.11.0"
@@ -170,6 +171,7 @@ shared-jvm-android-compose = [
   "androidx-compose-lifecycle-runtime",
   "androidx-compose-lifecycle-viewmodel",
   "androidx-compose-navigation",
+  "koin-androidx-compose",
 ]
 shared-jvm-android-compose-debug = [
   "androidx-compose-ui-tooling",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
+androidx-compose-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-compose-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidxComposeMaterial" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidxComposeMaterial" }
@@ -166,6 +167,7 @@ shared-jvm-android-app = [
 shared-jvm-android-compose = [
   "androidx-compose-foundation",
   "androidx-compose-ui-tooling-preview",
+  "androidx-compose-lifecycle-runtime",
   "androidx-compose-lifecycle-viewmodel",
   "androidx-compose-navigation",
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -188,6 +188,7 @@ shared-jvm-test = [
   "mockito-kotlin",
   "koin-test",
   "koin-test-junit4",
+  "turbine",
 ]
 shared-jvm-test-compose = [
   "robolectric",


### PR DESCRIPTION
This adds the `UnidirectionalViewModel` as a variation of the MVI pattern with side effects. It is used to manage compose ui in the project to ensure unidirectional data flows. 

It has a `STATE` and can handle `EVENT`s, if necessary, it emits `EFFECT`'s to trigger one-off actions.
- The `STATE` represents the state of the view model. For example, the ui state of a screen can berepresented as a state.
- The `EVENT` represents user actions that can occur and should be handled by the view model. For example, a button click can be represented as an event.
- The `EFFECT` represents side-effects that can occur in response to the state changes. For example, a navigation event can be represented as an effect.

It comes with a `BaseViewModel` that wires state, events and effects to an Android ViewModel.

For better integration in composable views, the `UnidirectionalViewModel` can be observed by using the `viewmodel.observe` extension.

The account setup screen has been changed to use `UnidirectionalViewModel` and a contract is added to define all necessary components.


