### PR TITLE
Fix "Cannot connect to crypto provider" when trying to send a mail with PGP enabled and K9 was started from contacts app

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -741,8 +741,6 @@ class RecipientPresenter(
         }
     }
 
-
-
     private fun Array<String>.toAddressArray(): Array<Address> {
         return flatMap { addressString ->
             Address.parseUnencoded(addressString).toList()


### PR DESCRIPTION
`openPgpCallback` was null when `onSwitchAccount()` is called in `init {}`. This change simply moves the declaration of `openPgpCallback` before `init {}` and now the issue is gone as the OpenPgpProvider initialization now completes and can execute the callback.

Fixes #6068