### PR TITLE
Use value classes `EmailAddress` and `Domain` in `:feature:autodiscovery:autoconfig`

### DIFF
--- a/core/common/src/main/kotlin/app/k9mail/core/common/mail/EmailAddress.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/mail/EmailAddress.kt
@@ -6,3 +6,5 @@ value class EmailAddress(val address: String) {
         require(address.isNotBlank()) { "Email address must not be blank" }
     }
 }
+
+fun String.toEmailAddress() = EmailAddress(this)

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/Domain.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/Domain.kt
@@ -6,3 +6,5 @@ value class Domain(val value: String) {
         requireNotNull(HostNameUtils.isLegalHostName(value)) { "Not a valid domain name: '$value'" }
     }
 }
+
+fun String.toDomain() = Domain(this)

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/Domain.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/Domain.kt
@@ -1,0 +1,8 @@
+package app.k9mail.core.common.net
+
+@JvmInline
+value class Domain(val value: String) {
+    init {
+        requireNotNull(HostNameUtils.isLegalHostName(value)) { "Not a valid domain name: '$value'" }
+    }
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/HostNameUtils.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/HostNameUtils.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.helper
+package app.k9mail.core.common.net
 
 /**
  * Code to check the validity of host names and IP addresses.

--- a/core/common/src/test/kotlin/app/k9mail/core/common/net/DomainTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/net/DomainTest.kt
@@ -1,0 +1,25 @@
+package app.k9mail.core.common.net
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+
+class DomainTest {
+    @Test
+    fun `valid domain`() {
+        val domain = Domain("domain.example")
+
+        assertThat(domain.value).isEqualTo("domain.example")
+    }
+
+    @Test
+    fun `invalid domain should throw`() {
+        assertFailure {
+            Domain("invalid domain")
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("Not a valid domain name: 'invalid domain'")
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/net/HostNameUtilsTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/net/HostNameUtilsTest.kt
@@ -1,11 +1,11 @@
-package com.fsck.k9.helper
+package app.k9mail.core.common.net
 
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import org.junit.Test
+import kotlin.test.Test
 
 /**
  * Test data copied from `mailnews/base/test/unit/test_hostnameUtils.js`

--- a/feature/autodiscovery/autoconfig/build.gradle.kts
+++ b/feature/autodiscovery/autoconfig/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(projects.feature.autodiscovery.api)
 
     compileOnly(libs.xmlpull)
+    implementation(projects.core.common)
     implementation(libs.okhttp)
     implementation(libs.minidns.hla)
 

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigDiscovery.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigDiscovery.kt
@@ -2,6 +2,7 @@ package app.k9mail.autodiscovery.autoconfig
 
 import app.k9mail.autodiscovery.api.ConnectionSettingsDiscovery
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.net.toDomain
 import com.fsck.k9.helper.EmailHelper
 
 class AutoconfigDiscovery(
@@ -11,7 +12,7 @@ class AutoconfigDiscovery(
 ) : ConnectionSettingsDiscovery {
 
     override fun discover(email: String): DiscoveryResults? {
-        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)) {
+        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)?.toDomain()) {
             "Couldn't extract domain from email address: $email"
         }
 

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigDiscovery.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigDiscovery.kt
@@ -1,7 +1,7 @@
 package app.k9mail.autodiscovery.autoconfig
 
-import app.k9mail.autodiscovery.api.ConnectionSettingsDiscovery
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.toDomain
 import com.fsck.k9.helper.EmailHelper
 
@@ -9,10 +9,10 @@ class AutoconfigDiscovery(
     private val urlProvider: AutoconfigUrlProvider,
     private val fetcher: AutoconfigFetcher,
     private val parser: AutoconfigParser,
-) : ConnectionSettingsDiscovery {
+) {
 
-    override fun discover(email: String): DiscoveryResults? {
-        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)?.toDomain()) {
+    fun discover(email: EmailAddress): DiscoveryResults? {
+        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email.address)?.toDomain()) {
             "Couldn't extract domain from email address: $email"
         }
 

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParser.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParser.kt
@@ -2,8 +2,8 @@ package app.k9mail.autodiscovery.autoconfig
 
 import app.k9mail.autodiscovery.api.DiscoveredServerSettings
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.net.HostNameUtils
 import com.fsck.k9.helper.EmailHelper
-import com.fsck.k9.helper.HostNameUtils
 import com.fsck.k9.logging.Timber
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParser.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParser.kt
@@ -2,6 +2,7 @@ package app.k9mail.autodiscovery.autoconfig
 
 import app.k9mail.autodiscovery.api.DiscoveredServerSettings
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.HostNameUtils
 import com.fsck.k9.helper.EmailHelper
 import com.fsck.k9.logging.Timber
@@ -19,9 +20,9 @@ import org.xmlpull.v1.XmlPullParserFactory
  * See [https://github.com/thundernest/autoconfig](https://github.com/thundernest/autoconfig)
  */
 class AutoconfigParser {
-    fun parseSettings(stream: InputStream, email: String): DiscoveryResults {
+    fun parseSettings(stream: InputStream, email: EmailAddress): DiscoveryResults {
         return try {
-            ClientConfigParser(stream, email).parse()
+            ClientConfigParser(stream, email.address).parse()
         } catch (e: XmlPullParserException) {
             throw AutoconfigParserException("Error parsing Autoconfig XML", e)
         }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
@@ -1,8 +1,9 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 
 interface AutoconfigUrlProvider {
-    fun getAutoconfigUrls(domain: Domain, email: String? = null): List<HttpUrl>
+    fun getAutoconfigUrls(domain: Domain, email: EmailAddress? = null): List<HttpUrl>
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
@@ -1,7 +1,8 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 
 interface AutoconfigUrlProvider {
-    fun getAutoconfigUrls(domain: String, email: String? = null): List<HttpUrl>
+    fun getAutoconfigUrls(domain: Domain, email: String? = null): List<HttpUrl>
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/BaseDomainExtractor.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/BaseDomainExtractor.kt
@@ -1,10 +1,12 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+
 /**
  * Extract the base domain from a host name.
  *
  * An implementation needs to respect the [Public Suffix List](https://publicsuffix.org/).
  */
 interface BaseDomainExtractor {
-    fun extractBaseDomain(domain: String): String
+    fun extractBaseDomain(domain: Domain): Domain
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
@@ -1,18 +1,19 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 class IspDbAutoconfigUrlProvider : AutoconfigUrlProvider {
-    override fun getAutoconfigUrls(domain: String, email: String?): List<HttpUrl> {
+    override fun getAutoconfigUrls(domain: Domain, email: String?): List<HttpUrl> {
         return listOf(createIspDbUrl(domain))
     }
 
-    private fun createIspDbUrl(domain: String): HttpUrl {
+    private fun createIspDbUrl(domain: Domain): HttpUrl {
         // https://autoconfig.thunderbird.net/v1.1/{domain}
         return "https://autoconfig.thunderbird.net/v1.1/".toHttpUrl()
             .newBuilder()
-            .addPathSegment(domain)
+            .addPathSegment(domain.value)
             .build()
     }
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
@@ -1,11 +1,12 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 class IspDbAutoconfigUrlProvider : AutoconfigUrlProvider {
-    override fun getAutoconfigUrls(domain: Domain, email: String?): List<HttpUrl> {
+    override fun getAutoconfigUrls(domain: Domain, email: EmailAddress?): List<HttpUrl> {
         return listOf(createIspDbUrl(domain))
     }
 

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MiniDnsMxResolver.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MiniDnsMxResolver.kt
@@ -1,13 +1,15 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+import app.k9mail.core.common.net.toDomain
 import org.minidns.hla.ResolverApi
 import org.minidns.record.MX
 
 class MiniDnsMxResolver : MxResolver {
-    override fun lookup(domain: String): List<String> {
-        val result = ResolverApi.INSTANCE.resolve(domain, MX::class.java)
+    override fun lookup(domain: Domain): List<Domain> {
+        val result = ResolverApi.INSTANCE.resolve(domain.value, MX::class.java)
         return result.answersOrEmptySet
             .sortedBy { it.priority }
-            .map { it.target.toString() }
+            .map { it.target.toString().toDomain() }
     }
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
@@ -1,7 +1,7 @@
 package app.k9mail.autodiscovery.autoconfig
 
-import app.k9mail.autodiscovery.api.ConnectionSettingsDiscovery
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Domain
 import app.k9mail.core.common.net.toDomain
 import com.fsck.k9.helper.EmailHelper
@@ -13,12 +13,12 @@ class MxLookupAutoconfigDiscovery(
     private val urlProvider: AutoconfigUrlProvider,
     private val fetcher: AutoconfigFetcher,
     private val parser: AutoconfigParser,
-) : ConnectionSettingsDiscovery {
+) {
 
     @Suppress("ReturnCount")
-    override fun discover(email: String): DiscoveryResults? {
-        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)?.toDomain()) {
-            "Couldn't extract domain from email address: $email"
+    fun discover(email: EmailAddress): DiscoveryResults? {
+        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email.address)?.toDomain()) {
+            "Couldn't extract domain from email address: ${email.address}"
         }
 
         val mxHostName = mxLookup(domain) ?: return null

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
@@ -2,6 +2,8 @@ package app.k9mail.autodiscovery.autoconfig
 
 import app.k9mail.autodiscovery.api.ConnectionSettingsDiscovery
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.net.Domain
+import app.k9mail.core.common.net.toDomain
 import com.fsck.k9.helper.EmailHelper
 
 class MxLookupAutoconfigDiscovery(
@@ -15,7 +17,7 @@ class MxLookupAutoconfigDiscovery(
 
     @Suppress("ReturnCount")
     override fun discover(email: String): DiscoveryResults? {
-        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)) {
+        val domain = requireNotNull(EmailHelper.getDomainFromEmailAddress(email)?.toDomain()) {
             "Couldn't extract domain from email address: $email"
         }
 
@@ -42,16 +44,16 @@ class MxLookupAutoconfigDiscovery(
             .firstOrNull()
     }
 
-    private fun mxLookup(domain: String): String? {
+    private fun mxLookup(domain: Domain): Domain? {
         // Only return the most preferred entry to match Thunderbird's behavior.
         return mxResolver.lookup(domain).firstOrNull()
     }
 
-    private fun getMxBaseDomain(mxHostName: String): String {
+    private fun getMxBaseDomain(mxHostName: Domain): Domain {
         return baseDomainExtractor.extractBaseDomain(mxHostName)
     }
 
-    private fun getNextSubDomain(domain: String): String? {
+    private fun getNextSubDomain(domain: Domain): Domain? {
         return subDomainExtractor.extractSubDomain(domain)
     }
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxResolver.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxResolver.kt
@@ -1,8 +1,10 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+
 /**
  * Look up MX records for a domain.
  */
 interface MxResolver {
-    fun lookup(domain: String): List<String>
+    fun lookup(domain: Domain): List<Domain>
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/OkHttpBaseDomainExtractor.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/OkHttpBaseDomainExtractor.kt
@@ -1,10 +1,12 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+import app.k9mail.core.common.net.toDomain
 import okhttp3.HttpUrl
 
 class OkHttpBaseDomainExtractor : BaseDomainExtractor {
-    override fun extractBaseDomain(domain: String): String {
-        return domain.toHttpUrlOrNull().topPrivateDomain() ?: domain
+    override fun extractBaseDomain(domain: Domain): Domain {
+        return domain.value.toHttpUrlOrNull().topPrivateDomain()?.toDomain() ?: domain
     }
 
     private fun String.toHttpUrlOrNull(): HttpUrl {

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
@@ -1,10 +1,11 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 
 class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : AutoconfigUrlProvider {
-    override fun getAutoconfigUrls(domain: Domain, email: String?): List<HttpUrl> {
+    override fun getAutoconfigUrls(domain: Domain, email: EmailAddress?): List<HttpUrl> {
         return buildList {
             add(createProviderUrl(domain, email, useHttps = true))
             add(createDomainUrl(domain, email, useHttps = true))
@@ -16,7 +17,7 @@ class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : A
         }
     }
 
-    private fun createProviderUrl(domain: Domain, email: String?, useHttps: Boolean): HttpUrl {
+    private fun createProviderUrl(domain: Domain, email: EmailAddress?, useHttps: Boolean): HttpUrl {
         // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
         // http://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
@@ -25,13 +26,13 @@ class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : A
             .addEncodedPathSegments("mail/config-v1.1.xml")
             .apply {
                 if (email != null && config.includeEmailAddress) {
-                    addQueryParameter("emailaddress", email)
+                    addQueryParameter("emailaddress", email.address)
                 }
             }
             .build()
     }
 
-    private fun createDomainUrl(domain: Domain, email: String?, useHttps: Boolean): HttpUrl {
+    private fun createDomainUrl(domain: Domain, email: EmailAddress?, useHttps: Boolean): HttpUrl {
         // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
         // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
@@ -40,7 +41,7 @@ class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : A
             .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
             .apply {
                 if (email != null && config.includeEmailAddress) {
-                    addQueryParameter("emailaddress", email)
+                    addQueryParameter("emailaddress", email.address)
                 }
             }
             .build()

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
@@ -1,9 +1,10 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
 import okhttp3.HttpUrl
 
 class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : AutoconfigUrlProvider {
-    override fun getAutoconfigUrls(domain: String, email: String?): List<HttpUrl> {
+    override fun getAutoconfigUrls(domain: Domain, email: String?): List<HttpUrl> {
         return buildList {
             add(createProviderUrl(domain, email, useHttps = true))
             add(createDomainUrl(domain, email, useHttps = true))
@@ -15,12 +16,12 @@ class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : A
         }
     }
 
-    private fun createProviderUrl(domain: String, email: String?, useHttps: Boolean): HttpUrl {
+    private fun createProviderUrl(domain: Domain, email: String?, useHttps: Boolean): HttpUrl {
         // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
         // http://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
             .scheme(if (useHttps) "https" else "http")
-            .host("autoconfig.$domain")
+            .host("autoconfig.${domain.value}")
             .addEncodedPathSegments("mail/config-v1.1.xml")
             .apply {
                 if (email != null && config.includeEmailAddress) {
@@ -30,12 +31,12 @@ class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : A
             .build()
     }
 
-    private fun createDomainUrl(domain: String, email: String?, useHttps: Boolean): HttpUrl {
+    private fun createDomainUrl(domain: Domain, email: String?, useHttps: Boolean): HttpUrl {
         // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
         // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
             .scheme(if (useHttps) "https" else "http")
-            .host(domain)
+            .host(domain.value)
             .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
             .apply {
                 if (email != null && config.includeEmailAddress) {

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealSubDomainExtractor.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealSubDomainExtractor.kt
@@ -1,15 +1,19 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+import app.k9mail.core.common.net.toDomain
+
 class RealSubDomainExtractor(private val baseDomainExtractor: BaseDomainExtractor) : SubDomainExtractor {
     @Suppress("ReturnCount")
-    override fun extractSubDomain(domain: String): String? {
+    override fun extractSubDomain(domain: Domain): Domain? {
         val baseDomain = baseDomainExtractor.extractBaseDomain(domain)
         if (baseDomain == domain) {
             // The domain doesn't have a sub domain.
             return null
         }
 
-        val domainPrefix = domain.removeSuffix(".$baseDomain")
+        val baseDomainString = baseDomain.value
+        val domainPrefix = domain.value.removeSuffix(".$baseDomainString")
         val index = domainPrefix.indexOf('.')
         if (index == -1) {
             // The prefix is the sub domain. When we remove it only the base domain remains.
@@ -17,6 +21,6 @@ class RealSubDomainExtractor(private val baseDomainExtractor: BaseDomainExtracto
         }
 
         val prefixWithoutFirstLabel = domainPrefix.substring(index + 1)
-        return "$prefixWithoutFirstLabel.$baseDomain"
+        return "$prefixWithoutFirstLabel.$baseDomainString".toDomain()
     }
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/SubDomainExtractor.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/SubDomainExtractor.kt
@@ -1,10 +1,12 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+
 /**
  * Extract the sub domain from a host name.
  *
  * An implementation needs to respect the [Public Suffix List](https://publicsuffix.org/).
  */
 interface SubDomainExtractor {
-    fun extractSubDomain(domain: String): String?
+    fun extractSubDomain(domain: Domain): Domain?
 }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParserTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParserTest.kt
@@ -2,6 +2,7 @@ package app.k9mail.autodiscovery.autoconfig
 
 import app.k9mail.autodiscovery.api.DiscoveredServerSettings
 import app.k9mail.autodiscovery.api.DiscoveryResults
+import app.k9mail.core.common.mail.toEmailAddress
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
@@ -50,11 +51,13 @@ class AutoconfigParserTest {
         </clientConfig>
         """.trimIndent()
 
+    private val irrelevantEmailAddress = "irrelevant@domain.example".toEmailAddress()
+
     @Test
     fun `minimal data`() {
         val inputStream = minimalConfig.byteInputStream()
 
-        val result = parser.parseSettings(inputStream, email = "user@domain.example")
+        val result = parser.parseSettings(inputStream, email = "user@domain.example".toEmailAddress())
 
         assertThat(result).isNotNull().all {
             prop(DiscoveryResults::incoming).containsExactly(
@@ -84,7 +87,7 @@ class AutoconfigParserTest {
     fun `real-world data`() {
         val inputStream = javaClass.getResourceAsStream("/2022-11-19-googlemail.com.xml")!!
 
-        val result = parser.parseSettings(inputStream, email = "test@gmail.com")
+        val result = parser.parseSettings(inputStream, email = "test@gmail.com".toEmailAddress())
 
         assertThat(result).isNotNull().all {
             prop(DiscoveryResults::incoming).containsExactly(
@@ -118,7 +121,7 @@ class AutoconfigParserTest {
             element("outgoingServer > username").text("%EMAILDOMAIN%")
         }
 
-        val result = parser.parseSettings(inputStream, email = "user@domain.example")
+        val result = parser.parseSettings(inputStream, email = "user@domain.example".toEmailAddress())
 
         assertThat(result).isNotNull().all {
             prop(DiscoveryResults::incoming).containsExactly(
@@ -154,7 +157,7 @@ class AutoconfigParserTest {
             element("incomingServer > username").prepend("<!-- comment -->")
         }
 
-        val result = parser.parseSettings(inputStream, email = "user@domain.example")
+        val result = parser.parseSettings(inputStream, email = "user@domain.example".toEmailAddress())
 
         assertThat(result.incoming).containsExactly(
             DiscoveredServerSettings(
@@ -174,7 +177,7 @@ class AutoconfigParserTest {
             element("incomingServer > authentication").insertBefore("<authentication></authentication>")
         }
 
-        val result = parser.parseSettings(inputStream, email = "user@domain.example")
+        val result = parser.parseSettings(inputStream, email = "user@domain.example".toEmailAddress())
 
         assertThat(result.incoming).containsExactly(
             DiscoveredServerSettings(
@@ -195,7 +198,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'emailProvider.id' attribute")
     }
@@ -207,7 +210,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Invalid 'emailProvider.id' attribute")
     }
@@ -219,7 +222,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Valid 'domain' element required")
     }
@@ -231,7 +234,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Valid 'domain' element required")
     }
@@ -243,7 +246,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'incomingServer' element")
     }
@@ -255,7 +258,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'outgoingServer' element")
     }
@@ -267,7 +270,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'hostname' element")
     }
@@ -279,7 +282,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Invalid 'hostname' value: 'in valid'")
     }
@@ -291,7 +294,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'port' element")
     }
@@ -303,7 +306,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'socketType' element")
     }
@@ -315,7 +318,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("No usable 'authentication' element found")
     }
@@ -327,7 +330,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'username' element")
     }
@@ -339,7 +342,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Invalid 'port' value: 'invalid'")
     }
@@ -351,7 +354,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Invalid 'port' value: '100000'")
     }
@@ -363,7 +366,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Unknown 'socketType' value: 'TLS'")
     }
@@ -375,7 +378,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Expected text, but got START_TAG")
     }
@@ -387,7 +390,7 @@ class AutoconfigParserTest {
         }
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "user@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'emailProvider' element")
     }
@@ -397,7 +400,7 @@ class AutoconfigParserTest {
         val inputStream = "invalid".byteInputStream()
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "irrelevant@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Error parsing Autoconfig XML")
     }
@@ -412,7 +415,7 @@ class AutoconfigParserTest {
             """.trimIndent().byteInputStream()
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "irrelevant@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Missing 'clientConfig' element")
     }
@@ -444,7 +447,7 @@ class AutoconfigParserTest {
             """.trimIndent().byteInputStream()
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "irrelevant@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("Error parsing Autoconfig XML")
     }
@@ -460,7 +463,7 @@ class AutoconfigParserTest {
             """.trimIndent().byteInputStream()
 
         assertFailure {
-            parser.parseSettings(inputStream, email = "irrelevant@domain.example")
+            parser.parseSettings(inputStream, irrelevantEmailAddress)
         }.isInstanceOf<AutoconfigParserException>()
             .hasMessage("End of document reached while reading element 'emailProvider'")
     }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProviderTest.kt
@@ -1,7 +1,9 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.toDomain
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.extracting
 import org.junit.Test
 
 class IspDbAutoconfigUrlProviderTest {
@@ -9,9 +11,11 @@ class IspDbAutoconfigUrlProviderTest {
 
     @Test
     fun `getAutoconfigUrls with ASCII email address`() {
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example")
+        val domain = "domain.example".toDomain()
 
-        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain)
+
+        assertThat(autoconfigUrls).extracting { it.toString() }.containsExactly(
             "https://autoconfig.thunderbird.net/v1.1/domain.example",
         )
     }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/MiniDnsMxResolverTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/MiniDnsMxResolverTest.kt
@@ -1,8 +1,10 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.toDomain
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
 import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import kotlin.test.Ignore
@@ -14,9 +16,11 @@ class MiniDnsMxResolverTest {
     @Test
     @Ignore("Requires internet")
     fun `MX lookup for known domain`() {
-        val result = resolver.lookup("thunderbird.net")
+        val domain = "thunderbird.net".toDomain()
 
-        assertThat(result).all {
+        val result = resolver.lookup(domain)
+
+        assertThat(result).extracting { it.value }.all {
             index(0).isEqualTo("aspmx.l.google.com")
             containsExactlyInAnyOrder(
                 "aspmx.l.google.com",

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/OkHttpBaseDomainExtractorTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/OkHttpBaseDomainExtractorTest.kt
@@ -1,5 +1,6 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.toDomain
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import org.junit.Test
@@ -9,21 +10,37 @@ class OkHttpBaseDomainExtractorTest {
 
     @Test
     fun `basic domain`() {
-        assertThat(baseDomainExtractor.extractBaseDomain("domain.example")).isEqualTo("domain.example")
+        val domain = "domain.example".toDomain()
+
+        val result = baseDomainExtractor.extractBaseDomain(domain)
+
+        assertThat(result).isEqualTo(domain)
     }
 
     @Test
     fun `basic subdomain`() {
-        assertThat(baseDomainExtractor.extractBaseDomain("subdomain.domain.example")).isEqualTo("domain.example")
+        val domain = "subdomain.domain.example".toDomain()
+
+        val result = baseDomainExtractor.extractBaseDomain(domain)
+
+        assertThat(result).isEqualTo("domain.example".toDomain())
     }
 
     @Test
     fun `domain with public suffix`() {
-        assertThat(baseDomainExtractor.extractBaseDomain("example.co.uk")).isEqualTo("example.co.uk")
+        val domain = "example.co.uk".toDomain()
+
+        val result = baseDomainExtractor.extractBaseDomain(domain)
+
+        assertThat(result).isEqualTo(domain)
     }
 
     @Test
     fun `subdomain with public suffix`() {
-        assertThat(baseDomainExtractor.extractBaseDomain("subdomain.example.co.uk")).isEqualTo("example.co.uk")
+        val domain = "subdomain.example.co.uk".toDomain()
+
+        val result = baseDomainExtractor.extractBaseDomain(domain)
+
+        assertThat(result).isEqualTo("example.co.uk".toDomain())
     }
 }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
@@ -1,17 +1,21 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.toDomain
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import org.junit.Test
 
 class ProviderAutoconfigUrlProviderTest {
+    private val domain = "domain.example".toDomain()
+    private val email = "test@domain.example"
+
     @Test
     fun `getAutoconfigUrls with http allowed and email address included`() {
         val urlProvider = ProviderAutoconfigUrlProvider(
             AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = true),
         )
 
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example", email = "test@domain.example")
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, email)
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
@@ -27,7 +31,7 @@ class ProviderAutoconfigUrlProviderTest {
             AutoconfigUrlConfig(httpsOnly = true, includeEmailAddress = true),
         )
 
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example", email = "test@domain.example")
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, email)
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
@@ -41,7 +45,7 @@ class ProviderAutoconfigUrlProviderTest {
             AutoconfigUrlConfig(httpsOnly = true, includeEmailAddress = false),
         )
 
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example", email = "test@domain.example")
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, email)
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml",
@@ -55,7 +59,7 @@ class ProviderAutoconfigUrlProviderTest {
             AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = false),
         )
 
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example", email = "test@domain.example")
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, email)
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml",
@@ -71,7 +75,7 @@ class ProviderAutoconfigUrlProviderTest {
             AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = true),
         )
 
-        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain = "domain.example")
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain)
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml",

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
@@ -1,5 +1,6 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.mail.toEmailAddress
 import app.k9mail.core.common.net.toDomain
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -7,7 +8,7 @@ import org.junit.Test
 
 class ProviderAutoconfigUrlProviderTest {
     private val domain = "domain.example".toDomain()
-    private val email = "test@domain.example"
+    private val email = "test@domain.example".toEmailAddress()
 
     @Test
     fun `getAutoconfigUrls with http allowed and email address included`() {

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/RealSubDomainExtractorTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/RealSubDomainExtractorTest.kt
@@ -1,5 +1,7 @@
 package app.k9mail.autodiscovery.autoconfig
 
+import app.k9mail.core.common.net.Domain
+import app.k9mail.core.common.net.toDomain
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
@@ -11,71 +13,83 @@ class RealSubDomainExtractorTest {
 
     @Test
     fun `input has one more label than the base domain`() {
-        val result = baseSubDomainExtractor.extractSubDomain("subdomain.domain.example")
+        val domain = "subdomain.domain.example".toDomain()
 
-        assertThat(result).isEqualTo("domain.example")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
+
+        assertThat(result).isEqualTo("domain.example".toDomain())
     }
 
     @Test
     fun `input has two more labels than the base domain`() {
-        val result = baseSubDomainExtractor.extractSubDomain("more.subdomain.domain.example")
+        val domain = "more.subdomain.domain.example".toDomain()
 
-        assertThat(result).isEqualTo("subdomain.domain.example")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
+
+        assertThat(result).isEqualTo("subdomain.domain.example".toDomain())
     }
 
     @Test
     fun `input has three more labels than the base domain`() {
-        val result = baseSubDomainExtractor.extractSubDomain("three.two.one.domain.example")
+        val domain = "three.two.one.domain.example".toDomain()
 
-        assertThat(result).isEqualTo("two.one.domain.example")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
+
+        assertThat(result).isEqualTo("two.one.domain.example".toDomain())
     }
 
     @Test
     fun `no sub domain available`() {
-        val result = baseSubDomainExtractor.extractSubDomain("domain.example")
+        val domain = "domain.example".toDomain()
+
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `input has one more label than the base domain with public suffix`() {
+        val domain = "subdomain.example.co.uk".toDomain()
         testBaseDomainExtractor.baseDomain = "example.co.uk"
 
-        val result = baseSubDomainExtractor.extractSubDomain("subdomain.example.co.uk")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
 
-        assertThat(result).isEqualTo("example.co.uk")
+        assertThat(result).isEqualTo("example.co.uk".toDomain())
     }
 
     @Test
     fun `input has two more labels than the base domain with public suffix`() {
+        val domain = "more.subdomain.example.co.uk".toDomain()
         testBaseDomainExtractor.baseDomain = "example.co.uk"
 
-        val result = baseSubDomainExtractor.extractSubDomain("more.subdomain.example.co.uk")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
 
-        assertThat(result).isEqualTo("subdomain.example.co.uk")
+        assertThat(result).isEqualTo("subdomain.example.co.uk".toDomain())
     }
 
     @Test
     fun `input has three more labels than the base domain with public suffix`() {
+        val domain = "three.two.one.example.co.uk".toDomain()
         testBaseDomainExtractor.baseDomain = "example.co.uk"
 
-        val result = baseSubDomainExtractor.extractSubDomain("three.two.one.example.co.uk")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
 
-        assertThat(result).isEqualTo("two.one.example.co.uk")
+        assertThat(result).isEqualTo("two.one.example.co.uk".toDomain())
     }
 
     @Test
     fun `no sub domain available with public suffix`() {
+        val domain = "example.co.uk".toDomain()
         testBaseDomainExtractor.baseDomain = "example.co.uk"
 
-        val result = baseSubDomainExtractor.extractSubDomain("example.co.uk")
+        val result = baseSubDomainExtractor.extractSubDomain(domain)
 
         assertThat(result).isNull()
     }
 }
 
 private class TestBaseDomainExtractor(var baseDomain: String) : BaseDomainExtractor {
-    override fun extractBaseDomain(domain: String): String {
-        return baseDomain
+    override fun extractBaseDomain(domain: Domain): Domain {
+        return Domain(baseDomain)
     }
 }


### PR DESCRIPTION
I'm tired of getting the order of consecutive `String` arguments wrong.

Needs to be rebased/updated once #6907 is merged.