### PR TITLE
Add `UserInputEmailAddressParser`

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/KoinModule.kt
@@ -16,4 +16,5 @@ val viewModule = module {
         K9WebViewClient(clipboardManager = get(), attachmentResolver, onPageFinishedListener)
     }
     factory { WebViewClientFactory() }
+    factory { UserInputEmailAddressParser() }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/UserInputEmailAddressParser.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/UserInputEmailAddressParser.kt
@@ -1,0 +1,31 @@
+package com.fsck.k9.view
+
+import com.fsck.k9.mail.Address
+import org.apache.james.mime4j.util.CharsetUtil
+
+/**
+ * Used to parse name & email address pairs entered by the user.
+ *
+ * TODO: Build a custom implementation that can deal with typical inputs from users who are not familiar with the
+ *  RFC 5322 address-list syntax. See (ignored) tests in `UserInputEmailAddressParserTest`.
+ */
+internal class UserInputEmailAddressParser {
+
+    @Throws(NonAsciiEmailAddressException::class)
+    fun parse(input: String): List<Address> {
+        return Address.parseUnencoded(input)
+            .mapNotNull { address ->
+                when {
+                    address.isIncomplete() -> null
+                    address.isNonAsciiAddress() -> throw NonAsciiEmailAddressException(address.address)
+                    else -> Address.parse(address.toEncodedString()).firstOrNull()
+                }
+            }
+    }
+
+    private fun Address.isIncomplete() = hostname.isNullOrBlank()
+
+    private fun Address.isNonAsciiAddress() = !CharsetUtil.isASCII(address)
+}
+
+internal class NonAsciiEmailAddressException(message: String) : Exception(message)

--- a/app/ui/legacy/src/test/java/com/fsck/k9/view/UserInputEmailAddressParserTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/view/UserInputEmailAddressParserTest.kt
@@ -1,0 +1,153 @@
+package com.fsck.k9.view
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isInstanceOf
+import com.fsck.k9.mail.Address
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+class UserInputEmailAddressParserTest {
+    private val parser = UserInputEmailAddressParser()
+
+    @Test
+    fun `plain email address`() {
+        val addresses = parser.parse("user@domain.example")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example"))
+    }
+
+    @Test
+    fun `email address followed by space`() {
+        val addresses = parser.parse("user@domain.example ")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example"))
+    }
+
+    @Test
+    fun `email address in angle brackets`() {
+        val addresses = parser.parse("<user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example"))
+    }
+
+    @Test
+    fun `simple name and address`() {
+        val addresses = parser.parse("Name <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Name"))
+    }
+
+    @Test
+    fun `name with quoted string and address`() {
+        val addresses = parser.parse("\"Name\" <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Name"))
+    }
+
+    @Test
+    fun `name with multiple words and address`() {
+        val addresses = parser.parse("Firstname Lastname <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Firstname Lastname"))
+    }
+
+    @Test
+    fun `name with non-ASCII characters and address`() {
+        val addresses = parser.parse("Käthe Gehäusegröße <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Käthe Gehäusegröße"))
+    }
+
+    @Test
+    fun `address with non-ASCII character in local part`() {
+        assertFailure {
+            parser.parse("müller@domain.example")
+        }.isInstanceOf<NonAsciiEmailAddressException>()
+    }
+
+    @Test
+    fun `address with non-ASCII character in domain part`() {
+        assertFailure {
+            parser.parse("user@dömain.example")
+        }.isInstanceOf<NonAsciiEmailAddressException>()
+    }
+
+    @Test
+    fun `multiple addresses separated by comma`() {
+        val addresses = parser.parse("one@domain.example,<two@domain.example>")
+
+        assertThat(addresses).containsExactly(
+            Address("one@domain.example"),
+            Address("two@domain.example"),
+        )
+    }
+
+    @Test
+    @Ignore("Currently not supported")
+    fun `multiple addresses separated by space`() {
+        val addresses = parser.parse("one@domain.example two@domain.example")
+
+        assertThat(addresses).containsExactly(
+            Address("one@domain.example"),
+            Address("two@domain.example"),
+        )
+    }
+
+    @Test
+    fun `multiple addresses in angle brackets separated by space`() {
+        val addresses = parser.parse("<one@domain.example>, <two@domain.example>")
+
+        assertThat(addresses).containsExactly(
+            Address("one@domain.example"),
+            Address("two@domain.example"),
+        )
+    }
+
+    @Test
+    fun `incomplete address should not return a result`() {
+        val addresses = parser.parse("user")
+
+        assertThat(addresses).isEmpty()
+    }
+
+    @Test
+    fun `incomplete address ending in @ should not return a result`() {
+        val addresses = parser.parse("user@")
+
+        assertThat(addresses).isEmpty()
+    }
+
+    @Test
+    fun `name and incomplete address should not return a result`() {
+        val addresses = parser.parse("Name <user")
+
+        assertThat(addresses).isEmpty()
+    }
+
+    @Test
+    @Ignore("Currently not supported")
+    fun `name followed by address not in angle brackets`() {
+        val addresses = parser.parse("Firstname Lastname user@domain.example")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Firstname LastName"))
+    }
+
+    @Test
+    @Ignore("Currently not supported")
+    fun `name containing parenthesis`() {
+        val addresses = parser.parse("Firstname (Nickname) Lastname <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Firstname (Nickname) LastName"))
+    }
+
+    @Test
+    @Ignore("Currently not supported")
+    fun `name containing double quotes in the middle`() {
+        val addresses = parser.parse("Firstname \"Nickname\" Lastname <user@domain.example>")
+
+        assertThat(addresses).containsExactly(Address("user@domain.example", "Firstname \"Nickname\" LastName"))
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -115,7 +115,8 @@ public class Address implements Serializable {
             for (Rfc822Token token : tokens) {
                 String address = token.getAddress();
                 if (!TextUtils.isEmpty(address)) {
-                    addresses.add(new Address(token.getAddress(), token.getName(), false));
+                    String name = TextUtils.isEmpty(token.getName()) ? null : token.getName();
+                    addresses.add(new Address(token.getAddress(), name, false));
                 }
             }
         }


### PR DESCRIPTION
Used to parse name and email address pairs entered by the user when composing a message. This can handle names containing non-ASCII characters while still not allowing email addresses containing non-ASCII characters.

It's not what we actually want. But it's better than what we have now.

Fixes #6843