### PR TITLE
Inconsistent recipient names when composing a message

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -72,7 +72,6 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
     private static final String[] PROJECTION_NICKNAME = {
             ContactsContract.Data.CONTACT_ID,
-            ContactsContract.CommonDataKinds.Nickname.NAME
     };
 
     private static final int INDEX_CONTACT_ID_FOR_NICKNAME = 0;
@@ -377,8 +376,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
                 Cursor cursor = contentResolver
                         .query(queryUri, PROJECTION, selection, new String[] { id }, SORT_ORDER);
 
-                String contactNickname = nicknameCursor.getString(INDEX_NICKNAME);
-                fillContactDataFromCursor(cursor, recipients, recipientMap, contactNickname, null);
+                fillContactDataFromCursor(cursor, recipients, recipientMap, null);
 
                 hasContact = true;
             }
@@ -403,7 +401,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
             return recipients;
         }
 
-        fillContactDataFromCursor(cursor, recipients, new HashMap<>(), null, maxRecipients);
+        fillContactDataFromCursor(cursor, recipients, new HashMap<>(), maxRecipients);
 
         return recipients;
     }
@@ -437,14 +435,14 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
     private void fillContactDataFromCursor(Cursor cursor, List<Recipient> recipients,
             Map<String, Recipient> recipientMap) {
-        fillContactDataFromCursor(cursor, recipients, recipientMap, null, null);
+        fillContactDataFromCursor(cursor, recipients, recipientMap, null);
     }
 
     private void fillContactDataFromCursor(Cursor cursor, List<Recipient> recipients,
-            Map<String, Recipient> recipientMap, @Nullable String prefilledName, @Nullable Integer maxRecipients) {
+            Map<String, Recipient> recipientMap, @Nullable Integer maxRecipients) {
 
         while (cursor.moveToNext() && (maxRecipients == null || recipients.size() < maxRecipients)) {
-            String name = prefilledName != null ? prefilledName : cursor.getString(INDEX_NAME);
+            String name = cursor.getString(INDEX_NAME);
 
             String email = cursor.getString(INDEX_EMAIL);
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -75,7 +75,6 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     };
 
     private static final int INDEX_CONTACT_ID_FOR_NICKNAME = 0;
-    private static final int INDEX_NICKNAME = 1;
 
     private static final String[] PROJECTION_CRYPTO_ADDRESSES = {
             "address",
@@ -443,7 +442,6 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
         while (cursor.moveToNext() && (maxRecipients == null || recipients.size() < maxRecipients)) {
             String name = cursor.getString(INDEX_NAME);
-
             String email = cursor.getString(INDEX_EMAIL);
 
             // already exists? just skip then

--- a/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -49,8 +49,7 @@ public class RecipientLoaderTest extends RobolectricTest {
             ContactsContract.Contacts.STARRED
     };
     static final String[] PROJECTION_NICKNAME = {
-            ContactsContract.Data.CONTACT_ID,
-            ContactsContract.CommonDataKinds.Nickname.NAME
+            ContactsContract.Data.CONTACT_ID
     };
     static final String[] PROJECTION_CRYPTO_ADDRESSES = { "address", "uid_address" };
     static final String[] PROJECTION_CRYPTO_STATUS = { "address", "uid_key_status", "autocrypt_key_status" };
@@ -66,7 +65,7 @@ public class RecipientLoaderTest extends RobolectricTest {
     static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED =
             new String[] { "0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2",
                     null, "0", "Eve", "0" };
-    static final String[] NICKNAME_NOT_CONTACTED = new String[] { "2", "Eves_Nickname_Bob" };
+    static final String[] NICKNAME_NOT_CONTACTED = new String[] { "2" };
 
     static final String QUERYSTRING = "querystring";
 


### PR DESCRIPTION
fixes https://github.com/thundernest/k-9/issues/6816
### PR Description
This PR ensures that the recipient's name is consistent when composing a message regardless of whether they are found using a nickname or not


### Steps to reproduce

1. Have a contact with the nickname different from the name.
2. Create a new message in K9
3. Start typing in "To"

### Issue loom
https://www.loom.com/share/429b833c1d8c46c4aeeaaae1902f0459

### Fix loom
https://www.loom.com/share/554b780adeb14b0aa0e4b3579b17ec55

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
