### PR TITLE
Add account setup options UI

### DIFF
--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/UseCase.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/UseCase.kt
@@ -1,0 +1,5 @@
+package app.k9mail.core.common.domain.usecase
+
+interface UseCase<T, R> {
+    fun execute(input: T): R
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationResult.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationResult.kt
@@ -1,0 +1,7 @@
+package app.k9mail.core.common.domain.usecase.validation
+
+interface ValidationResult {
+    object Success : ValidationResult
+
+    data class Failure(val error: Exception) : ValidationResult
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationUseCase.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationUseCase.kt
@@ -1,0 +1,5 @@
+package app.k9mail.core.common.domain.usecase.validation
+
+import app.k9mail.core.common.domain.usecase.UseCase
+
+interface ValidationUseCase<T> : UseCase<T, ValidationResult>

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(libs.assertk)
+    implementation(libs.turbine)
 }

--- a/core/testing/src/main/kotlin/assertk/assertions/TurbineExtensions.kt
+++ b/core/testing/src/main/kotlin/assertk/assertions/TurbineExtensions.kt
@@ -1,0 +1,34 @@
+package assertk.assertions
+
+import app.cash.turbine.ReceiveTurbine
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+
+/**
+ * The `assertThatAndTurbinesConsumed` function ensures that the assertion passed and
+ * all events in the given turbines have been consumed.
+ *
+ * Usage:
+ *  val actualValue: T = getActualValue()
+ *  val turbines: List<ReceiveTurbine<*>> = getTurbines()
+ *  assertThatAndEnsureAllEventsConsumed(actualValue, turbines) {
+ *      // your assertion here
+ *  }
+ *
+ * @param T The type of the actual value.
+ * @param actual The actual value being asserted.
+ * @param turbines The list of ReceiveTurbine instances to check if all events are consumed.
+ * @param assertion An extension function on `Assert<T>`, which is used to define assertions on the actual value.
+ */
+fun <T> assertThatAndTurbinesConsumed(
+    actual: T,
+    turbines: List<ReceiveTurbine<*>>,
+    assertion: Assert<T>.() -> Unit,
+) {
+    assertThat(actual).all {
+        assertion()
+    }
+
+    turbines.forEach { it.ensureAllEventsConsumed() }
+}

--- a/core/ui/compose/testing/build.gradle.kts
+++ b/core/ui/compose/testing/build.gradle.kts
@@ -7,6 +7,8 @@ android {
 }
 
 dependencies {
+    api(projects.core.testing)
+
     implementation(projects.core.ui.compose.theme)
     implementation(libs.androidx.compose.material)
 

--- a/feature/account/setup/build.gradle.kts
+++ b/feature/account/setup/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.core.common)
 
     testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -1,10 +1,12 @@
 package app.k9mail.feature.account.setup
 
 import app.k9mail.feature.account.setup.ui.AccountSetupViewModel
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val featureAccountSetupModule: Module = module {
     viewModel { AccountSetupViewModel() }
+    viewModel { AccountOptionsViewModel() }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/entity/EmailCheckFrequency.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/entity/EmailCheckFrequency.kt
@@ -1,0 +1,29 @@
+package app.k9mail.feature.account.setup.domain.entity
+
+import kotlinx.collections.immutable.toImmutableList
+
+@Suppress("MagicNumber")
+enum class EmailCheckFrequency(
+    val minutes: Int,
+) {
+    MANUAL(-1),
+    EVERY_15_MINUTES(15),
+    EVERY_30_MINUTES(30),
+    EVERY_HOUR(1.fromHour()),
+    EVERY_2_HOURS(2.fromHour()),
+    EVERY_3_HOURS(3.fromHour()),
+    EVERY_6_HOURS(6.fromHour()),
+    EVERY_12_HOURS(12.fromHour()),
+    EVERY_24_HOURS(24.fromHour()),
+    ;
+
+    companion object {
+        val DEFAULT = EVERY_HOUR
+        fun all() = values().toList().toImmutableList()
+    }
+}
+
+@Suppress("MagicNumber")
+private fun Int.fromHour(): Int {
+    return 60 * this
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/entity/EmailDisplayCount.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/entity/EmailDisplayCount.kt
@@ -1,0 +1,22 @@
+package app.k9mail.feature.account.setup.domain.entity
+
+import kotlinx.collections.immutable.toImmutableList
+
+@Suppress("MagicNumber")
+enum class EmailDisplayCount(
+    val count: Int,
+) {
+    MESSAGES_10(10),
+    MESSAGES_25(25),
+    MESSAGES_50(50),
+    MESSAGES_100(100),
+    MESSAGES_250(250),
+    MESSAGES_500(500),
+    MESSAGES_1000(1000),
+    ;
+
+    companion object {
+        val DEFAULT = MESSAGES_25
+        fun all() = values().toList().toImmutableList()
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/InputField.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/InputField.kt
@@ -1,0 +1,43 @@
+package app.k9mail.feature.account.setup.domain.input
+
+/**
+ * InputField is an interface defining the state of an input field.
+ *
+ * @param T The type of the value the input field holds.
+ */
+interface InputField<T> {
+    val value: T
+    val errorMessage: String?
+    val isValid: Boolean
+
+    /**
+     * Updates the current value of the input field.
+     *
+     * @param value The new value to be set for the input field.
+     * @return a new InputField instance with the updated value.
+     */
+    fun updateValue(value: T): InputField<T>
+
+    /**
+     * Updates the current error message of the input field.
+     *
+     * @param errorMessage The new error message to be set for the input field.
+     */
+    fun updateErrorMessage(errorMessage: String?): InputField<T>
+
+    /**
+     * Updates the current validity of the input field.
+     *
+     * @param isValid The new validity to be set for the input field.
+     */
+    fun updateValidity(isValid: Boolean): InputField<T>
+
+    /**
+     * Checks if the input field currently has an error.
+     *
+     * @return a Boolean indicating whether the input field has an error.
+     */
+    fun hasError(): Boolean {
+        return errorMessage != null
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputField.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputField.kt
@@ -1,0 +1,34 @@
+package app.k9mail.feature.account.setup.domain.input
+
+data class StringInputField(
+    override val value: String = "",
+    override val errorMessage: String? = null,
+    override val isValid: Boolean = false,
+) : InputField<String> {
+
+    override fun updateValue(value: String): StringInputField {
+        return StringInputField(
+            value = value,
+            errorMessage = null,
+            isValid = false,
+        )
+    }
+
+    override fun updateErrorMessage(errorMessage: String?): StringInputField {
+        return StringInputField(
+            value = value,
+            errorMessage = errorMessage,
+            isValid = false,
+        )
+    }
+
+    override fun updateValidity(isValid: Boolean): StringInputField {
+        if (isValid == this.isValid) return this
+
+        return StringInputField(
+            value = value,
+            errorMessage = null,
+            isValid = isValid,
+        )
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
@@ -1,0 +1,15 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidateAccountName : ValidationUseCase<String> {
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(EmptyAccountName())
+            else -> ValidationResult.Success
+        }
+    }
+
+    class EmptyAccountName : Exception()
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
@@ -1,0 +1,16 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidateDisplayName : ValidationUseCase<String> {
+
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(EmptyDisplayName())
+            else -> ValidationResult.Success
+        }
+    }
+
+    class EmptyDisplayName : Exception()
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
@@ -1,0 +1,17 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+// TODO check signature for input validity
+class ValidateEmailSignature : ValidationUseCase<String> {
+
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(EmptyEmailSignature())
+            else -> ValidationResult.Success
+        }
+    }
+
+    class EmptyEmailSignature : Exception()
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
@@ -9,7 +9,9 @@ import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.ViewModel
 import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigScreen
 import app.k9mail.feature.account.setup.ui.incoming.AccountIncomingConfigScreen
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsScreen
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsViewModel
 import app.k9mail.feature.account.setup.ui.outgoing.AccountOutgoingConfigScreen
 import org.koin.androidx.compose.koinViewModel
 
@@ -18,6 +20,7 @@ fun AccountSetupScreen(
     onFinish: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel = koinViewModel<AccountSetupViewModel>(),
+    optionsViewModel: AccountOptionsContract.ViewModel = koinViewModel<AccountOptionsViewModel>(),
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
@@ -52,6 +55,7 @@ fun AccountSetupScreen(
             AccountOptionsScreen(
                 onNext = { dispatch(Event.OnNext) },
                 onBack = { dispatch(Event.OnBack) },
+                viewModel = optionsViewModel,
             )
         }
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/common/ItemPadding.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/common/ItemPadding.kt
@@ -1,0 +1,19 @@
+package app.k9mail.feature.account.setup.ui.common
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.theme.MainTheme
+
+@Composable
+internal fun defaultHeadlineItemPadding() = PaddingValues(
+    start = MainTheme.spacings.quadruple,
+    top = MainTheme.spacings.triple,
+    end = MainTheme.spacings.quadruple,
+    bottom = MainTheme.spacings.default,
+)
+
+@Composable
+internal fun defaultItemPadding() = PaddingValues(
+    horizontal = MainTheme.spacings.quadruple,
+    vertical = MainTheme.spacings.zero,
+)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
@@ -1,30 +1,51 @@
 package app.k9mail.feature.account.setup.ui.options
 
+import android.content.res.Resources
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
-import app.k9mail.core.ui.compose.designsystem.atom.text.TextBody1
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextOverline
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SwitchInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
+import app.k9mail.feature.account.setup.R
+import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
+import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
+import app.k9mail.feature.account.setup.ui.common.defaultHeadlineItemPadding
+import app.k9mail.feature.account.setup.ui.common.defaultItemPadding
 
+@OptIn(ExperimentalLayoutApi::class)
+@Suppress("LongMethod")
 @Composable
 internal fun AccountOptionsContent(
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
+    val resources = LocalContext.current.resources
+
     ResponsiveWidthContainer(
         modifier = Modifier
             .testTag("AccountOptionsContent")
+            .consumeWindowInsets(contentPadding)
             .padding(contentPadding)
             .then(modifier),
     ) {
@@ -36,11 +57,120 @@ internal fun AccountOptionsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             item {
-                TextBody1(text = "Options placeholder")
+                TextOverline(
+                    text = stringResource(id = R.string.account_setup_options_section_display_options),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(defaultHeadlineItemPadding()),
+                )
+            }
+
+            item {
+                TextInput(
+                    text = "",
+                    onTextChange = { },
+                    label = stringResource(id = R.string.account_setup_options_account_name_label),
+                    contentPadding = defaultItemPadding(),
+                )
+            }
+
+            item {
+                TextInput(
+                    text = "",
+                    onTextChange = { },
+                    label = stringResource(id = R.string.account_setup_options_display_name_label),
+                    contentPadding = defaultItemPadding(),
+                    isRequired = true,
+                )
+            }
+
+            item {
+                TextInput(
+                    text = "",
+                    onTextChange = { },
+                    label = stringResource(id = R.string.account_setup_options_email_signature_label),
+                    contentPadding = defaultItemPadding(),
+                    isSingleLine = false,
+                )
+            }
+
+            item {
+                TextOverline(
+                    text = stringResource(id = R.string.account_setup_options_section_sync_options_),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(defaultHeadlineItemPadding()),
+                )
+            }
+
+            item {
+                SelectInput(
+                    options = EmailCheckFrequency.all(),
+                    optionToStringTransformation = { transformCheckFrequency(resources, it) },
+                    selectedOption = EmailCheckFrequency.DEFAULT,
+                    onOptionChange = { },
+                    label = stringResource(id = R.string.account_setup_options_account_check_frequency_label),
+                    contentPadding = defaultItemPadding(),
+                )
+            }
+
+            item {
+                SelectInput(
+                    options = EmailDisplayCount.all(),
+                    optionToStringTransformation = { transformMessageDisplayCount(resources, it) },
+                    selectedOption = EmailDisplayCount.DEFAULT,
+                    onOptionChange = { },
+                    label = stringResource(id = R.string.account_setup_options_email_display_count_label),
+                    contentPadding = defaultItemPadding(),
+                )
+            }
+
+            item {
+                SwitchInput(
+                    text = stringResource(id = R.string.account_setup_options_show_notifications_label),
+                    checked = false,
+                    onCheckedChange = { },
+                    contentPadding = defaultItemPadding(),
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
             }
         }
     }
 }
+
+@Suppress("MagicNumber")
+private fun transformCheckFrequency(
+    resources: Resources,
+    it: EmailCheckFrequency,
+): String {
+    return when (it.minutes) {
+        -1 -> resources.getString(R.string.account_setup_options_email_check_frequency_zero)
+
+        in 1..59 -> resources.getQuantityString(
+            R.plurals.account_setup_options_email_check_frequency_minutes,
+            it.minutes,
+            it.minutes,
+        )
+
+        else -> resources.getQuantityString(
+            R.plurals.account_setup_options_email_check_frequency_hours,
+            (it.minutes / 60),
+            (it.minutes / 60),
+        )
+    }
+}
+
+private fun transformMessageDisplayCount(
+    resources: Resources,
+    it: EmailDisplayCount,
+) = resources.getQuantityString(
+    R.plurals.account_setup_options_email_display_count_messages,
+    it.count,
+    it.count,
+)
 
 @Composable
 @DevicePreviews

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
@@ -32,11 +32,15 @@ import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
 import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
 import app.k9mail.feature.account.setup.ui.common.defaultHeadlineItemPadding
 import app.k9mail.feature.account.setup.ui.common.defaultItemPadding
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
 
 @OptIn(ExperimentalLayoutApi::class)
 @Suppress("LongMethod")
 @Composable
 internal fun AccountOptionsContent(
+    state: State,
+    onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
@@ -67,8 +71,8 @@ internal fun AccountOptionsContent(
 
             item {
                 TextInput(
-                    text = "",
-                    onTextChange = { },
+                    text = state.accountName.value,
+                    onTextChange = { onEvent(Event.OnAccountNameChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_account_name_label),
                     contentPadding = defaultItemPadding(),
                 )
@@ -76,8 +80,8 @@ internal fun AccountOptionsContent(
 
             item {
                 TextInput(
-                    text = "",
-                    onTextChange = { },
+                    text = state.displayName.value,
+                    onTextChange = { onEvent(Event.OnDisplayNameChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_display_name_label),
                     contentPadding = defaultItemPadding(),
                     isRequired = true,
@@ -86,8 +90,8 @@ internal fun AccountOptionsContent(
 
             item {
                 TextInput(
-                    text = "",
-                    onTextChange = { },
+                    text = state.emailSignature.value,
+                    onTextChange = { onEvent(Event.OnEmailSignatureChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_email_signature_label),
                     contentPadding = defaultItemPadding(),
                     isSingleLine = false,
@@ -107,8 +111,8 @@ internal fun AccountOptionsContent(
                 SelectInput(
                     options = EmailCheckFrequency.all(),
                     optionToStringTransformation = { transformCheckFrequency(resources, it) },
-                    selectedOption = EmailCheckFrequency.DEFAULT,
-                    onOptionChange = { },
+                    selectedOption = state.checkFrequency,
+                    onOptionChange = { onEvent(Event.OnCheckFrequencyChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_account_check_frequency_label),
                     contentPadding = defaultItemPadding(),
                 )
@@ -118,8 +122,8 @@ internal fun AccountOptionsContent(
                 SelectInput(
                     options = EmailDisplayCount.all(),
                     optionToStringTransformation = { transformMessageDisplayCount(resources, it) },
-                    selectedOption = EmailDisplayCount.DEFAULT,
-                    onOptionChange = { },
+                    selectedOption = state.messageDisplayCount,
+                    onOptionChange = { onEvent(Event.OnMessageDisplayCountChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_email_display_count_label),
                     contentPadding = defaultItemPadding(),
                 )
@@ -128,8 +132,8 @@ internal fun AccountOptionsContent(
             item {
                 SwitchInput(
                     text = stringResource(id = R.string.account_setup_options_show_notifications_label),
-                    checked = false,
-                    onCheckedChange = { },
+                    checked = state.showNotification,
+                    onCheckedChange = { onEvent(Event.OnShowNotificationChanged(it)) },
                     contentPadding = defaultItemPadding(),
                 )
             }
@@ -177,6 +181,8 @@ private fun transformMessageDisplayCount(
 internal fun AccountOptionsContentK9Preview() {
     K9Theme {
         AccountOptionsContent(
+            state = State(),
+            onEvent = {},
             contentPadding = PaddingValues(),
         )
     }
@@ -187,6 +193,8 @@ internal fun AccountOptionsContentK9Preview() {
 internal fun AccountOptionsContentThunderbirdPreview() {
     ThunderbirdTheme {
         AccountOptionsContent(
+            state = State(),
+            onEvent = {},
             contentPadding = PaddingValues(),
         )
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
@@ -1,0 +1,39 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
+import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
+import app.k9mail.feature.account.setup.domain.input.StringInputField
+
+interface AccountOptionsContract {
+
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect> {
+        fun initState(state: State)
+    }
+
+    data class State(
+        val accountName: StringInputField = StringInputField(),
+        val displayName: StringInputField = StringInputField(),
+        val emailSignature: StringInputField = StringInputField(),
+        val checkFrequency: EmailCheckFrequency = EmailCheckFrequency.DEFAULT,
+        val messageDisplayCount: EmailDisplayCount = EmailDisplayCount.DEFAULT,
+        val showNotification: Boolean = false,
+    )
+
+    sealed class Event {
+        data class OnAccountNameChanged(val accountName: String) : Event()
+        data class OnDisplayNameChanged(val displayName: String) : Event()
+        data class OnEmailSignatureChanged(val emailSignature: String) : Event()
+        data class OnCheckFrequencyChanged(val checkFrequency: EmailCheckFrequency) : Event()
+        data class OnMessageDisplayCountChanged(val messageDisplayCount: EmailDisplayCount) : Event()
+        data class OnShowNotificationChanged(val showNotification: Boolean) : Event()
+
+        object OnNextClicked : Event()
+        object OnBackClicked : Event()
+    }
+
+    sealed class Effect {
+        object NavigateNext : Effect()
+        object NavigateBack : Effect()
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
@@ -1,22 +1,41 @@
 package app.k9mail.feature.account.setup.ui.options
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.setup.R.string
 import app.k9mail.feature.account.setup.ui.common.AccountSetupBottomBar
 import app.k9mail.feature.account.setup.ui.common.AccountSetupTopAppBar
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Effect
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.ViewModel
 
 @Composable
 internal fun AccountOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
+    viewModel: ViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
+    val (state, dispatch) = viewModel.observe { effect ->
+        when (effect) {
+            Effect.NavigateBack -> onBack()
+            Effect.NavigateNext -> {
+                Toast.makeText(context, "Finish clicked", Toast.LENGTH_SHORT).show() // TODO remove
+                onNext()
+            }
+        }
+    }
+
     Scaffold(
         topBar = {
             AccountSetupTopAppBar(
@@ -27,13 +46,15 @@ internal fun AccountOptionsScreen(
             AccountSetupBottomBar(
                 nextButtonText = stringResource(id = string.account_setup_button_finish),
                 backButtonText = stringResource(id = string.account_setup_button_back),
-                onNextClick = onNext,
-                onBackClick = onBack,
+                onNextClick = { dispatch(Event.OnNextClicked) },
+                onBackClick = { dispatch(Event.OnBackClicked) },
             )
         },
         modifier = modifier,
     ) { innerPadding ->
         AccountOptionsContent(
+            state = state.value,
+            onEvent = { dispatch(it) },
             contentPadding = innerPadding,
         )
     }
@@ -46,6 +67,7 @@ internal fun AccountOptionsScreenK9Preview() {
         AccountOptionsScreen(
             onNext = {},
             onBack = {},
+            viewModel = AccountOptionsViewModel(),
         )
     }
 }
@@ -57,6 +79,7 @@ internal fun AccountOptionsScreenThunderbirdPreview() {
         AccountOptionsScreen(
             onNext = {},
             onBack = {},
+            viewModel = AccountOptionsViewModel(),
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
@@ -1,0 +1,76 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Effect
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnAccountNameChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnBackClicked
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnCheckFrequencyChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnDisplayNameChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnEmailSignatureChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnMessageDisplayCountChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnNextClicked
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnShowNotificationChanged
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.ViewModel
+
+internal class AccountOptionsViewModel(
+    initialState: State = State(),
+) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
+    override fun event(event: Event) {
+        when (event) {
+            is OnAccountNameChanged -> updateState { state ->
+                state.copy(
+                    accountName = state.accountName.updateValue(event.accountName),
+                )
+            }
+
+            is OnDisplayNameChanged -> updateState {
+                it.copy(
+                    displayName = it.displayName.updateValue(event.displayName),
+                )
+            }
+
+            is OnEmailSignatureChanged -> updateState {
+                it.copy(
+                    emailSignature = it.emailSignature.updateValue(event.emailSignature),
+                )
+            }
+
+            is OnCheckFrequencyChanged -> updateState {
+                it.copy(
+                    checkFrequency = event.checkFrequency,
+                )
+            }
+
+            is OnMessageDisplayCountChanged -> updateState { state ->
+                state.copy(
+                    messageDisplayCount = event.messageDisplayCount,
+                )
+            }
+
+            is OnShowNotificationChanged -> updateState { state ->
+                state.copy(
+                    showNotification = event.showNotification,
+                )
+            }
+
+            OnNextClicked -> submit()
+            OnBackClicked -> navigateBack()
+        }
+    }
+
+    override fun initState(state: State) {
+        updateState {
+            state.copy()
+        }
+    }
+
+    private fun submit() {
+        navigateNext()
+    }
+
+    private fun navigateBack() = emitEffect(Effect.NavigateBack)
+
+    private fun navigateNext() = emitEffect(Effect.NavigateNext)
+}

--- a/feature/account/setup/src/main/res/values/plurals.xml
+++ b/feature/account/setup/src/main/res/values/plurals.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="account_setup_options_email_check_frequency_minutes">
+        <item quantity="one">Every minute</item>
+        <item quantity="other">Every %d minutes</item>
+    </plurals>
+    <plurals name="account_setup_options_email_check_frequency_hours">
+        <item quantity="one">Every hour</item>
+        <item quantity="other">Every %d hours</item>
+    </plurals>
+    <plurals name="account_setup_options_email_display_count_messages">
+        <item quantity="one">1 message</item>
+        <item quantity="other">%d messages</item>
+    </plurals>
+</resources>

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -12,4 +12,13 @@
     <string name="account_setup_outgoing_config_top_bar_title">Outgoing server settings</string>
 
     <string name="account_setup_options_top_bar_title">Account options</string>
+    <string name="account_setup_options_section_display_options">Display options</string>
+    <string name="account_setup_options_account_name_label">Account name</string>
+    <string name="account_setup_options_display_name_label">Display name</string>
+    <string name="account_setup_options_email_signature_label">Email signature</string>
+    <string name="account_setup_options_section_sync_options_">Sync options</string>
+    <string name="account_setup_options_account_check_frequency_label">Check frequency</string>
+    <string name="account_setup_options_email_check_frequency_zero">Never</string>
+    <string name="account_setup_options_email_display_count_label">Number of messages to display</string>
+    <string name="account_setup_options_show_notifications_label">Show notifications</string>
 </resources>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputFieldTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputFieldTest.kt
@@ -1,0 +1,79 @@
+package app.k9mail.feature.account.setup.domain.input
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import org.junit.Test
+
+class StringInputFieldTest {
+
+    @Test
+    fun `should set default values`() {
+        val stringInputState = StringInputField()
+
+        assertThat(stringInputState).all {
+            prop(StringInputField::value).isEqualTo("")
+            prop(StringInputField::errorMessage).isNull()
+            prop(StringInputField::isValid).isFalse()
+        }
+    }
+
+    @Test
+    fun `should reset errorMessage and isValid when value changed`() {
+        val initialInputState = StringInputField(errorMessage = "error", isValid = false)
+
+        val result = initialInputState.updateValue("new value")
+
+        assertThat(result).all {
+            prop(StringInputField::value).isEqualTo("new value")
+            prop(StringInputField::errorMessage).isNull()
+            prop(StringInputField::isValid).isFalse()
+        }
+    }
+
+    @Test
+    fun `should reset isValid when error set`() {
+        val initialInputState = StringInputField(value = "input", isValid = true)
+
+        val result = initialInputState.updateErrorMessage("error")
+
+        assertThat(result).all {
+            prop(StringInputField::value).isEqualTo("input")
+            prop(StringInputField::errorMessage).isEqualTo("error")
+            prop(StringInputField::isValid).isFalse()
+        }
+    }
+
+    @Test
+    fun `should reset errorMessage when valid`() {
+        val initialInputState = StringInputField(value = "input", errorMessage = "error")
+
+        val result = initialInputState.updateValidity(isValid = true)
+
+        assertThat(result).all {
+            prop(StringInputField::value).isEqualTo("input")
+            prop(StringInputField::errorMessage).isNull()
+            prop(StringInputField::isValid).isTrue()
+        }
+    }
+
+    @Test
+    fun `should not reset errorMessage when invalid`() {
+        val initialInputState = StringInputField(
+            value = "input",
+            errorMessage = "error",
+        )
+
+        val result = initialInputState.updateValidity(isValid = false)
+
+        assertThat(result).all {
+            prop(StringInputField::value).isEqualTo("input")
+            prop(StringInputField::errorMessage).isEqualTo("error")
+            prop(StringInputField::isValid).isFalse()
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidateAccountNameTest {
+
+    @Test
+    fun `should succeed when account name is set`() {
+        val useCase = ValidateAccountName()
+
+        val result = useCase.execute("account name")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when account name is empty`() {
+        val useCase = ValidateAccountName()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateAccountName.EmptyAccountName::class)
+    }
+
+    @Test
+    fun `should fail when account name is blank`() {
+        val useCase = ValidateAccountName()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateAccountName.EmptyAccountName::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidateDisplayNameTest {
+
+    @Test
+    fun `should succeed when display name is set`() {
+        val useCase = ValidateDisplayName()
+
+        val result = useCase.execute("display name")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when display name is empty`() {
+        val useCase = ValidateDisplayName()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateDisplayName.EmptyDisplayName::class)
+    }
+
+    @Test
+    fun `should fail when display name is blank`() {
+        val useCase = ValidateDisplayName()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateDisplayName.EmptyDisplayName::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidateEmailSignatureTest {
+
+    @Test
+    fun `should succeed when email signature is set`() {
+        val useCase = ValidateEmailSignature()
+
+        val result = useCase.execute("email signature")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when email signature is empty`() {
+        val useCase = ValidateEmailSignature()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateEmailSignature.EmptyEmailSignature::class)
+    }
+
+    @Test
+    fun `should fail when email signature is blank`() {
+        val useCase = ValidateEmailSignature()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateEmailSignature.EmptyEmailSignature::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreenKtTest.kt
@@ -7,6 +7,7 @@ import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
+import app.k9mail.feature.account.setup.ui.options.FakeAccountOptionsViewModel
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +21,7 @@ class AccountSetupScreenKtTest : ComposeTest() {
     @Test
     fun `should display correct screen for every setup step`() = runTest {
         val viewModel = FakeAccountSetupViewModel()
+        val optionsViewModel = FakeAccountOptionsViewModel()
 
         setContent {
             ThunderbirdTheme {
@@ -27,6 +29,7 @@ class AccountSetupScreenKtTest : ComposeTest() {
                     onFinish = { },
                     onBack = { },
                     viewModel = viewModel,
+                    optionsViewModel = optionsViewModel,
                 )
             }
         }
@@ -41,6 +44,7 @@ class AccountSetupScreenKtTest : ComposeTest() {
     fun `should delegate navigation effects`() = runTest {
         val initialState = State()
         val viewModel = FakeAccountSetupViewModel(initialState)
+        val optionsViewModel = FakeAccountOptionsViewModel()
         var onFinishCounter = 0
         var onBackCounter = 0
 
@@ -50,6 +54,7 @@ class AccountSetupScreenKtTest : ComposeTest() {
                     onFinish = { onFinishCounter++ },
                     onBack = { onBackCounter++ },
                     viewModel = viewModel,
+                    optionsViewModel = optionsViewModel,
                 )
             }
         }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupViewModelTest.kt
@@ -1,15 +1,12 @@
 package app.k9mail.feature.account.setup.ui
 
-import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.testIn
 import app.k9mail.core.ui.compose.testing.MainDispatcherRule
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect.NavigateBack
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.Effect.NavigateNext
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.SetupStep
 import app.k9mail.feature.account.setup.ui.AccountSetupContract.State
-import assertk.Assert
-import assertk.all
-import assertk.assertThat
+import assertk.assertions.assertThatAndTurbinesConsumed
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,7 +28,7 @@ class AccountSetupViewModelTest {
         val turbines = listOf(stateTurbine, effectTurbine)
 
         // Initial state
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -40,7 +37,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnNext)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -49,7 +46,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnNext)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -58,7 +55,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnNext)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -67,7 +64,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnNext)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = effectTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -84,7 +81,7 @@ class AccountSetupViewModelTest {
         val turbines = listOf(stateTurbine, effectTurbine)
 
         // Initial state
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -93,7 +90,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnBack)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -102,7 +99,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnBack)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -111,7 +108,7 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnBack)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = stateTurbine.awaitItem(),
             turbines = turbines,
         ) {
@@ -120,23 +117,11 @@ class AccountSetupViewModelTest {
 
         viewModel.event(AccountSetupContract.Event.OnBack)
 
-        assertThatAndAllEventsConsumed(
+        assertThatAndTurbinesConsumed(
             actual = effectTurbine.awaitItem(),
             turbines = turbines,
         ) {
             isEqualTo(NavigateBack)
         }
-    }
-
-    private fun <T> assertThatAndAllEventsConsumed(
-        actual: T,
-        turbines: List<ReceiveTurbine<*>>,
-        assertion: Assert<T>.() -> Unit,
-    ) {
-        assertThat(actual).all {
-            assertion()
-        }
-
-        turbines.forEach { it.ensureAllEventsConsumed() }
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreenKtTest.kt
@@ -1,0 +1,45 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.setContent
+import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Effect
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AccountOptionsScreenKtTest : ComposeTest() {
+
+    @Test
+    fun `should delegate navigation effects`() = runTest {
+        val initialState = State()
+        val viewModel = FakeAccountOptionsViewModel(initialState)
+        var onNextCounter = 0
+        var onBackCounter = 0
+
+        setContent {
+            ThunderbirdTheme {
+                AccountOptionsScreen(
+                    onNext = { onNextCounter++ },
+                    onBack = { onBackCounter++ },
+                    viewModel = viewModel,
+                )
+            }
+        }
+
+        assertThat(onNextCounter).isEqualTo(0)
+        assertThat(onBackCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.NavigateNext)
+
+        assertThat(onNextCounter).isEqualTo(1)
+        assertThat(onBackCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.NavigateBack)
+
+        assertThat(onNextCounter).isEqualTo(1)
+        assertThat(onBackCounter).isEqualTo(1)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsStateTest.kt
@@ -1,0 +1,28 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
+import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
+import app.k9mail.feature.account.setup.domain.input.StringInputField
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import org.junit.Test
+
+class AccountOptionsStateTest {
+
+    @Test
+    fun `should set default values`() {
+        val state = State()
+
+        assertThat(state).all {
+            prop(State::accountName).isEqualTo(StringInputField())
+            prop(State::displayName).isEqualTo(StringInputField())
+            prop(State::emailSignature).isEqualTo(StringInputField())
+            prop(State::checkFrequency).isEqualTo(EmailCheckFrequency.DEFAULT)
+            prop(State::messageDisplayCount).isEqualTo(EmailDisplayCount.DEFAULT)
+            prop(State::showNotification).isEqualTo(false)
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModelTest.kt
@@ -1,0 +1,150 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.cash.turbine.testIn
+import app.k9mail.core.ui.compose.testing.MainDispatcherRule
+import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
+import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
+import app.k9mail.feature.account.setup.domain.input.StringInputField
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import assertk.assertions.assertThatAndTurbinesConsumed
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class AccountOptionsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `should change state when OnAccountNameChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnAccountNameChanged("accountName"),
+            expectedState = State(accountName = StringInputField(value = "accountName")),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should change state when OnDisplayNameChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnDisplayNameChanged("displayName"),
+            expectedState = State(displayName = StringInputField(value = "displayName")),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should change state when OnEmailSignatureChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnEmailSignatureChanged("emailSignature"),
+            expectedState = State(emailSignature = StringInputField(value = "emailSignature")),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should change state when OnCheckFrequencyChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnCheckFrequencyChanged(EmailCheckFrequency.EVERY_12_HOURS),
+            expectedState = State(checkFrequency = EmailCheckFrequency.EVERY_12_HOURS),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should change state when OnMessageDisplayCountChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnMessageDisplayCountChanged(EmailDisplayCount.MESSAGES_1000),
+            expectedState = State(messageDisplayCount = EmailDisplayCount.MESSAGES_1000),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should change state when OnShowNotificationChanged event is received`() = runTest {
+        eventStateTest(
+            event = Event.OnShowNotificationChanged(true),
+            expectedState = State(showNotification = true),
+            coroutineScope = backgroundScope,
+        )
+    }
+
+    @Test
+    fun `should emit NavigateNext effect when OnNextClicked event is received`() = runTest {
+        val viewModel = AccountOptionsViewModel()
+        val stateTurbine = viewModel.state.testIn(backgroundScope)
+        val effectTurbine = viewModel.effect.testIn(backgroundScope)
+        val turbines = listOf(stateTurbine, effectTurbine)
+
+        assertThatAndTurbinesConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(State())
+        }
+
+        viewModel.event(Event.OnNextClicked)
+
+        assertThatAndTurbinesConsumed(
+            actual = effectTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(AccountOptionsContract.Effect.NavigateNext)
+        }
+    }
+
+    @Test
+    fun `should emit NavigateBack effect when OnBackClicked event is received`() = runTest {
+        val viewModel = AccountOptionsViewModel()
+        val stateTurbine = viewModel.state.testIn(backgroundScope)
+        val effectTurbine = viewModel.effect.testIn(backgroundScope)
+        val turbines = listOf(stateTurbine, effectTurbine)
+
+        assertThatAndTurbinesConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(State())
+        }
+
+        viewModel.event(Event.OnBackClicked)
+
+        assertThatAndTurbinesConsumed(
+            actual = effectTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(AccountOptionsContract.Effect.NavigateBack)
+        }
+    }
+
+    private suspend fun eventStateTest(
+        event: Event,
+        expectedState: State,
+        coroutineScope: CoroutineScope,
+    ) {
+        val viewModel = AccountOptionsViewModel()
+        val stateTurbine = viewModel.state.testIn(coroutineScope)
+        val effectTurbine = viewModel.effect.testIn(coroutineScope)
+        val turbines = listOf(stateTurbine, effectTurbine)
+
+        assertThatAndTurbinesConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(State())
+        }
+
+        viewModel.event(event)
+
+        assertThatAndTurbinesConsumed(
+            actual = stateTurbine.awaitItem(),
+            turbines = turbines,
+        ) {
+            isEqualTo(expectedState)
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsViewModel.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsViewModel.kt
@@ -1,0 +1,25 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Effect
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.ViewModel
+
+class FakeAccountOptionsViewModel(initialState: State = State()) :
+    BaseViewModel<State, Event, Effect>(initialState), ViewModel {
+
+    val events = mutableListOf<Event>()
+
+    override fun initState(state: State) {
+        updateState { state }
+    }
+
+    override fun event(event: Event) {
+        events.add(event)
+    }
+
+    fun effect(effect: Effect) {
+        emitEffect(effect)
+    }
+}


### PR DESCRIPTION
This adds the AccountSetup UI for options. Validation is prepared and will be wired in one of the next pull-requests. Also it is currently very basic, could be extended over time. Especially adding requirements around minimal length and escaping email signature input.

Depends on #6940 
