### PR TITLE
Deleting account doesn't change current color correctly

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -221,6 +221,11 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
     private fun setAccounts(displayAccounts: List<DisplayAccount>) {
         val oldSelectedBackgroundColor = selectedBackgroundColor
 
+        val isOpenedAccountStillAvailable = displayAccounts.any { it.account.uuid == openedAccountUuid }
+        if (!isOpenedAccountStillAvailable) {
+            openedAccountUuid = displayAccounts.first().account.uuid
+        }
+
         var newActiveProfile: IProfile? = null
         val accountItems = displayAccounts.map { displayAccount ->
             val account = displayAccount.account


### PR DESCRIPTION
fixes https://github.com/thundernest/k-9/issues/6964
### PR Description
When a user has more than one account and deletes one the drawer colour will change to the correct account colour.

### Steps to reproduce
1. Have two accounts A and B with different colours on the app `e.g YELLOW and RED respectively`
2. Select account B `RED` and delete it
3. Check that the drawer color is now YELLOW `ie the color for account A`

### Issue video
https://www.loom.com/share/38433f9e9fa6444088b87b91395ea666?sid=c2bc65a1-734e-4424-8fde-5e3b60987296

### Fix Video
https://www.loom.com/share/e38cef00d00d4f588ded4f9c76d33797?sid=591a6d90-be5e-4ff7-a71d-c693080621bf

---

This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
