### PR TITLE
Allow space to complete an email address in recipient fields

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -371,6 +371,9 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
     @Override
     public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_SPACE) {
+            performCompletion();
+        }
         alternatesPopup.dismiss();
         return super.onKeyDown(keyCode, event);
     }


### PR DESCRIPTION
fixes https://github.com/thundernest/k-9/issues/6050
### PR Description
The PR ensures that two emails separated by a space are correctly parsed

### Steps to reproduce

1. Open screen to compose a new message (To field has the focus)
2. Enter text "[user1@domain.example](mailto:user1@domain.example) [user2@domain.example](mailto:user2@domain.example)"
3. Change focus to another field

### Issue video
https://www.loom.com/share/8614d99295ca4aa797b21b0e55993e9b

### Fix Video
https://www.loom.com/share/d23dad8b919d4659a2ac32cb703f784e?sid=7b586b4b-a0f9-4a1c-bcdb-75036fea759d

---

This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.