### PR TITLE
Change input to allow booleans with error

### DIFF
--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/ButtonItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/ButtonItems.kt
@@ -1,9 +1,11 @@
 package app.k9mail.ui.catalog.ui.atom.items
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonOutlined
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
@@ -11,34 +13,38 @@ import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.ui.catalog.ui.common.list.itemDefaultPadding
 import app.k9mail.ui.catalog.ui.common.list.sectionHeaderItem
 
+@OptIn(ExperimentalLayoutApi::class)
 fun LazyGridScope.buttonItems() {
     sectionHeaderItem(text = "Buttons - Filled")
     item {
-        Row(
+        FlowRow(
             horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
             modifier = Modifier.itemDefaultPadding(),
         ) {
             Button(text = "Enabled", onClick = { })
+            Button(text = "Colored", onClick = { }, color = Color.Magenta)
             Button(text = "Disabled", onClick = { }, enabled = false)
         }
     }
     sectionHeaderItem(text = "Buttons - Outlined")
     item {
-        Row(
+        FlowRow(
             horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
             modifier = Modifier.itemDefaultPadding(),
         ) {
             ButtonOutlined(text = "Enabled", onClick = { })
+            ButtonOutlined(text = "Colored", onClick = { }, color = Color.Magenta)
             ButtonOutlined(text = "Disabled", onClick = { }, enabled = false)
         }
     }
     sectionHeaderItem(text = "Buttons - Text only")
     item {
-        Row(
+        FlowRow(
             horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
             modifier = Modifier.itemDefaultPadding(),
         ) {
             ButtonText(text = "Enabled", onClick = { })
+            ButtonText(text = "Colored", onClick = { }, color = Color.Magenta)
             ButtonText(text = "Disabled", onClick = { }, enabled = false)
         }
     }

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/molecule/items/InputItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/molecule/items/InputItems.kt
@@ -131,6 +131,7 @@ fun LazyGridScope.inputItems() {
     }
 
     sectionHeaderItem(text = "CheckboxInput")
+    sectionSubtitleItem(text = "Default")
     item {
         ItemOutlined {
             WithRememberedState(input = false) { state ->
@@ -142,8 +143,22 @@ fun LazyGridScope.inputItems() {
             }
         }
     }
+    sectionSubtitleItem(text = "With error")
+    item {
+        ItemOutlined {
+            WithRememberedState(input = false) { state ->
+                CheckboxInput(
+                    text = "Check the box",
+                    checked = state.value,
+                    onCheckedChange = { state.value = it },
+                    errorMessage = "Checkbox must be checked",
+                )
+            }
+        }
+    }
 
     sectionHeaderItem(text = "SwitchInput")
+    sectionSubtitleItem(text = "Default")
     item {
         ItemOutlined {
             WithRememberedState(input = false) { state ->
@@ -151,6 +166,19 @@ fun LazyGridScope.inputItems() {
                     text = "Switch the toggle",
                     checked = state.value,
                     onCheckedChange = { state.value = it },
+                )
+            }
+        }
+    }
+    sectionSubtitleItem(text = "With error")
+    item {
+        ItemOutlined {
+            WithRememberedState(input = false) { state ->
+                SwitchInput(
+                    text = "Switch the toggle",
+                    checked = state.value,
+                    onCheckedChange = { state.value = it },
+                    errorMessage = "Switch must be checked",
                 )
             }
         }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -792,7 +792,7 @@ style:
 Compose:
   CompositionLocalAllowlist:
     active: true
-    allowedCompositionLocals: [LocalColors, LocalElevations, LocalImages, LocalSizes, LocalSpacings]
+    allowedCompositionLocals: [LocalColors, LocalElevations, LocalImages, LocalShapes, LocalSizes, LocalSpacings]
   ContentEmitterReturningValues:
     active: true
   ModifierComposable:

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Surface.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Surface.kt
@@ -1,11 +1,15 @@
 package app.k9mail.core.ui.compose.designsystem.atom
 
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import androidx.compose.material.Surface as MaterialSurface
@@ -13,12 +17,14 @@ import androidx.compose.material.Surface as MaterialSurface
 @Composable
 fun Surface(
     modifier: Modifier = Modifier,
+    shape: Shape = RectangleShape,
     color: Color = MainTheme.colors.surface,
     elevation: Dp = MainTheme.elevations.default,
     content: @Composable () -> Unit,
 ) {
     MaterialSurface(
         modifier = modifier,
+        shape = shape,
         content = content,
         elevation = elevation,
         color = color,
@@ -30,8 +36,27 @@ fun Surface(
 internal fun SurfacePreview() {
     PreviewWithThemes {
         Surface(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .requiredHeight(100.dp)
+                .requiredWidth(100.dp),
             content = {},
         )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun SurfaceWithShapePreview() {
+    PreviewWithThemes {
+        Background {
+            Surface(
+                modifier = Modifier
+                    .requiredHeight(MainTheme.sizes.larger)
+                    .requiredWidth(MainTheme.sizes.larger),
+                shape = MainTheme.shapes.small,
+                color = MainTheme.colors.primary,
+                content = {},
+            )
+        }
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/Button.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/Button.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextButton
+import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import androidx.compose.material.Button as MaterialButton
 
@@ -15,13 +17,16 @@ fun Button(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    color: Color? = null,
     contentPadding: PaddingValues = buttonContentPadding(),
 ) {
     MaterialButton(
         onClick = onClick,
         modifier = modifier,
         enabled = enabled,
-        colors = ButtonDefaults.buttonColors(),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = color ?: MainTheme.colors.primary,
+        ),
         contentPadding = contentPadding,
     ) {
         TextButton(text = text)
@@ -35,6 +40,18 @@ internal fun ButtonPreview() {
         Button(
             text = "Button",
             onClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun ButtonColoredPreview() {
+    PreviewWithThemes {
+        Button(
+            text = "ButtonColored",
+            onClick = {},
+            color = Color.Magenta,
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
@@ -19,6 +19,7 @@ fun ButtonOutlined(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    color: Color? = null,
     contentPadding: PaddingValues = buttonContentPadding(),
 ) {
     MaterialOutlinedButton(
@@ -26,6 +27,7 @@ fun ButtonOutlined(
         modifier = modifier,
         enabled = enabled,
         colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = color ?: MainTheme.colors.primary,
             backgroundColor = Color.Transparent,
         ),
         border = BorderStroke(
@@ -51,6 +53,18 @@ internal fun ButtonOutlinedPreview() {
         ButtonOutlined(
             text = "ButtonOutlined",
             onClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun ButtonOutlinedColoredPreview() {
+    PreviewWithThemes {
+        ButtonOutlined(
+            text = "ButtonOutlinedColored",
+            onClick = {},
+            color = Color.Magenta,
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextButton
+import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import androidx.compose.material.TextButton as MaterialTextButton
 
@@ -15,13 +17,16 @@ fun ButtonText(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    color: Color? = null,
     contentPadding: PaddingValues = buttonContentPadding(),
 ) {
     MaterialTextButton(
         onClick = onClick,
         modifier = modifier,
         enabled = enabled,
-        colors = ButtonDefaults.textButtonColors(),
+        colors = ButtonDefaults.textButtonColors(
+            contentColor = color ?: MainTheme.colors.primary,
+        ),
         contentPadding = contentPadding,
     ) {
         TextButton(text = text)
@@ -35,6 +40,18 @@ internal fun ButtonTextPreview() {
         ButtonText(
             text = "ButtonText",
             onClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun ButtonTextColoredPreview() {
+    PreviewWithThemes {
+        ButtonText(
+            text = "ButtonTextColored",
+            onClick = {},
+            color = Color.Magenta,
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextBody1.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextBody1.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextBody1(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.body1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.body1,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextBody1(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.body1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.body1,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextBody2.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextBody2.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextBody2(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.body2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.body2,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextBody2(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.body2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.body2,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextButton.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextButton(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text.uppercase(),
-        style = MainTheme.typography.button,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.button,
     )
 }
 
@@ -32,6 +35,7 @@ fun TextButton(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = AnnotatedString(
@@ -39,9 +43,10 @@ fun TextButton(
             spanStyles = text.spanStyles,
             paragraphStyles = text.paragraphStyles,
         ),
-        style = MainTheme.typography.button,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.button,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextCaption.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextCaption.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextCaption(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.caption,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.caption,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextCaption(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.caption,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.caption,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline1.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline1.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline1(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h1,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline1(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h1,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline2.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline2.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline2(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h2,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline2(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h2,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline3.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline3.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline3(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h3,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h3,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline3(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h3,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h3,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline4.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline4.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline4(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h4,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h4,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline4(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h4,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h4,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline5.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline5.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline5(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h5,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h5,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline5(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h5,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h5,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline6.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextHeadline6.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextHeadline6(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h6,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h6,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextHeadline6(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.h6,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.h6,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextOverline.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextOverline.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextOverline(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text.uppercase(),
-        style = MainTheme.typography.overline,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.overline,
     )
 }
 
@@ -32,6 +35,7 @@ fun TextOverline(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = AnnotatedString(
@@ -39,9 +43,10 @@ fun TextOverline(
             spanStyles = text.spanStyles,
             paragraphStyles = text.paragraphStyles,
         ),
-        style = MainTheme.typography.overline,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.overline,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextSubtitle1.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextSubtitle1.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextSubtitle1(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.subtitle1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.subtitle1,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextSubtitle1(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.subtitle1,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.subtitle1,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextSubtitle2.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextSubtitle2.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -18,12 +19,14 @@ fun TextSubtitle2(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.subtitle2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.subtitle2,
     )
 }
 
@@ -32,12 +35,14 @@ fun TextSubtitle2(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     MaterialText(
         text = text,
-        style = MainTheme.typography.subtitle2,
         modifier = modifier,
         color = color,
+        textAlign = textAlign,
+        style = MainTheme.typography.subtitle2,
     )
 }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/CheckboxInput.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/CheckboxInput.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,22 +20,27 @@ fun CheckboxInput(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    errorMessage: String? = null,
     contentPadding: PaddingValues = inputContentPadding(),
 ) {
-    Row(
-        modifier = Modifier
-            .padding(contentPadding)
-            .fillMaxWidth()
-            .clickable { onCheckedChange(!checked) }
-            .then(modifier),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+    InputLayout(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        errorMessage = errorMessage,
     ) {
-        Checkbox(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-        )
-        TextBody1(text = text)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onCheckedChange(!checked) },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+        ) {
+            Checkbox(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+            TextBody1(text = text)
+        }
     }
 }
 
@@ -48,6 +52,19 @@ internal fun CheckboxInputPreview() {
             text = "CheckboxInput",
             checked = false,
             onCheckedChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun CheckboxInputWithErrorPreview() {
+    PreviewWithThemes {
+        CheckboxInput(
+            text = "CheckboxInput",
+            checked = false,
+            onCheckedChange = {},
+            errorMessage = "Error message",
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/SwitchInput.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/SwitchInput.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,22 +20,27 @@ fun SwitchInput(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    errorMessage: String? = null,
     contentPadding: PaddingValues = inputContentPadding(),
 ) {
-    Row(
-        modifier = Modifier
-            .padding(contentPadding)
-            .fillMaxWidth()
-            .clickable { onCheckedChange(!checked) }
-            .then(modifier),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+    InputLayout(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        errorMessage = errorMessage,
     ) {
-        Switch(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-        )
-        TextBody1(text = text)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onCheckedChange(!checked) },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+        ) {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+            TextBody1(text = text)
+        }
     }
 }
 
@@ -48,6 +52,19 @@ internal fun SwitchInputPreview() {
             text = "SwitchInput",
             checked = false,
             onCheckedChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun SwitchInputWithErrorPreview() {
+    PreviewWithThemes {
+        SwitchInput(
+            text = "SwitchInput",
+            checked = false,
+            onCheckedChange = {},
+            errorMessage = "Error message",
         )
     }
 }

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/MainTheme.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/MainTheme.kt
@@ -2,7 +2,6 @@ package app.k9mail.core.ui.compose.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Shapes
 import androidx.compose.material.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -34,17 +33,20 @@ fun MainTheme(
 
     SetSystemBarsColor(color = colors.toolbar)
 
+    val shapes = MainTheme.shapes
+
     CompositionLocalProvider(
         LocalColors provides colors,
         LocalElevations provides Elevations(),
         LocalImages provides images,
         LocalSizes provides Sizes(),
         LocalSpacings provides Spacings(),
+        LocalShapes provides shapes,
     ) {
         MaterialTheme(
             colors = colors.toMaterialColors(),
             typography = typography,
-            shapes = shapes,
+            shapes = shapes.toMaterialShapes(),
             content = content,
         )
     }
@@ -64,7 +66,7 @@ object MainTheme {
     val shapes: Shapes
         @Composable
         @ReadOnlyComposable
-        get() = MaterialTheme.shapes
+        get() = LocalShapes.current
 
     val spacings: Spacings
         @Composable

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Shapes.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Shapes.kt
@@ -1,11 +1,23 @@
 package app.k9mail.core.ui.compose.theme
 
+import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Shapes
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.Shapes as MaterialShapes
 
-val shapes = Shapes(
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp),
+@Immutable
+data class Shapes(
+    val small: CornerBasedShape = RoundedCornerShape(8.dp),
+    val medium: CornerBasedShape = RoundedCornerShape(4.dp),
+    val large: CornerBasedShape = RoundedCornerShape(0.dp),
 )
+
+internal fun Shapes.toMaterialShapes() = MaterialShapes(
+    small = small,
+    medium = medium,
+    large = large,
+)
+
+internal val LocalShapes = staticCompositionLocalOf { Shapes() }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/BooleanInputField.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/input/BooleanInputField.kt
@@ -1,0 +1,74 @@
+package app.k9mail.feature.account.setup.domain.input
+
+import app.k9mail.core.common.domain.usecase.validation.ValidationError
+import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+
+class BooleanInputField(
+    override val value: Boolean? = null,
+    override val error: ValidationError? = null,
+    override val isValid: Boolean = false,
+) : InputField<Boolean?> {
+    override fun updateValue(value: Boolean?): InputField<Boolean?> {
+        return BooleanInputField(
+            value = value,
+            error = null,
+            isValid = false,
+        )
+    }
+
+    override fun updateError(error: ValidationError?): InputField<Boolean?> {
+        return BooleanInputField(
+            value = value,
+            error = error,
+            isValid = false,
+        )
+    }
+
+    override fun updateValidity(isValid: Boolean): InputField<Boolean?> {
+        if (isValid == this.isValid) return this
+
+        return BooleanInputField(
+            value = value,
+            error = null,
+            isValid = isValid,
+        )
+    }
+
+    override fun updateFromValidationResult(result: ValidationResult): InputField<Boolean?> {
+        return when (result) {
+            is ValidationResult.Success -> BooleanInputField(
+                value = value,
+                error = null,
+                isValid = true,
+            )
+
+            is ValidationResult.Failure -> BooleanInputField(
+                value = value,
+                error = result.error,
+                isValid = false,
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BooleanInputField
+
+        if (value != other.value) return false
+        if (error != other.error) return false
+        return isValid == other.isValid
+    }
+
+    override fun hashCode(): Int {
+        var result = value?.hashCode() ?: 0
+        result = 31 * result + (error?.hashCode() ?: 0)
+        result = 31 * result + isValid.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "BooleanInputField(value=$value, error=$error, isValid=$isValid)"
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/input/InputFieldTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/input/InputFieldTest.kt
@@ -243,6 +243,16 @@ class InputFieldTest(
                 initialIsValid = false,
                 updatedValue = 456L,
             ),
+            InputFieldTestData(
+                name = "BooleanInputField",
+                createInitialInput = { value, error, isValid -> BooleanInputField(value, error, isValid) },
+                initialState = BooleanInputField(),
+                initialValue = true,
+                initialValueEmpty = null,
+                initialError = null,
+                initialIsValid = false,
+                updatedValue = false,
+            ),
         )
     }
 


### PR DESCRIPTION
We need to display an error in case a switch or checkbox state is required. This introduces a BooleanInputField and wraps CheckboxInput and SwitchInput with an error. 

This also decouples shapes from Material Theme to be used in downstream modules.

Text composables now also support text alignment.

Changes Buttons to allow custom color.
