### PR TITLE
Message view: Account chip not displayed when viewing messages in a thread (from Unified Inbox)

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1089,6 +1089,7 @@ open class MessageList :
         showMessageViewPlaceHolder()
 
         val tmpSearch = LocalSearch().apply {
+            setId(search?.id)
             addAccountUuid(account.uuid)
             and(SearchField.THREAD_ID, threadRootId.toString(), SearchSpecification.Attribute.EQUALS)
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -157,7 +157,7 @@ class MessageListFragment :
         }
 
     val isShowAccountChip: Boolean
-        get() = !isSingleAccountMode
+        get() = isUnifiedInbox || !isSingleAccountMode
 
     override fun onAttach(context: Context) {
         super.onAttach(context)


### PR DESCRIPTION
fixes https://github.com/thundernest/k-9/issues/6824

### PR Description
This PR ensures that when selected unified from drawer settings it should show account name chip in message details when user navigates through threaded view.


### Steps to reproduce

1. Go to Unified Inbox
2. Click on a message which is not in a message thread.
3. Enjoy the restyled message view.
4. Go to Unified Inbox
5. Click on a message which is part of a message thread - you'll be taken to the thread view
6. Click on a message in the thread view
7. Enjoy the "old" message view instead of the restyled one.

### Issue video
https://www.loom.com/share/7296a1c056ae4da79f4be36618fc6163?sid=6c162ba2-dc58-4c81-8a5f-0a4c8e76d581

### Demo after fix
https://www.loom.com/share/b45920ae61f54f9b9d1e2b7994b890dc?sid=523a7fbc-2b5b-44c6-84ed-8ad958e791a0

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
