### PR TITLE
Change catalog and feature app to use new insets api

### DIFF
--- a/app-feature-preview/src/main/AndroidManifest.xml
+++ b/app-feature-preview/src/main/AndroidManifest.xml
@@ -2,23 +2,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".FeatureApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Thunderbird.Splashscreen"
-        android:name=".FeatureApplication"
         >
 
         <activity
             android:name=".FeatureActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/ui/FeatureApp.kt
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/ui/FeatureApp.kt
@@ -1,10 +1,7 @@
 package app.k9mail.feature.preview.ui
 
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
@@ -19,12 +16,10 @@ fun FeatureApp(
     val navController = rememberNavController()
 
     K9Theme {
-        val contentPadding = WindowInsets.systemBars.asPaddingValues()
-
         Background(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(contentPadding)
+                .systemBarsPadding()
                 .then(modifier),
         ) {
             FeatureNavHost(navController = navController)

--- a/app-feature-preview/src/main/res/values/themes.xml
+++ b/app-feature-preview/src/main/res/values/themes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Thunderbird" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+    <style name="Theme.Thunderbird" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 
     <style name="Theme.Thunderbird.Splashscreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>

--- a/app-ui-catalog/src/main/AndroidManifest.xml
+++ b/app-ui-catalog/src/main/AndroidManifest.xml
@@ -2,24 +2,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".CatalogApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Thunderbird.Splashscreen"
-        android:name=".CatalogApplication"
         >
 
         <activity
             android:name=".CatalogActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        
+
     </application>
 
 </manifest>

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/CatalogActivity.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/CatalogActivity.kt
@@ -13,7 +13,7 @@ class CatalogActivity : ComponentActivity() {
 
         super.onCreate(savedInstanceState)
 
-        WindowCompat.setDecorFitsSystemWindows(window, true)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             CatalogScreen()

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/CatalogContent.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/CatalogContent.kt
@@ -1,9 +1,5 @@
 package app.k9mail.ui.catalog.ui
 
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
@@ -24,12 +20,9 @@ fun CatalogContent(
     modifier: Modifier = Modifier,
 ) {
     val navController = rememberNavController()
-    val contentPadding = WindowInsets.systemBars.asPaddingValues()
 
     Scaffold(
-        modifier = Modifier
-            .padding(top = contentPadding.calculateTopPadding())
-            .then(modifier),
+        modifier = modifier,
         topBar = { toggleDrawer ->
             ThemeTopAppBar(
                 onNavigationClick = toggleDrawer,

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/CatalogScreen.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/CatalogScreen.kt
@@ -1,5 +1,6 @@
 package app.k9mail.ui.catalog.ui
 
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.common.mvi.observe
@@ -24,7 +25,9 @@ fun CatalogScreen(
             state = state.value,
             onThemeChanged = { dispatch(OnThemeChanged) },
             onThemeVariantChanged = { dispatch(OnThemeVariantChanged) },
-            modifier = modifier,
+            modifier = Modifier
+                .systemBarsPadding()
+                .then(modifier),
         )
     }
 }

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/common/PagedContent.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/common/PagedContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -61,7 +62,8 @@ fun <T> PagedContent(
             ) { page ->
                 LazyVerticalGrid(
                     columns = GridCells.Adaptive(300.dp),
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize()
+                        .imePadding(),
                     horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
                     verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
                 ) {

--- a/app-ui-catalog/src/main/res/values/themes.xml
+++ b/app-ui-catalog/src/main/res/values/themes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Thunderbird" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+    <style name="Theme.Thunderbird" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 
     <style name="Theme.Thunderbird.Splashscreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>


### PR DESCRIPTION
With Compose 1.2 window insets could be handled by using modifiers. This changes the setup of the Catalog and Feature apps to use these. See [WindowInsets and IME Animations](https://developer.android.com/jetpack/compose/migrate/other-considerations#ime-animations)

This also removes the TopAppBar flickering when used with a Scaffold on my Samsung device.