### PR TITLE
Add account setup outgoing config validation

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -4,16 +4,23 @@ import app.k9mail.feature.account.setup.ui.AccountSetupViewModel
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsContract
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsValidator
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsViewModel
+import app.k9mail.feature.account.setup.ui.outgoing.AccountOutgoingConfigContract
+import app.k9mail.feature.account.setup.ui.outgoing.AccountOutgoingConfigValidator
 import app.k9mail.feature.account.setup.ui.outgoing.AccountOutgoingConfigViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val featureAccountSetupModule: Module = module {
+    factory<AccountOutgoingConfigContract.Validator> { AccountOutgoingConfigValidator() }
     factory<AccountOptionsContract.Validator> { AccountOptionsValidator() }
 
     viewModel { AccountSetupViewModel() }
-    viewModel { AccountOutgoingConfigViewModel() }
+    viewModel {
+        AccountOutgoingConfigViewModel(
+            validator = get(),
+        )
+    }
     viewModel {
         AccountOptionsViewModel(
             validator = get(),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePassword.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePassword.kt
@@ -1,0 +1,21 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidatePassword : ValidationUseCase<String> {
+
+    // TODO change behavior to allow empty password when no password is required based on auth type
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(ValidatePasswordError.EmptyPassword)
+
+            else -> ValidationResult.Success
+        }
+    }
+
+    sealed interface ValidatePasswordError : ValidationError {
+        object EmptyPassword : ValidatePasswordError
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
@@ -1,0 +1,27 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidatePort : ValidationUseCase<Long?> {
+
+    override fun execute(input: Long?): ValidationResult {
+        return when {
+            input == null -> ValidationResult.Failure(ValidatePortError.EmptyPort)
+            input < MIN_PORT_NUMBER -> ValidationResult.Failure(ValidatePortError.InvalidPort)
+            input > MAX_PORT_NUMBER -> ValidationResult.Failure(ValidatePortError.InvalidPort)
+            else -> ValidationResult.Success
+        }
+    }
+
+    sealed interface ValidatePortError : ValidationError {
+        object EmptyPort : ValidatePortError
+        object InvalidPort : ValidatePortError
+    }
+
+    companion object {
+        const val MAX_PORT_NUMBER = 65535
+        const val MIN_PORT_NUMBER = 0
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
@@ -7,11 +7,10 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 class ValidatePort : ValidationUseCase<Long?> {
 
     override fun execute(input: Long?): ValidationResult {
-        return when {
-            input == null -> ValidationResult.Failure(ValidatePortError.EmptyPort)
-            input < MIN_PORT_NUMBER -> ValidationResult.Failure(ValidatePortError.InvalidPort)
-            input > MAX_PORT_NUMBER -> ValidationResult.Failure(ValidatePortError.InvalidPort)
-            else -> ValidationResult.Success
+        return when (input) {
+            null -> ValidationResult.Failure(ValidatePortError.EmptyPort)
+            in MIN_PORT_NUMBER..MAX_PORT_NUMBER -> ValidationResult.Success
+            else -> ValidationResult.Failure(ValidatePortError.InvalidPort)
         }
     }
 
@@ -22,6 +21,6 @@ class ValidatePort : ValidationUseCase<Long?> {
 
     companion object {
         const val MAX_PORT_NUMBER = 65535
-        const val MIN_PORT_NUMBER = 0
+        const val MIN_PORT_NUMBER = 1
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServer.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServer.kt
@@ -1,0 +1,20 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidateServer : ValidationUseCase<String> {
+
+    // TODO validate domain, ip4 or ip6
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(ValidateServerError.EmptyServer)
+            else -> ValidationResult.Success
+        }
+    }
+
+    sealed interface ValidateServerError : ValidationError {
+        object EmptyServer : ValidateServerError
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsername.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsername.kt
@@ -1,0 +1,20 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
+
+class ValidateUsername : ValidationUseCase<String> {
+
+    override fun execute(input: String): ValidationResult {
+        return when {
+            input.isBlank() -> ValidationResult.Failure(ValidateUsernameError.EmptyUsername)
+
+            else -> ValidationResult.Success
+        }
+    }
+
+    sealed interface ValidateUsernameError : ValidationError {
+        object EmptyUsername : ValidateUsernameError
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContent.kt
@@ -63,8 +63,10 @@ internal fun AccountOutgoingConfigContent(
             item {
                 TextInput(
                     text = state.server.value,
+                    errorMessage = state.server.error?.toResourceString(resources),
                     onTextChange = { onEvent(Event.ServerChanged(it)) },
                     label = stringResource(id = R.string.account_setup_outgoing_config_server_label),
+                    isRequired = true,
                     contentPadding = defaultItemPadding(),
                 )
             }
@@ -83,8 +85,10 @@ internal fun AccountOutgoingConfigContent(
             item {
                 NumberInput(
                     value = state.port.value,
+                    errorMessage = state.port.error?.toResourceString(resources),
                     onValueChange = { onEvent(Event.PortChanged(it)) },
                     label = stringResource(id = R.string.account_setup_outgoing_config_port_label),
+                    isRequired = true,
                     contentPadding = defaultItemPadding(),
                 )
             }
@@ -92,8 +96,10 @@ internal fun AccountOutgoingConfigContent(
             item {
                 TextInput(
                     text = state.username.value,
+                    errorMessage = state.username.error?.toResourceString(resources),
                     onTextChange = { onEvent(Event.UsernameChanged(it)) },
                     label = stringResource(id = R.string.account_setup_outgoing_config_username_label),
+                    isRequired = true,
                     contentPadding = defaultItemPadding(),
                 )
             }
@@ -101,7 +107,9 @@ internal fun AccountOutgoingConfigContent(
             item {
                 PasswordInput(
                     password = state.password.value,
+                    errorMessage = state.password.error?.toResourceString(resources),
                     onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
+                    isRequired = true,
                     contentPadding = defaultItemPadding(),
                 )
             }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.setup.ui.outgoing
 
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.account.setup.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.setup.domain.entity.toSmtpDefaultPort
@@ -39,5 +40,13 @@ interface AccountOutgoingConfigContract {
     sealed class Effect {
         object NavigateNext : Effect()
         object NavigateBack : Effect()
+    }
+
+    interface Validator {
+        fun validateServer(server: String): ValidationResult
+
+        fun validatePort(port: Long?): ValidationResult
+        fun validateUsername(username: String): ValidationResult
+        fun validatePassword(password: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigScreen.kt
@@ -27,7 +27,7 @@ fun AccountOutgoingConfigScreen(
             Effect.NavigateBack -> onBack()
             Effect.NavigateNext -> onNext()
         }
-    }	
+    }
 
     Scaffold(
         topBar = {
@@ -60,7 +60,9 @@ internal fun AccountOutgoingConfigScreenK9Preview() {
         AccountOutgoingConfigScreen(
             onNext = {},
             onBack = {},
-            viewModel = AccountOutgoingConfigViewModel(),
+            viewModel = AccountOutgoingConfigViewModel(
+                validator = AccountOutgoingConfigValidator(),
+            ),
         )
     }
 }
@@ -72,7 +74,9 @@ internal fun AccountOutgoingConfigScreenThunderbirdPreview() {
         AccountOutgoingConfigScreen(
             onNext = {},
             onBack = {},
-            viewModel = AccountOutgoingConfigViewModel(),
+            viewModel = AccountOutgoingConfigViewModel(
+                validator = AccountOutgoingConfigValidator(),
+            ),
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigValidator.kt
@@ -1,0 +1,30 @@
+package app.k9mail.feature.account.setup.ui.outgoing
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidatePassword
+import app.k9mail.feature.account.setup.domain.usecase.ValidatePort
+import app.k9mail.feature.account.setup.domain.usecase.ValidateServer
+import app.k9mail.feature.account.setup.domain.usecase.ValidateUsername
+
+class AccountOutgoingConfigValidator(
+    private val serverValidator: ValidateServer = ValidateServer(),
+    private val portValidator: ValidatePort = ValidatePort(),
+    private val usernameValidator: ValidateUsername = ValidateUsername(),
+    private val passwordValidator: ValidatePassword = ValidatePassword(),
+) : AccountOutgoingConfigContract.Validator {
+    override fun validateServer(server: String): ValidationResult {
+        return serverValidator.execute(server)
+    }
+
+    override fun validatePort(port: Long?): ValidationResult {
+        return portValidator.execute(port)
+    }
+
+    override fun validateUsername(username: String): ValidationResult {
+        return usernameValidator.execute(username)
+    }
+
+    override fun validatePassword(password: String): ValidationResult {
+        return passwordValidator.execute(password)
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingStringMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingStringMapper.kt
@@ -1,13 +1,64 @@
 package app.k9mail.feature.account.setup.ui.outgoing
 
 import android.content.res.Resources
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
 import app.k9mail.feature.account.setup.R
 import app.k9mail.feature.account.setup.domain.entity.ConnectionSecurity
+import app.k9mail.feature.account.setup.domain.usecase.ValidatePassword.ValidatePasswordError
+import app.k9mail.feature.account.setup.domain.usecase.ValidatePort.ValidatePortError
+import app.k9mail.feature.account.setup.domain.usecase.ValidateServer.ValidateServerError
+import app.k9mail.feature.account.setup.domain.usecase.ValidateUsername.ValidateUsernameError
 
 internal fun ConnectionSecurity.toResourceString(resources: Resources): String {
     return when (this) {
         ConnectionSecurity.None -> resources.getString(R.string.account_setup_outgoing_config_security_none)
         ConnectionSecurity.StartTLS -> resources.getString(R.string.account_setup_outgoing_config_security_start_tls)
         ConnectionSecurity.TLS -> resources.getString(R.string.account_setup_outgoing_config_security_ssl)
+    }
+}
+
+internal fun ValidationError.toResourceString(resources: Resources): String {
+    return when (this) {
+        is ValidateServerError -> toServerErrorString(resources)
+        is ValidatePortError -> toPortErrorString(resources)
+        is ValidateUsernameError -> toUsernameErrorString(resources)
+        is ValidatePasswordError -> toPasswordErrorString(resources)
+        else -> throw IllegalArgumentException("Unknown error: $this")
+    }
+}
+
+private fun ValidateServerError.toServerErrorString(resources: Resources): String {
+    return when (this) {
+        is ValidateServerError.EmptyServer -> resources.getString(
+            R.string.account_setup_outgoing_config_server_error_required,
+        )
+    }
+}
+
+private fun ValidatePortError.toPortErrorString(resources: Resources): String {
+    return when (this) {
+        is ValidatePortError.EmptyPort -> resources.getString(
+            R.string.account_setup_outgoing_config_port_error_required,
+        )
+
+        is ValidatePortError.InvalidPort -> resources.getString(
+            R.string.account_setup_outgoing_config_port_error_invalid,
+        )
+    }
+}
+
+private fun ValidateUsernameError.toUsernameErrorString(resources: Resources): String {
+    return when (this) {
+        ValidateUsernameError.EmptyUsername -> resources.getString(
+            R.string.account_setup_outgoing_config_username_error_required,
+        )
+    }
+}
+
+private fun ValidatePasswordError.toPasswordErrorString(resources: Resources): String {
+    return when (this) {
+        ValidatePasswordError.EmptyPassword -> resources.getString(
+            R.string.account_setup_outgoing_config_password_error_required,
+        )
     }
 }

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -11,18 +11,23 @@
 
     <string name="account_setup_outgoing_config_top_bar_title">Outgoing server settings</string>
     <string name="account_setup_outgoing_config_server_label">Server</string>
+    <string name="account_setup_outgoing_config_server_error_required">Server name is required.</string>
     <string name="account_setup_outgoing_config_security_label">Security</string>
     <string name="account_setup_outgoing_config_security_none">None</string>
     <string name="account_setup_outgoing_config_security_ssl">SSL/TLS</string>
     <string name="account_setup_outgoing_config_security_start_tls">StartTLS</string>
     <string name="account_setup_outgoing_config_port_label">Port</string>
+    <string name="account_setup_outgoing_config_port_error_required">Port is required.</string>
+    <string name="account_setup_outgoing_config_port_error_invalid">Port is invalid (0–65535).</string>
     <string name="account_setup_outgoing_config_username_label">Username</string>
+    <string name="account_setup_outgoing_config_username_error_required">Username is required.</string>
+    <string name="account_setup_outgoing_config_password_error_required">Password is required.</string>
     <string name="account_setup_outgoing_config_client_certificate_label">Client certificate</string>
     <string name="account_setup_outgoing_config_client_certificate_none_available">None available</string>
     <string name="account_setup_outgoing_config_imap_namespace_label">Auto-detect IMAP namespace</string>
     <string name="account_setup_outgoing_config_compression_label">Use compression</string>
 
-	<string name="account_setup_options_top_bar_title">Account options</string>
+    <string name="account_setup_options_top_bar_title">Account options</string>
     <string name="account_setup_options_section_display_options">Display options</string>
     <string name="account_setup_options_account_name_label">Account name</string>
     <string name="account_setup_options_account_name_error_blank">Account name can\'t be blank.</string>

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="account_setup_outgoing_config_security_start_tls">StartTLS</string>
     <string name="account_setup_outgoing_config_port_label">Port</string>
     <string name="account_setup_outgoing_config_port_error_required">Port is required.</string>
-    <string name="account_setup_outgoing_config_port_error_invalid">Port is invalid (0–65535).</string>
+    <string name="account_setup_outgoing_config_port_error_invalid">Port is invalid (must be 1–65535).</string>
     <string name="account_setup_outgoing_config_username_label">Username</string>
     <string name="account_setup_outgoing_config_username_error_required">Username is required.</string>
     <string name="account_setup_outgoing_config_password_error_required">Password is required.</string>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePasswordTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePasswordTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidatePasswordTest {
+
+    @Test
+    fun `should succeed when password is set`() {
+        val useCase = ValidatePassword()
+
+        val result = useCase.execute("password")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when password is empty`() {
+        val useCase = ValidatePassword()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePassword.ValidatePasswordError.EmptyPassword::class)
+    }
+
+    @Test
+    fun `should fail when password is blank`() {
+        val useCase = ValidatePassword()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePassword.ValidatePasswordError.EmptyPassword::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
@@ -1,0 +1,53 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import app.k9mail.feature.account.setup.domain.usecase.ValidatePort.ValidatePortError
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidatePortTest {
+
+    @Test
+    fun `should succeed when port is set`() {
+        val useCase = ValidatePort()
+
+        val result = useCase.execute(123L)
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when port is negative`() {
+        val useCase = ValidatePort()
+
+        val result = useCase.execute(-1L)
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePortError.InvalidPort::class)
+    }
+
+    @Test
+    fun `should fail when port exceeds maximum`() {
+        val useCase = ValidatePort()
+
+        val result = useCase.execute(65536L)
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePortError.InvalidPort::class)
+    }
+
+    @Test
+    fun `should fail when port is null`() {
+        val useCase = ValidatePort()
+
+        val result = useCase.execute(null)
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePortError.EmptyPort::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
@@ -30,6 +30,17 @@ class ValidatePortTest {
     }
 
     @Test
+    fun `should fail when port is zero`() {
+        val useCase = ValidatePort()
+
+        val result = useCase.execute(0)
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidatePortError.InvalidPort::class)
+    }
+
+    @Test
     fun `should fail when port exceeds maximum`() {
         val useCase = ValidatePort()
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServerTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServerTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidateServerTest {
+
+    @Test
+    fun `should succeed when server is set`() {
+        val useCase = ValidateServer()
+
+        val result = useCase.execute("server")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when server is empty`() {
+        val useCase = ValidateServer()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateServer.ValidateServerError.EmptyServer::class)
+    }
+
+    @Test
+    fun `should fail when server is blank`() {
+        val useCase = ValidateServer()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateServer.ValidateServerError.EmptyServer::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsernameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsernameTest.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.Test
+
+class ValidateUsernameTest {
+
+    @Test
+    fun `should succeed when username is set`() {
+        val useCase = ValidateUsername()
+
+        val result = useCase.execute("username")
+
+        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+    }
+
+    @Test
+    fun `should fail when username is empty`() {
+        val useCase = ValidateUsername()
+
+        val result = useCase.execute("")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateUsername.ValidateUsernameError.EmptyUsername::class)
+    }
+
+    @Test
+    fun `should fail when username is blank`() {
+        val useCase = ValidateUsername()
+
+        val result = useCase.execute(" ")
+
+        assertThat(result).isInstanceOf(ValidationResult.Failure::class)
+            .prop(ValidationResult.Failure::error)
+            .isInstanceOf(ValidateUsername.ValidateUsernameError.EmptyUsername::class)
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/FakeAccountOutgoingConfigValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/FakeAccountOutgoingConfigValidator.kt
@@ -1,0 +1,15 @@
+package app.k9mail.feature.account.setup.ui.outgoing
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+
+class FakeAccountOutgoingConfigValidator(
+    private val serverAnswer: ValidationResult = ValidationResult.Success,
+    private val portAnswer: ValidationResult = ValidationResult.Success,
+    private val usernameAnswer: ValidationResult = ValidationResult.Success,
+    private val passwordAnswer: ValidationResult = ValidationResult.Success,
+) : AccountOutgoingConfigContract.Validator {
+    override fun validateServer(server: String): ValidationResult = serverAnswer
+    override fun validatePort(port: Long?): ValidationResult = portAnswer
+    override fun validateUsername(username: String): ValidationResult = usernameAnswer
+    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+}


### PR DESCRIPTION
Needs to be extended to match existing validation -> following pull-request.

Depends on #6951 
