### PR TITLE
Add account setup options validation

### DIFF
--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationError.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationError.kt
@@ -1,0 +1,3 @@
+package app.k9mail.core.common.domain.usecase.validation
+
+interface ValidationError

--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationResult.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/validation/ValidationResult.kt
@@ -1,7 +1,7 @@
 package app.k9mail.core.common.domain.usecase.validation
 
-interface ValidationResult {
+sealed interface ValidationResult {
     object Success : ValidationResult
 
-    data class Failure(val error: Exception) : ValidationResult
+    data class Failure(val error: ValidationError) : ValidationResult
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -1,12 +1,20 @@
 package app.k9mail.feature.account.setup
 
 import app.k9mail.feature.account.setup.ui.AccountSetupViewModel
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsValidator
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val featureAccountSetupModule: Module = module {
+    factory<AccountOptionsContract.Validator> { AccountOptionsValidator() }
+
     viewModel { AccountSetupViewModel() }
-    viewModel { AccountOptionsViewModel() }
+    viewModel {
+        AccountOptionsViewModel(
+            validator = get(),
+        )
+    }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/InputField.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/InputField.kt
@@ -1,5 +1,7 @@
 package app.k9mail.feature.account.setup.domain.input
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+
 /**
  * InputField is an interface defining the state of an input field.
  *
@@ -7,7 +9,7 @@ package app.k9mail.feature.account.setup.domain.input
  */
 interface InputField<T> {
     val value: T
-    val errorMessage: String?
+    val error: ValidationError?
     val isValid: Boolean
 
     /**
@@ -19,11 +21,11 @@ interface InputField<T> {
     fun updateValue(value: T): InputField<T>
 
     /**
-     * Updates the current error message of the input field.
+     * Updates the current error of the input field.
      *
-     * @param errorMessage The new error message to be set for the input field.
+     * @param error The new error to be set for the input field.
      */
-    fun updateErrorMessage(errorMessage: String?): InputField<T>
+    fun updateError(error: ValidationError?): InputField<T>
 
     /**
      * Updates the current validity of the input field.
@@ -38,6 +40,6 @@ interface InputField<T> {
      * @return a Boolean indicating whether the input field has an error.
      */
     fun hasError(): Boolean {
-        return errorMessage != null
+        return error != null
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputField.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/StringInputField.kt
@@ -1,23 +1,26 @@
 package app.k9mail.feature.account.setup.domain.input
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+
 data class StringInputField(
     override val value: String = "",
-    override val errorMessage: String? = null,
+    override val error: ValidationError? = null,
     override val isValid: Boolean = false,
 ) : InputField<String> {
 
     override fun updateValue(value: String): StringInputField {
         return StringInputField(
             value = value,
-            errorMessage = null,
+            error = null,
             isValid = false,
         )
     }
 
-    override fun updateErrorMessage(errorMessage: String?): StringInputField {
+    override fun updateError(error: ValidationError?): StringInputField {
         return StringInputField(
             value = value,
-            errorMessage = errorMessage,
+            error = error,
             isValid = false,
         )
     }
@@ -27,8 +30,22 @@ data class StringInputField(
 
         return StringInputField(
             value = value,
-            errorMessage = null,
+            error = null,
             isValid = isValid,
+        )
+    }
+}
+
+fun StringInputField.fromValidationResult(result: ValidationResult): StringInputField {
+    return when (result) {
+        is ValidationResult.Success -> copy(
+            error = null,
+            isValid = true,
+        )
+
+        is ValidationResult.Failure -> copy(
+            error = result.error,
+            isValid = false,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
@@ -1,15 +1,19 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidateAccountName : ValidationUseCase<String> {
     override fun execute(input: String): ValidationResult {
         return when {
-            input.isBlank() -> ValidationResult.Failure(EmptyAccountName())
+            input.isEmpty() -> ValidationResult.Success
+            input.isBlank() -> ValidationResult.Failure(ValidateAccountNameError.BlankAccountName)
             else -> ValidationResult.Success
         }
     }
 
-    class EmptyAccountName : Exception()
+    sealed interface ValidateAccountNameError : ValidationError {
+        object BlankAccountName : ValidateAccountNameError
+    }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
@@ -7,10 +8,12 @@ class ValidateDisplayName : ValidationUseCase<String> {
 
     override fun execute(input: String): ValidationResult {
         return when {
-            input.isBlank() -> ValidationResult.Failure(EmptyDisplayName())
+            input.isBlank() -> ValidationResult.Failure(ValidateDisplayNameError.EmptyDisplayName)
             else -> ValidationResult.Success
         }
     }
 
-    class EmptyDisplayName : Exception()
+    sealed interface ValidateDisplayNameError : ValidationError {
+        object EmptyDisplayName : ValidateDisplayNameError
+    }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
@@ -1,17 +1,22 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError.BlankEmailSignature
 
 // TODO check signature for input validity
 class ValidateEmailSignature : ValidationUseCase<String> {
 
     override fun execute(input: String): ValidationResult {
         return when {
-            input.isBlank() -> ValidationResult.Failure(EmptyEmailSignature())
+            input.isEmpty() -> ValidationResult.Success
+            input.isBlank() -> ValidationResult.Failure(error = BlankEmailSignature)
             else -> ValidationResult.Success
         }
     }
 
-    class EmptyEmailSignature : Exception()
+    sealed interface ValidateEmailSignatureError : ValidationError {
+        object BlankEmailSignature : ValidateEmailSignatureError
+    }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
@@ -1,6 +1,5 @@
 package app.k9mail.feature.account.setup.ui.options
 
-import android.content.res.Resources
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
@@ -72,6 +71,7 @@ internal fun AccountOptionsContent(
             item {
                 TextInput(
                     text = state.accountName.value,
+                    errorMessage = state.accountName.error?.toResourceString(resources),
                     onTextChange = { onEvent(Event.OnAccountNameChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_account_name_label),
                     contentPadding = defaultItemPadding(),
@@ -81,6 +81,7 @@ internal fun AccountOptionsContent(
             item {
                 TextInput(
                     text = state.displayName.value,
+                    errorMessage = state.displayName.error?.toResourceString(resources),
                     onTextChange = { onEvent(Event.OnDisplayNameChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_display_name_label),
                     contentPadding = defaultItemPadding(),
@@ -91,6 +92,7 @@ internal fun AccountOptionsContent(
             item {
                 TextInput(
                     text = state.emailSignature.value,
+                    errorMessage = state.emailSignature.error?.toResourceString(resources),
                     onTextChange = { onEvent(Event.OnEmailSignatureChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_email_signature_label),
                     contentPadding = defaultItemPadding(),
@@ -110,7 +112,7 @@ internal fun AccountOptionsContent(
             item {
                 SelectInput(
                     options = EmailCheckFrequency.all(),
-                    optionToStringTransformation = { transformCheckFrequency(resources, it) },
+                    optionToStringTransformation = { it.toResourceString(resources) },
                     selectedOption = state.checkFrequency,
                     onOptionChange = { onEvent(Event.OnCheckFrequencyChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_account_check_frequency_label),
@@ -121,7 +123,7 @@ internal fun AccountOptionsContent(
             item {
                 SelectInput(
                     options = EmailDisplayCount.all(),
-                    optionToStringTransformation = { transformMessageDisplayCount(resources, it) },
+                    optionToStringTransformation = { it.toResourceString(resources) },
                     selectedOption = state.messageDisplayCount,
                     onOptionChange = { onEvent(Event.OnMessageDisplayCountChanged(it)) },
                     label = stringResource(id = R.string.account_setup_options_email_display_count_label),
@@ -144,37 +146,6 @@ internal fun AccountOptionsContent(
         }
     }
 }
-
-@Suppress("MagicNumber")
-private fun transformCheckFrequency(
-    resources: Resources,
-    it: EmailCheckFrequency,
-): String {
-    return when (it.minutes) {
-        -1 -> resources.getString(R.string.account_setup_options_email_check_frequency_zero)
-
-        in 1..59 -> resources.getQuantityString(
-            R.plurals.account_setup_options_email_check_frequency_minutes,
-            it.minutes,
-            it.minutes,
-        )
-
-        else -> resources.getQuantityString(
-            R.plurals.account_setup_options_email_check_frequency_hours,
-            (it.minutes / 60),
-            (it.minutes / 60),
-        )
-    }
-}
-
-private fun transformMessageDisplayCount(
-    resources: Resources,
-    it: EmailDisplayCount,
-) = resources.getQuantityString(
-    R.plurals.account_setup_options_email_display_count_messages,
-    it.count,
-    it.count,
-)
 
 @Composable
 @DevicePreviews

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.setup.ui.options
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
 import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
@@ -35,5 +36,11 @@ interface AccountOptionsContract {
     sealed class Effect {
         object NavigateNext : Effect()
         object NavigateBack : Effect()
+    }
+
+    interface Validator {
+        fun validateAccountName(accountName: String): ValidationResult
+        fun validateDisplayName(displayName: String): ValidationResult
+        fun validateEmailSignature(emailSignature: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
@@ -30,7 +30,7 @@ internal fun AccountOptionsScreen(
         when (effect) {
             Effect.NavigateBack -> onBack()
             Effect.NavigateNext -> {
-                Toast.makeText(context, "Finish clicked", Toast.LENGTH_SHORT).show() // TODO remove
+                Toast.makeText(context, "Input is valid", Toast.LENGTH_SHORT).show() // TODO remove
                 onNext()
             }
         }
@@ -67,7 +67,9 @@ internal fun AccountOptionsScreenK9Preview() {
         AccountOptionsScreen(
             onNext = {},
             onBack = {},
-            viewModel = AccountOptionsViewModel(),
+            viewModel = AccountOptionsViewModel(
+                validator = AccountOptionsValidator(),
+            ),
         )
     }
 }
@@ -79,7 +81,9 @@ internal fun AccountOptionsScreenThunderbirdPreview() {
         AccountOptionsScreen(
             onNext = {},
             onBack = {},
-            viewModel = AccountOptionsViewModel(),
+            viewModel = AccountOptionsViewModel(
+                validator = AccountOptionsValidator(),
+            ),
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsStringMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsStringMapper.kt
@@ -1,0 +1,65 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import android.content.res.Resources
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.feature.account.setup.R
+import app.k9mail.feature.account.setup.domain.entity.EmailCheckFrequency
+import app.k9mail.feature.account.setup.domain.entity.EmailDisplayCount
+import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName.ValidateAccountNameError
+import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName.ValidateAccountNameError.BlankAccountName
+import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.ValidateDisplayNameError
+import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.ValidateDisplayNameError.EmptyDisplayName
+import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError
+import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError.BlankEmailSignature
+
+internal fun EmailDisplayCount.toResourceString(resources: Resources) = resources.getQuantityString(
+    R.plurals.account_setup_options_email_display_count_messages,
+    count,
+    count,
+)
+
+@Suppress("MagicNumber")
+internal fun EmailCheckFrequency.toResourceString(resources: Resources): String {
+    return when (minutes) {
+        -1 -> resources.getString(R.string.account_setup_options_email_check_frequency_never)
+
+        in 1..59 -> resources.getQuantityString(
+            R.plurals.account_setup_options_email_check_frequency_minutes,
+            minutes,
+            minutes,
+        )
+
+        else -> resources.getQuantityString(
+            R.plurals.account_setup_options_email_check_frequency_hours,
+            (minutes / 60),
+            (minutes / 60),
+        )
+    }
+}
+
+internal fun ValidationError.toResourceString(resources: Resources): String {
+    return when (this) {
+        is ValidateAccountNameError -> toAccountNameErrorString(resources)
+        is ValidateDisplayNameError -> toDisplayNameErrorString(resources)
+        is ValidateEmailSignatureError -> toEmailSignatureErrorString(resources)
+        else -> throw IllegalArgumentException("Unknown error: $this")
+    }
+}
+
+private fun ValidateAccountNameError.toAccountNameErrorString(resources: Resources): String {
+    return when (this) {
+        is BlankAccountName -> resources.getString(R.string.account_setup_options_account_name_error_blank)
+    }
+}
+
+private fun ValidateDisplayNameError.toDisplayNameErrorString(resources: Resources): String {
+    return when (this) {
+        is EmptyDisplayName -> resources.getString(R.string.account_setup_options_display_name_error_required)
+    }
+}
+
+private fun ValidateEmailSignatureError.toEmailSignatureErrorString(resources: Resources): String {
+    return when (this) {
+        is BlankEmailSignature -> resources.getString(R.string.account_setup_options_email_signature_error_blank)
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsValidator.kt
@@ -1,0 +1,25 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName
+import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName
+import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Validator
+
+internal class AccountOptionsValidator(
+    private val accountNameValidator: ValidateAccountName = ValidateAccountName(),
+    private val displayNameValidator: ValidateDisplayName = ValidateDisplayName(),
+    private val emailSignatureValidator: ValidateEmailSignature = ValidateEmailSignature(),
+) : Validator {
+    override fun validateAccountName(accountName: String): ValidationResult {
+        return accountNameValidator.execute(accountName)
+    }
+
+    override fun validateDisplayName(displayName: String): ValidationResult {
+        return displayNameValidator.execute(displayName)
+    }
+
+    override fun validateEmailSignature(emailSignature: String): ValidationResult {
+        return emailSignatureValidator.execute(emailSignature)
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
@@ -1,6 +1,8 @@
 package app.k9mail.feature.account.setup.ui.options
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.setup.domain.input.fromValidationResult
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnAccountNameChanged
@@ -12,10 +14,12 @@ import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnNextClicked
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Event.OnShowNotificationChanged
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.State
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Validator
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.ViewModel
 
 internal class AccountOptionsViewModel(
     initialState: State = State(),
+    private val validator: Validator,
 ) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
     override fun event(event: Event) {
         when (event) {
@@ -66,8 +70,28 @@ internal class AccountOptionsViewModel(
         }
     }
 
-    private fun submit() {
-        navigateNext()
+    private fun submit() = with(state.value) {
+        val accountNameResult = validator.validateAccountName(accountName.value)
+        val displayNameResult = validator.validateDisplayName(displayName.value)
+        val emailSignatureResult = validator.validateEmailSignature(emailSignature.value)
+
+        val hasError = listOf(
+            accountNameResult,
+            displayNameResult,
+            emailSignatureResult,
+        ).any { it is ValidationResult.Failure }
+
+        updateState {
+            it.copy(
+                accountName = state.value.accountName.fromValidationResult(accountNameResult),
+                displayName = state.value.displayName.fromValidationResult(displayNameResult),
+                emailSignature = state.value.emailSignature.fromValidationResult(emailSignatureResult),
+            )
+        }
+
+        if (!hasError) {
+            navigateNext()
+        }
     }
 
     private fun navigateBack() = emitEffect(Effect.NavigateBack)

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -14,11 +14,14 @@
     <string name="account_setup_options_top_bar_title">Account options</string>
     <string name="account_setup_options_section_display_options">Display options</string>
     <string name="account_setup_options_account_name_label">Account name</string>
+    <string name="account_setup_options_account_name_error_blank">Account name can\'t be blank.</string>
     <string name="account_setup_options_display_name_label">Display name</string>
+    <string name="account_setup_options_display_name_error_required">Display name is required.</string>
     <string name="account_setup_options_email_signature_label">Email signature</string>
+    <string name="account_setup_options_email_signature_error_blank">Email signature name can\'t be blank.</string>
     <string name="account_setup_options_section_sync_options_">Sync options</string>
     <string name="account_setup_options_account_check_frequency_label">Check frequency</string>
-    <string name="account_setup_options_email_check_frequency_zero">Never</string>
+    <string name="account_setup_options_email_check_frequency_never">Never</string>
     <string name="account_setup_options_email_display_count_label">Number of messages to display</string>
     <string name="account_setup_options_show_notifications_label">Show notifications</string>
 </resources>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName.ValidateAccountNameError
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -18,14 +19,12 @@ class ValidateAccountNameTest {
     }
 
     @Test
-    fun `should fail when account name is empty`() {
+    fun `should succeed when account name is empty`() {
         val useCase = ValidateAccountName()
 
         val result = useCase.execute("")
 
-        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
-            .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateAccountName.EmptyAccountName::class)
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
     }
 
     @Test
@@ -36,6 +35,6 @@ class ValidateAccountNameTest {
 
         assertThat(result).isInstanceOf(ValidationResult.Failure::class)
             .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateAccountName.EmptyAccountName::class)
+            .isInstanceOf(ValidateAccountNameError.BlankAccountName::class)
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.ValidateDisplayNameError
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -25,7 +26,7 @@ class ValidateDisplayNameTest {
 
         assertThat(result).isInstanceOf(ValidationResult.Failure::class)
             .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateDisplayName.EmptyDisplayName::class)
+            .isInstanceOf(ValidateDisplayNameError.EmptyDisplayName::class)
     }
 
     @Test
@@ -36,6 +37,6 @@ class ValidateDisplayNameTest {
 
         assertThat(result).isInstanceOf(ValidationResult.Failure::class)
             .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateDisplayName.EmptyDisplayName::class)
+            .isInstanceOf(ValidateDisplayNameError.EmptyDisplayName::class)
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -18,14 +19,12 @@ class ValidateEmailSignatureTest {
     }
 
     @Test
-    fun `should fail when email signature is empty`() {
+    fun `should succeed when email signature is empty`() {
         val useCase = ValidateEmailSignature()
 
         val result = useCase.execute("")
 
-        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
-            .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateEmailSignature.EmptyEmailSignature::class)
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
     }
 
     @Test
@@ -36,6 +35,6 @@ class ValidateEmailSignatureTest {
 
         assertThat(result).isInstanceOf(ValidationResult.Failure::class)
             .prop(ValidationResult.Failure::error)
-            .isInstanceOf(ValidateEmailSignature.EmptyEmailSignature::class)
+            .isInstanceOf(ValidateEmailSignatureError.BlankEmailSignature::class)
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsValidator.kt
@@ -1,0 +1,14 @@
+package app.k9mail.feature.account.setup.ui.options
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract.Validator
+
+internal class FakeAccountOptionsValidator(
+    private val accountNameAnswer: ValidationResult = ValidationResult.Success,
+    private val displayNameAnswer: ValidationResult = ValidationResult.Success,
+    private val emailSignatureAnswer: ValidationResult = ValidationResult.Success,
+) : Validator {
+    override fun validateAccountName(accountName: String): ValidationResult = accountNameAnswer
+    override fun validateDisplayName(displayName: String): ValidationResult = displayNameAnswer
+    override fun validateEmailSignature(emailSignature: String): ValidationResult = emailSignatureAnswer
+}


### PR DESCRIPTION
This changes the validaton approach a bit by using a ValidationError interface istead of Exceptions. This gives more freedom to handle error states as sealed interfaces or classes for exhaustive handling.

Updates AccountSetupOptions to use validation on submit.
