### PR TITLE
Create better `AuthenticationFailedException` instances

### DIFF
--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -255,8 +255,7 @@ class Pop3Connection {
         try {
             executeSimpleCommand(PASS_COMMAND + " " + settings.getPassword(), true);
         } catch (Pop3ErrorResponse e) {
-            throw new AuthenticationFailedException(
-                    "POP3 login authentication failed: " + e.getMessage(), e);
+            throw new AuthenticationFailedException("USER/PASS failed", e, e.getResponseText());
         }
     }
 
@@ -267,9 +266,7 @@ class Pop3Connection {
                     + "\000" + settings.getPassword()).getBytes());
             executeSimpleCommand(new String(encodedBytes), true);
         } catch (Pop3ErrorResponse e) {
-            throw new AuthenticationFailedException(
-                    "POP3 SASL auth PLAIN authentication failed: "
-                            + e.getMessage(), e);
+            throw new AuthenticationFailedException("AUTH PLAIN failed", e, e.getResponseText());
         }
     }
 
@@ -293,8 +290,7 @@ class Pop3Connection {
         try {
             executeSimpleCommand("APOP " + settings.getUsername() + " " + hexDigest, true);
         } catch (Pop3ErrorResponse e) {
-            throw new AuthenticationFailedException(
-                    "POP3 APOP authentication failed: " + e.getMessage(), e);
+            throw new AuthenticationFailedException("APOP failed", e, e.getResponseText());
         }
     }
 
@@ -305,9 +301,7 @@ class Pop3Connection {
         try {
             executeSimpleCommand(b64CRAM, true);
         } catch (Pop3ErrorResponse e) {
-            throw new AuthenticationFailedException(
-                    "POP3 CRAM-MD5 authentication failed: "
-                            + e.getMessage(), e);
+            throw new AuthenticationFailedException("AUTH CRAM-MD5 failed", e, e.getResponseText());
         }
     }
 

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3ErrorResponse.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3ErrorResponse.java
@@ -13,4 +13,9 @@ class Pop3ErrorResponse extends MessagingException {
     public Pop3ErrorResponse(String message) {
         super(message, true);
     }
+
+    public String getResponseText() {
+        // TODO: Extract response text from response line
+        return getMessage();
+    }
 }

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.mail.transport.smtp
 
+import assertk.Assert
 import assertk.all
 import assertk.assertFailure
 import assertk.assertions.hasMessage
@@ -231,6 +232,7 @@ class SmtpTransportTest {
             output("220 localhost Simple Mail Transfer Service Ready")
             expect("EHLO [127.0.0.1]")
             output("250-localhost Hello client.localhost")
+            output("250-ENHANCEDSTATUSCODES")
             output("250 AUTH XOAUTH2")
             expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=")
             output("334 " + XOAuth2ChallengeParserTest.STATUS_401_RESPONSE)
@@ -245,9 +247,9 @@ class SmtpTransportTest {
         assertFailure {
             transport.open()
         }.isInstanceOf<AuthenticationFailedException>()
-            .hasMessage(
-                "5.7.1 Username and Password not accepted. Learn more at " +
-                    "5.7.1 http://support.google.com/mail/bin/answer.py?answer=14257 hx9sm5317360pbc.68",
+            .hasServerMessage(
+                "Username and Password not accepted. Learn more at " +
+                    "http://support.google.com/mail/bin/answer.py?answer=14257 hx9sm5317360pbc.68",
             )
 
         inOrder(oAuth2TokenProvider) {
@@ -348,6 +350,7 @@ class SmtpTransportTest {
             output("220 localhost Simple Mail Transfer Service Ready")
             expect("EHLO [127.0.0.1]")
             output("250-localhost Hello client.localhost")
+            output("250-ENHANCEDSTATUSCODES")
             output("250 AUTH XOAUTH2")
             expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=")
             output("334 " + XOAuth2ChallengeParserTest.STATUS_400_RESPONSE)
@@ -368,9 +371,9 @@ class SmtpTransportTest {
         assertFailure {
             transport.open()
         }.isInstanceOf<AuthenticationFailedException>()
-            .hasMessage(
-                "5.7.1 Username and Password not accepted. Learn more at " +
-                    "5.7.1 http://support.google.com/mail/bin/answer.py?answer=14257 hx9sm5317360pbc.68",
+            .hasServerMessage(
+                "Username and Password not accepted. Learn more at " +
+                    "http://support.google.com/mail/bin/answer.py?answer=14257 hx9sm5317360pbc.68",
             )
 
         server.verifyConnectionClosed()
@@ -547,7 +550,7 @@ class SmtpTransportTest {
         assertFailure {
             transport.open()
         }.isInstanceOf<AuthenticationFailedException>()
-            .hasMessage(
+            .hasServerMessage(
                 "Username and Password not accepted. " +
                     "Learn more at http://support.google.com/mail/bin/answer.py?answer=14257 hx9sm5317360pbc.68",
             )
@@ -971,4 +974,8 @@ class SmtpTransportTest {
             on { getToken(anyLong()) } doReturn "oldToken" doReturn "newToken"
         }
     }
+}
+
+private fun Assert<AuthenticationFailedException>.hasServerMessage(expected: String) = given { actual ->
+    assertThat(actual.messageFromServer).isEqualTo(expected)
 }


### PR DESCRIPTION
Provide a value for `messageFromServer` whenever possible. We're showing this to the user when checking server settings has failed, so they get a better idea of what went wrong.