### PR TITLE
Fix recipients being displayed multiple times

### DIFF
--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -19,13 +19,16 @@ class DisplayRecipientsExtractorTest {
 
     private val recipientFormatter = object : MessageViewRecipientFormatter {
         override fun getDisplayName(address: Address, account: Account): CharSequence {
-            return when (address.address) {
-                IDENTITY_ADDRESS -> "me"
-                "user1@domain.example" -> "Contact One"
-                "user2@domain.example" -> "Contact Two"
-                "user3@domain.example" -> "Contact Three"
-                "user4@domain.example" -> "Contact Four"
-                else -> address.personal ?: address.address
+            return if (account.isAnIdentity(address)) {
+                "me"
+            } else {
+                when (address.address) {
+                    "user1@domain.example" -> "Contact One"
+                    "user2@domain.example" -> "Contact Two"
+                    "user3@domain.example" -> "Contact Three"
+                    "user4@domain.example" -> "Contact Four"
+                    else -> address.personal ?: address.address
+                }
             }
         }
     }

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -49,6 +49,45 @@ class DisplayRecipientsExtractorTest {
     }
 
     @Test
+    fun `single recipient is identity address with different local part case`() {
+        val message = buildMessage {
+            header("To", "Test User <ME@domain.example>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("me"), numberOfRecipients = 1),
+        )
+    }
+
+    @Test
+    fun `single recipient is identity address with different domain case`() {
+        val message = buildMessage {
+            header("To", "Test User <me@DOMAIN.EXAMPLE>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("me"), numberOfRecipients = 1),
+        )
+    }
+
+    @Test
+    fun `single recipient is identity address with different local part and domain case`() {
+        val message = buildMessage {
+            header("To", "Test User <ME@DOMAIN.EXAMPLE>")
+        }
+
+        val displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account)
+
+        assertThat(displayRecipients).isEqualTo(
+            DisplayRecipients(recipientNames = listOf("me"), numberOfRecipients = 1),
+        )
+    }
+
+    @Test
     fun `single recipient is a contact`() {
         val message = buildMessage {
             header("To", "User 1 <user1@domain.example>")


### PR DESCRIPTION
The problem was caused by inconsistent email address equality checks. This change leaves the comparison to `Account.isAnIdentity()`.

Fixes #6933