### PR TITLE
Fetch `List-Post` header when downloading partial message

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -543,7 +543,7 @@ internal class RealImapFolder(
             fetchFields.add("RFC822.SIZE")
             fetchFields.add(
                 "BODY.PEEK[HEADER.FIELDS (date subject from content-type to cc bcc " +
-                    "reply-to message-id references in-reply-to list-unsubscribe sender " +
+                    "reply-to message-id references in-reply-to list-post list-unsubscribe sender " +
                     K9MailLib.IDENTITY_HEADER + " " + K9MailLib.CHAT_HEADER + ")]",
             )
         }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -673,7 +673,7 @@ class RealImapFolderTest {
         verify(imapConnection).sendCommand(
             "UID FETCH 1 (UID INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS " +
                 "(date subject from content-type to cc bcc reply-to message-id references in-reply-to " +
-                "list-unsubscribe sender X-K9mail-Identity Chat-Version)])",
+                "list-post list-unsubscribe sender X-K9mail-Identity Chat-Version)])",
             false,
         )
     }


### PR DESCRIPTION
`ReplyToParser` currently checks the `List-Post` header to figure out which email address to use as recipient when replying. With this change we make sure the `List-Post` header is always available, i.e. we explicitly fetch it when downloading a partial message.

Fixes #6414