### PR TITLE
Change use case to suspendable execution

### DIFF
--- a/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/UseCase.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/domain/usecase/UseCase.kt
@@ -1,5 +1,18 @@
 package app.k9mail.core.common.domain.usecase
 
-interface UseCase<T, R> {
-    fun execute(input: T): R
+/**
+ * A use case is a single action the user can trigger.
+ *
+ * @param INPUT The input type of the use case.
+ * @param RESULT The result type of the use case.
+ */
+interface UseCase<INPUT, RESULT> {
+
+    /**
+     * Executes the use case.
+     *
+     * @param input The input for the use case.
+     * @return The result of the use case.
+     */
+    suspend fun execute(input: INPUT): RESULT
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
@@ -5,7 +5,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidateAccountName : ValidationUseCase<String> {
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isEmpty() -> ValidationResult.Success
             input.isBlank() -> ValidationResult.Failure(ValidateAccountNameError.BlankAccountName)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidateDisplayName : ValidationUseCase<String> {
 
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isBlank() -> ValidationResult.Failure(ValidateDisplayNameError.EmptyDisplayName)
             else -> ValidationResult.Success

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddress.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddress.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 class ValidateEmailAddress : ValidationUseCase<String> {
 
     // TODO replace by new email validation
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isBlank() -> ValidationResult.Failure(ValidateEmailAddressError.EmptyEmailAddress)
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
@@ -8,7 +8,7 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.Va
 // TODO check signature for input validity
 class ValidateEmailSignature : ValidationUseCase<String> {
 
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isEmpty() -> ValidationResult.Success
             input.isBlank() -> ValidationResult.Failure(error = BlankEmailSignature)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateImapPrefix.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateImapPrefix.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidateImapPrefix : ValidationUseCase<String> {
 
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isEmpty() -> ValidationResult.Success
             input.isBlank() -> ValidationResult.Failure(ValidateImapPrefixError.BlankImapPrefix)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePassword.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePassword.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 class ValidatePassword : ValidationUseCase<String> {
 
     // TODO change behavior to allow empty password when no password is required based on auth type
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isBlank() -> ValidationResult.Failure(ValidatePasswordError.EmptyPassword)
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePort.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidatePort : ValidationUseCase<Long?> {
 
-    override fun execute(input: Long?): ValidationResult {
+    override suspend fun execute(input: Long?): ValidationResult {
         return when (input) {
             null -> ValidationResult.Failure(ValidatePortError.EmptyPort)
             in MIN_PORT_NUMBER..MAX_PORT_NUMBER -> ValidationResult.Success

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServer.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServer.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 class ValidateServer : ValidationUseCase<String> {
 
     // TODO validate domain, ip4 or ip6
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isBlank() -> ValidationResult.Failure(ValidateServerError.EmptyServer)
             else -> ValidationResult.Success

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsername.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsername.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationUseCase
 
 class ValidateUsername : ValidationUseCase<String> {
 
-    override fun execute(input: String): ValidationResult {
+    override suspend fun execute(input: String): ValidationResult {
         return when {
             input.isBlank() -> ValidationResult.Failure(ValidateUsernameError.EmptyUsername)
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigContract.kt
@@ -41,7 +41,7 @@ interface AccountAutoConfigContract {
     }
 
     interface Validator {
-        fun validateEmailAddress(emailAddress: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
+        suspend fun validateEmailAddress(emailAddress: String): ValidationResult
+        suspend fun validatePassword(password: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigValidator.kt
@@ -9,11 +9,11 @@ class AccountAutoConfigValidator(
     private val passwordValidator: ValidatePassword = ValidatePassword(),
 ) : AccountAutoConfigContract.Validator {
 
-    override fun validateEmailAddress(emailAddress: String): ValidationResult {
+    override suspend fun validateEmailAddress(emailAddress: String): ValidationResult {
         return emailAddressValidator.execute(emailAddress)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override suspend fun validatePassword(password: String): ValidationResult {
         return passwordValidator.execute(password)
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/AccountAutoConfigViewModel.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.setup.ui.autoconfig
 
+import androidx.lifecycle.viewModelScope
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.setup.domain.input.StringInputField
@@ -9,6 +10,7 @@ import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigContract.
 import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigContract.State
 import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigContract.Validator
 import app.k9mail.feature.account.setup.ui.autoconfig.AccountAutoConfigContract.ViewModel
+import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions")
 class AccountAutoConfigViewModel(
@@ -63,8 +65,8 @@ class AccountAutoConfigViewModel(
     }
 
     private fun submitEmail() {
-        with(state.value) {
-            val emailValidationResult = validator.validateEmailAddress(emailAddress.value)
+        viewModelScope.launch {
+            val emailValidationResult = validator.validateEmailAddress(state.value.emailAddress.value)
             val hasError = emailValidationResult is ValidationResult.Failure
 
             updateState {
@@ -77,9 +79,9 @@ class AccountAutoConfigViewModel(
     }
 
     private fun submitPassword() {
-        with(state.value) {
-            val emailValidationResult = validator.validateEmailAddress(emailAddress.value)
-            val passwordValidationResult = validator.validatePassword(password.value)
+        viewModelScope.launch {
+            val emailValidationResult = validator.validateEmailAddress(state.value.emailAddress.value)
+            val passwordValidationResult = validator.validatePassword(state.value.password.value)
             val hasError = listOf(emailValidationResult, passwordValidationResult)
                 .any { it is ValidationResult.Failure }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContract.kt
@@ -50,10 +50,10 @@ interface AccountIncomingConfigContract {
     }
 
     interface Validator {
-        fun validateServer(server: String): ValidationResult
-        fun validatePort(port: Long?): ValidationResult
-        fun validateUsername(username: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
-        fun validateImapPrefix(imapPrefix: String): ValidationResult
+        suspend fun validateServer(server: String): ValidationResult
+        suspend fun validatePort(port: Long?): ValidationResult
+        suspend fun validateUsername(username: String): ValidationResult
+        suspend fun validatePassword(password: String): ValidationResult
+        suspend fun validateImapPrefix(imapPrefix: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigValidator.kt
@@ -14,23 +14,23 @@ class AccountIncomingConfigValidator(
     private val passwordValidator: ValidatePassword = ValidatePassword(),
     private val imapPrefixValidator: ValidateImapPrefix = ValidateImapPrefix(),
 ) : AccountIncomingConfigContract.Validator {
-    override fun validateServer(server: String): ValidationResult {
+    override suspend fun validateServer(server: String): ValidationResult {
         return serverValidator.execute(server)
     }
 
-    override fun validatePort(port: Long?): ValidationResult {
+    override suspend fun validatePort(port: Long?): ValidationResult {
         return portValidator.execute(port)
     }
 
-    override fun validateUsername(username: String): ValidationResult {
+    override suspend fun validateUsername(username: String): ValidationResult {
         return usernameValidator.execute(username)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override suspend fun validatePassword(password: String): ValidationResult {
         return passwordValidator.execute(password)
     }
 
-    override fun validateImapPrefix(imapPrefix: String): ValidationResult {
+    override suspend fun validateImapPrefix(imapPrefix: String): ValidationResult {
         return imapPrefixValidator.execute(imapPrefix)
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContract.kt
@@ -39,8 +39,8 @@ interface AccountOptionsContract {
     }
 
     interface Validator {
-        fun validateAccountName(accountName: String): ValidationResult
-        fun validateDisplayName(displayName: String): ValidationResult
-        fun validateEmailSignature(emailSignature: String): ValidationResult
+        suspend fun validateAccountName(accountName: String): ValidationResult
+        suspend fun validateDisplayName(displayName: String): ValidationResult
+        suspend fun validateEmailSignature(emailSignature: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsValidator.kt
@@ -11,15 +11,15 @@ internal class AccountOptionsValidator(
     private val displayNameValidator: ValidateDisplayName = ValidateDisplayName(),
     private val emailSignatureValidator: ValidateEmailSignature = ValidateEmailSignature(),
 ) : Validator {
-    override fun validateAccountName(accountName: String): ValidationResult {
+    override suspend fun validateAccountName(accountName: String): ValidationResult {
         return accountNameValidator.execute(accountName)
     }
 
-    override fun validateDisplayName(displayName: String): ValidationResult {
+    override suspend fun validateDisplayName(displayName: String): ValidationResult {
         return displayNameValidator.execute(displayName)
     }
 
-    override fun validateEmailSignature(emailSignature: String): ValidationResult {
+    override suspend fun validateEmailSignature(emailSignature: String): ValidationResult {
         return emailSignatureValidator.execute(emailSignature)
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
@@ -43,9 +43,9 @@ interface AccountOutgoingConfigContract {
     }
 
     interface Validator {
-        fun validateServer(server: String): ValidationResult
-        fun validatePort(port: Long?): ValidationResult
-        fun validateUsername(username: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
+        suspend fun validateServer(server: String): ValidationResult
+        suspend fun validatePort(port: Long?): ValidationResult
+        suspend fun validateUsername(username: String): ValidationResult
+        suspend fun validatePassword(password: String): ValidationResult
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigValidator.kt
@@ -12,19 +12,19 @@ class AccountOutgoingConfigValidator(
     private val usernameValidator: ValidateUsername = ValidateUsername(),
     private val passwordValidator: ValidatePassword = ValidatePassword(),
 ) : AccountOutgoingConfigContract.Validator {
-    override fun validateServer(server: String): ValidationResult {
+    override suspend fun validateServer(server: String): ValidationResult {
         return serverValidator.execute(server)
     }
 
-    override fun validatePort(port: Long?): ValidationResult {
+    override suspend fun validatePort(port: Long?): ValidationResult {
         return portValidator.execute(port)
     }
 
-    override fun validateUsername(username: String): ValidationResult {
+    override suspend fun validateUsername(username: String): ValidationResult {
         return usernameValidator.execute(username)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override suspend fun validatePassword(password: String): ValidationResult {
         return passwordValidator.execute(password)
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
@@ -5,12 +5,15 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName.Valid
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateAccountNameTest {
 
     @Test
-    fun `should succeed when account name is set`() {
+    fun `should succeed when account name is set`() = runTest {
         val useCase = ValidateAccountName()
 
         val result = useCase.execute("account name")
@@ -19,7 +22,7 @@ class ValidateAccountNameTest {
     }
 
     @Test
-    fun `should succeed when account name is empty`() {
+    fun `should succeed when account name is empty`() = runTest {
         val useCase = ValidateAccountName()
 
         val result = useCase.execute("")
@@ -28,7 +31,7 @@ class ValidateAccountNameTest {
     }
 
     @Test
-    fun `should fail when account name is blank`() {
+    fun `should fail when account name is blank`() = runTest {
         val useCase = ValidateAccountName()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
@@ -5,12 +5,15 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.Valid
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateDisplayNameTest {
 
     @Test
-    fun `should succeed when display name is set`() {
+    fun `should succeed when display name is set`() = runTest {
         val useCase = ValidateDisplayName()
 
         val result = useCase.execute("display name")
@@ -19,7 +22,7 @@ class ValidateDisplayNameTest {
     }
 
     @Test
-    fun `should fail when display name is empty`() {
+    fun `should fail when display name is empty`() = runTest {
         val useCase = ValidateDisplayName()
 
         val result = useCase.execute("")
@@ -30,7 +33,7 @@ class ValidateDisplayNameTest {
     }
 
     @Test
-    fun `should fail when display name is blank`() {
+    fun `should fail when display name is blank`() = runTest {
         val useCase = ValidateDisplayName()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddressTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddressTest.kt
@@ -5,12 +5,15 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailAddress.Vali
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateEmailAddressTest {
 
     @Test
-    fun `should succeed when email address is valid`() {
+    fun `should succeed when email address is valid`() = runTest {
         val useCase = ValidateEmailAddress()
 
         val result = useCase.execute("test@example.com")
@@ -19,7 +22,7 @@ class ValidateEmailAddressTest {
     }
 
     @Test
-    fun `should fail when email address is blank`() {
+    fun `should fail when email address is blank`() = runTest {
         val useCase = ValidateEmailAddress()
 
         val result = useCase.execute(" ")
@@ -30,7 +33,7 @@ class ValidateEmailAddressTest {
     }
 
     @Test
-    fun `should fail when email address is invalid`() {
+    fun `should fail when email address is invalid`() = runTest {
         val useCase = ValidateEmailAddress()
 
         val result = useCase.execute("test")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
@@ -5,12 +5,15 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.Va
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateEmailSignatureTest {
 
     @Test
-    fun `should succeed when email signature is set`() {
+    fun `should succeed when email signature is set`() = runTest {
         val useCase = ValidateEmailSignature()
 
         val result = useCase.execute("email signature")
@@ -19,7 +22,7 @@ class ValidateEmailSignatureTest {
     }
 
     @Test
-    fun `should succeed when email signature is empty`() {
+    fun `should succeed when email signature is empty`() = runTest {
         val useCase = ValidateEmailSignature()
 
         val result = useCase.execute("")
@@ -28,7 +31,7 @@ class ValidateEmailSignatureTest {
     }
 
     @Test
-    fun `should fail when email signature is blank`() {
+    fun `should fail when email signature is blank`() = runTest {
         val useCase = ValidateEmailSignature()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateImapPrefixTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateImapPrefixTest.kt
@@ -4,21 +4,26 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateImapPrefixTest {
 
     @Test
-    fun `should success when imap prefix is set`() {
+    fun `should success when imap prefix is set`() = runTest {
         val useCase = ValidateImapPrefix()
 
         val result = useCase.execute("imap")
 
-        assertThat(result).isInstanceOf(ValidationResult.Success::class)
+        assertThat(result).isInstanceOf(
+            ValidationResult.Success::class,
+        )
     }
 
     @Test
-    fun `should succeed when imap prefix is empty`() {
+    fun `should succeed when imap prefix is empty`() = runTest {
         val useCase = ValidateImapPrefix()
 
         val result = useCase.execute("")
@@ -27,7 +32,7 @@ class ValidateImapPrefixTest {
     }
 
     @Test
-    fun `should fail when imap prefix is blank`() {
+    fun `should fail when imap prefix is blank`() = runTest {
         val useCase = ValidateImapPrefix()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePasswordTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePasswordTest.kt
@@ -4,12 +4,15 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidatePasswordTest {
 
     @Test
-    fun `should succeed when password is set`() {
+    fun `should succeed when password is set`() = runTest {
         val useCase = ValidatePassword()
 
         val result = useCase.execute("password")
@@ -18,7 +21,7 @@ class ValidatePasswordTest {
     }
 
     @Test
-    fun `should fail when password is empty`() {
+    fun `should fail when password is empty`() = runTest {
         val useCase = ValidatePassword()
 
         val result = useCase.execute("")
@@ -29,7 +32,7 @@ class ValidatePasswordTest {
     }
 
     @Test
-    fun `should fail when password is blank`() {
+    fun `should fail when password is blank`() = runTest {
         val useCase = ValidatePassword()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidatePortTest.kt
@@ -5,12 +5,15 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidatePort.ValidatePort
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidatePortTest {
 
     @Test
-    fun `should succeed when port is set`() {
+    fun `should succeed when port is set`() = runTest {
         val useCase = ValidatePort()
 
         val result = useCase.execute(123L)
@@ -19,7 +22,7 @@ class ValidatePortTest {
     }
 
     @Test
-    fun `should fail when port is negative`() {
+    fun `should fail when port is negative`() = runTest {
         val useCase = ValidatePort()
 
         val result = useCase.execute(-1L)
@@ -30,7 +33,7 @@ class ValidatePortTest {
     }
 
     @Test
-    fun `should fail when port is zero`() {
+    fun `should fail when port is zero`() = runTest {
         val useCase = ValidatePort()
 
         val result = useCase.execute(0)
@@ -41,7 +44,7 @@ class ValidatePortTest {
     }
 
     @Test
-    fun `should fail when port exceeds maximum`() {
+    fun `should fail when port exceeds maximum`() = runTest {
         val useCase = ValidatePort()
 
         val result = useCase.execute(65536L)
@@ -52,7 +55,7 @@ class ValidatePortTest {
     }
 
     @Test
-    fun `should fail when port is null`() {
+    fun `should fail when port is null`() = runTest {
         val useCase = ValidatePort()
 
         val result = useCase.execute(null)

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServerTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateServerTest.kt
@@ -4,12 +4,15 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateServerTest {
 
     @Test
-    fun `should succeed when server is set`() {
+    fun `should succeed when server is set`() = runTest {
         val useCase = ValidateServer()
 
         val result = useCase.execute("server")
@@ -18,7 +21,7 @@ class ValidateServerTest {
     }
 
     @Test
-    fun `should fail when server is empty`() {
+    fun `should fail when server is empty`() = runTest {
         val useCase = ValidateServer()
 
         val result = useCase.execute("")
@@ -29,7 +32,7 @@ class ValidateServerTest {
     }
 
     @Test
-    fun `should fail when server is blank`() {
+    fun `should fail when server is blank`() = runTest {
         val useCase = ValidateServer()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsernameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateUsernameTest.kt
@@ -4,12 +4,15 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ValidateUsernameTest {
 
     @Test
-    fun `should succeed when username is set`() {
+    fun `should succeed when username is set`() = runTest {
         val useCase = ValidateUsername()
 
         val result = useCase.execute("username")
@@ -18,7 +21,7 @@ class ValidateUsernameTest {
     }
 
     @Test
-    fun `should fail when username is empty`() {
+    fun `should fail when username is empty`() = runTest {
         val useCase = ValidateUsername()
 
         val result = useCase.execute("")
@@ -29,7 +32,7 @@ class ValidateUsernameTest {
     }
 
     @Test
-    fun `should fail when username is blank`() {
+    fun `should fail when username is blank`() = runTest {
         val useCase = ValidateUsername()
 
         val result = useCase.execute(" ")

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/FakeAccountAutoConfigValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autoconfig/FakeAccountAutoConfigValidator.kt
@@ -6,6 +6,6 @@ class FakeAccountAutoConfigValidator(
     private val emailAddressAnswer: ValidationResult = ValidationResult.Success,
     private val passwordAnswer: ValidationResult = ValidationResult.Success,
 ) : AccountAutoConfigContract.Validator {
-    override fun validateEmailAddress(emailAddress: String): ValidationResult = emailAddressAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override suspend fun validateEmailAddress(emailAddress: String): ValidationResult = emailAddressAnswer
+    override suspend fun validatePassword(password: String): ValidationResult = passwordAnswer
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/FakeAccountIncomingConfigValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/FakeAccountIncomingConfigValidator.kt
@@ -9,9 +9,9 @@ class FakeAccountIncomingConfigValidator(
     private val passwordAnswer: ValidationResult = ValidationResult.Success,
     private val imapPrefixAnswer: ValidationResult = ValidationResult.Success,
 ) : AccountIncomingConfigContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
-    override fun validateImapPrefix(imapPrefix: String): ValidationResult = imapPrefixAnswer
+    override suspend fun validateServer(server: String): ValidationResult = serverAnswer
+    override suspend fun validatePort(port: Long?): ValidationResult = portAnswer
+    override suspend fun validateUsername(username: String): ValidationResult = usernameAnswer
+    override suspend fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override suspend fun validateImapPrefix(imapPrefix: String): ValidationResult = imapPrefixAnswer
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/FakeAccountOptionsValidator.kt
@@ -8,7 +8,7 @@ internal class FakeAccountOptionsValidator(
     private val displayNameAnswer: ValidationResult = ValidationResult.Success,
     private val emailSignatureAnswer: ValidationResult = ValidationResult.Success,
 ) : Validator {
-    override fun validateAccountName(accountName: String): ValidationResult = accountNameAnswer
-    override fun validateDisplayName(displayName: String): ValidationResult = displayNameAnswer
-    override fun validateEmailSignature(emailSignature: String): ValidationResult = emailSignatureAnswer
+    override suspend fun validateAccountName(accountName: String): ValidationResult = accountNameAnswer
+    override suspend fun validateDisplayName(displayName: String): ValidationResult = displayNameAnswer
+    override suspend fun validateEmailSignature(emailSignature: String): ValidationResult = emailSignatureAnswer
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/FakeAccountOutgoingConfigValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/FakeAccountOutgoingConfigValidator.kt
@@ -8,8 +8,8 @@ class FakeAccountOutgoingConfigValidator(
     private val usernameAnswer: ValidationResult = ValidationResult.Success,
     private val passwordAnswer: ValidationResult = ValidationResult.Success,
 ) : AccountOutgoingConfigContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override suspend fun validateServer(server: String): ValidationResult = serverAnswer
+    override suspend fun validatePort(port: Long?): ValidationResult = portAnswer
+    override suspend fun validateUsername(username: String): ValidationResult = usernameAnswer
+    override suspend fun validatePassword(password: String): ValidationResult = passwordAnswer
 }


### PR DESCRIPTION
When using more complex validation methods, it could take some time to execute. To safeguard this, all use case execution is changed to supending functions. This moves the thread handling responsibility to the caller.
