### PR TITLE
Add `Icon` and `ButtonIcon` atoms and `Icons` to the theme

### DIFF
--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/items/IconItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/items/IconItems.kt
@@ -16,14 +16,27 @@ import app.k9mail.core.ui.compose.theme.Icons
 import app.k9mail.core.ui.compose.theme.MainTheme
 
 fun LazyGridScope.iconItems() {
-    sectionHeaderItem(text = "Icons")
-    item {
-        IconItem(
-            name = "Error",
-            imageVector = Icons.error,
-        )
+    sectionHeaderItem(text = "Filled")
+    getIconsFor(Icons.Filled)
+    sectionHeaderItem(text = "Outlined")
+    getIconsFor(Icons.Outlined)
+}
+
+@Suppress("UnusedPrivateMember")
+private inline fun <reified T> LazyGridScope.getIconsFor(icons: T) {
+    for (field in T::class.java.declaredFields) {
+        if (field.name in exclusions) continue
+        item {
+            field.isAccessible = true
+            IconItem(
+                name = field.name.replaceFirstChar { it.uppercase() },
+                imageVector = field.get(Icons.Filled) as ImageVector,
+            )
+        }
     }
 }
+
+private val exclusions = listOf("\$stable", "INSTANCE")
 
 @Composable
 private fun IconItem(

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Icon.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Icon.kt
@@ -30,7 +30,7 @@ fun Icon(
 internal fun IconPreview() {
     PreviewWithThemes {
         Icon(
-            imageVector = Icons.error,
+            imageVector = Icons.Filled.error,
         )
     }
 }
@@ -40,7 +40,7 @@ internal fun IconPreview() {
 internal fun IconTintedPreview() {
     PreviewWithThemes {
         Icon(
-            imageVector = Icons.error,
+            imageVector = Icons.Filled.error,
             tint = Color.Magenta,
         )
     }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonIcon.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonIcon.kt
@@ -1,0 +1,41 @@
+package app.k9mail.core.ui.compose.designsystem.atom.button
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.theme.Icons
+import app.k9mail.core.ui.compose.theme.MainTheme
+import androidx.compose.material.IconButton as MaterialIconButton
+
+@Composable
+fun ButtonIcon(
+    onClick: () -> Unit,
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentDescription: String? = null,
+) {
+    MaterialIconButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+    ) {
+        Icon(
+            modifier = Modifier.size(MainTheme.sizes.icon),
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ButtonIconPreview() {
+    ButtonIcon(
+        onClick = { },
+        imageVector = Icons.Filled.user,
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPassword.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPassword.kt
@@ -61,9 +61,9 @@ private fun selectTrailingIcon(
     return if (hasTrailingIcon) {
         {
             val image = if (isShowPasswordAllowed(isEnabled, isPasswordVisible)) {
-                Icons.passwordVisibility
+                Icons.Filled.passwordVisibility
             } else {
-                Icons.passwordVisibilityOff
+                Icons.Filled.passwordVisibilityOff
             }
 
             val description = if (isShowPasswordAllowed(isEnabled, isPasswordVisible)) {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/ErrorView.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/ErrorView.kt
@@ -39,7 +39,7 @@ fun ErrorView(
         verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
     ) {
         Icon(
-            imageVector = Icons.error,
+            imageVector = Icons.Filled.error,
             contentDescription = null,
             tint = MainTheme.colors.error,
             modifier = Modifier.padding(top = MainTheme.spacings.default),

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Icons.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Icons.kt
@@ -1,12 +1,44 @@
 package app.k9mail.core.ui.compose.theme
 
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Outbox
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Error
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.Icons as MaterialIcons
 
 object Icons {
-    val error = MaterialIcons.Filled.Error
-    val passwordVisibility = MaterialIcons.Filled.Visibility
-    val passwordVisibilityOff = MaterialIcons.Filled.VisibilityOff
+    object Filled {
+        val error = MaterialIcons.Filled.Error
+        val inbox = MaterialIcons.Filled.Inbox
+        val notification = MaterialIcons.Filled.Notifications
+        val outbox = MaterialIcons.Filled.Outbox
+        val passwordVisibility = MaterialIcons.Filled.Visibility
+        val passwordVisibilityOff = MaterialIcons.Filled.VisibilityOff
+        val user = MaterialIcons.Filled.AccountCircle
+    }
+
+    object Outlined {
+        val arrowBack = MaterialIcons.Outlined.ArrowBack
+        val arrowDropDown = MaterialIcons.Outlined.ArrowDropDown
+        val arrowDropUp = MaterialIcons.Outlined.ArrowDropUp
+        val menu = MaterialIcons.Outlined.Menu
+        val check = MaterialIcons.Outlined.Check
+        val error = MaterialIcons.Outlined.ErrorOutline
+        val expandMore = MaterialIcons.Outlined.ExpandMore
+        val expandLess = MaterialIcons.Outlined.ExpandLess
+    }
 }

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Sizes.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Sizes.kt
@@ -14,6 +14,8 @@ data class Sizes(
     val larger: Dp = 128.dp,
     val huge: Dp = 256.dp,
     val huger: Dp = 384.dp,
+
+    val icon: Dp = 24.dp,
 )
 
 internal val LocalSizes = staticCompositionLocalOf { Sizes() }


### PR DESCRIPTION
This adds `Icon` and `ButtonIcon` atoms to the design system accompanied by a selection of Material icons made available as `Icons` in the theme.
