### PR TITLE
Add interface for validating server settings

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidationResult.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidationResult.kt
@@ -1,0 +1,40 @@
+package com.fsck.k9.mail.server
+
+import com.fsck.k9.mail.ServerSettings
+import java.io.IOException
+import java.security.cert.X509Certificate
+
+/**
+ * Result type for [ServerSettingsValidator].
+ */
+sealed interface ServerSettingsValidationResult {
+    /**
+     * The given [ServerSettings] were successfully used to connect to the server and log in.
+     */
+    object Success : ServerSettingsValidationResult
+
+    /**
+     * A network error occurred while checking the server settings.
+     */
+    data class NetworkError(val exception: IOException) : ServerSettingsValidationResult
+
+    /**
+     * A certificate error occurred while checking the server settings.
+     */
+    data class CertificateError(val certificateChain: List<X509Certificate>) : ServerSettingsValidationResult
+
+    /**
+     * Authentication failed while checking the server settings.
+     */
+    data class AuthenticationError(val serverMessage: String?) : ServerSettingsValidationResult
+
+    /**
+     * The server returned an error while checking the server settings.
+     */
+    data class ServerError(val serverMessage: String?) : ServerSettingsValidationResult
+
+    /**
+     * An unknown error occurred while checking the server settings.
+     */
+    data class UnknownError(val exception: Exception) : ServerSettingsValidationResult
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidator.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidator.kt
@@ -1,0 +1,10 @@
+package com.fsck.k9.mail.server
+
+import com.fsck.k9.mail.ServerSettings
+
+/**
+ * Validate [ServerSettings] by trying to connect to the server and log in.
+ */
+interface ServerSettingsValidator {
+    fun checkServerSettings(serverSettings: ServerSettings): ServerSettingsValidationResult
+}

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpServerSettingsValidator.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpServerSettingsValidator.kt
@@ -1,0 +1,45 @@
+package com.fsck.k9.mail.transport.smtp
+
+import com.fsck.k9.mail.AuthenticationFailedException
+import com.fsck.k9.mail.CertificateValidationException
+import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.oauth.OAuth2TokenProvider
+import com.fsck.k9.mail.server.ServerSettingsValidationResult
+import com.fsck.k9.mail.server.ServerSettingsValidator
+import com.fsck.k9.mail.ssl.TrustedSocketFactory
+import java.io.IOException
+
+class SmtpServerSettingsValidator(
+    private val trustedSocketFactory: TrustedSocketFactory,
+    private val oAuth2TokenProvider: OAuth2TokenProvider?,
+) : ServerSettingsValidator {
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun checkServerSettings(serverSettings: ServerSettings): ServerSettingsValidationResult {
+        val smtpTransport = SmtpTransport(serverSettings, trustedSocketFactory, oAuth2TokenProvider)
+
+        return try {
+            smtpTransport.checkSettings()
+
+            ServerSettingsValidationResult.Success
+        } catch (e: AuthenticationFailedException) {
+            ServerSettingsValidationResult.AuthenticationError(e.messageFromServer)
+        } catch (e: CertificateValidationException) {
+            ServerSettingsValidationResult.CertificateError(e.certChain.toList())
+        } catch (e: NegativeSmtpReplyException) {
+            ServerSettingsValidationResult.ServerError(e.replyText)
+        } catch (e: MessagingException) {
+            val cause = e.cause
+            if (cause is IOException) {
+                ServerSettingsValidationResult.NetworkError(cause)
+            } else {
+                ServerSettingsValidationResult.UnknownError(e)
+            }
+        } catch (e: IOException) {
+            ServerSettingsValidationResult.NetworkError(e)
+        } catch (e: Exception) {
+            ServerSettingsValidationResult.UnknownError(e)
+        }
+    }
+}

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -281,6 +281,10 @@ class SmtpTransport(
     private fun readGreeting() {
         val smtpResponse = responseParser!!.readGreeting()
         logResponse(smtpResponse)
+
+        if (smtpResponse.isNegativeResponse) {
+            throw buildNegativeSmtpReplyException(smtpResponse)
+        }
     }
 
     private fun logResponse(smtpResponse: SmtpResponse, sensitive: Boolean = false) {

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpServerSettingsValidatorTest.kt
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpServerSettingsValidatorTest.kt
@@ -1,0 +1,192 @@
+package com.fsck.k9.mail.transport.smtp
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.helpers.FakeTrustManager
+import com.fsck.k9.mail.helpers.SimpleTrustedSocketFactory
+import com.fsck.k9.mail.server.ServerSettingsValidationResult
+import com.fsck.k9.mail.transport.mockServer.MockSmtpServer
+import java.net.UnknownHostException
+import kotlin.test.Test
+
+private const val USERNAME = "user"
+private const val PASSWORD = "password"
+private val CLIENT_CERTIFICATE_ALIAS: String? = null
+
+class SmtpServerSettingsValidatorTest {
+    private val fakeTrustManager = FakeTrustManager()
+    private val serverSettingsValidator = SmtpServerSettingsValidator(
+        trustedSocketFactory = SimpleTrustedSocketFactory(fakeTrustManager),
+        oAuth2TokenProvider = null,
+    )
+
+    @Test
+    fun `valid server settings should return Success`() {
+        val server = MockSmtpServer().apply {
+            output("220 localhost Simple Mail Transfer Service Ready")
+            expect("EHLO [127.0.0.1]")
+            output("250-localhost Hello client.localhost")
+            output("250-ENHANCEDSTATUSCODES")
+            output("250-AUTH PLAIN LOGIN")
+            output("250 HELP")
+            expect("AUTH PLAIN AHVzZXIAcGFzc3dvcmQ=")
+            output("235 2.7.0 Authentication successful")
+            expect("QUIT")
+            closeConnection()
+        }
+        server.start()
+        val serverSettings = ServerSettings(
+            type = "smtp",
+            host = server.host,
+            port = server.port,
+            connectionSecurity = ConnectionSecurity.NONE,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        val result = serverSettingsValidator.checkServerSettings(serverSettings)
+
+        assertThat(result).isInstanceOf<ServerSettingsValidationResult.Success>()
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `authentication error should return AuthenticationError`() {
+        val server = MockSmtpServer().apply {
+            output("220 localhost Simple Mail Transfer Service Ready")
+            expect("EHLO [127.0.0.1]")
+            output("250-localhost Hello client.localhost")
+            output("250-ENHANCEDSTATUSCODES")
+            output("250-AUTH PLAIN LOGIN")
+            output("250 HELP")
+            expect("AUTH PLAIN AHVzZXIAcGFzc3dvcmQ=")
+            output("535 5.7.8 Authentication failed")
+            expect("QUIT")
+            closeConnection()
+        }
+        server.start()
+        val serverSettings = ServerSettings(
+            type = "smtp",
+            host = server.host,
+            port = server.port,
+            connectionSecurity = ConnectionSecurity.NONE,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        val result = serverSettingsValidator.checkServerSettings(serverSettings)
+
+        assertThat(result).isInstanceOf<ServerSettingsValidationResult.AuthenticationError>()
+            .prop(ServerSettingsValidationResult.AuthenticationError::serverMessage).isEqualTo("Authentication failed")
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `error code instead of greeting should return ServerError`() {
+        val server = MockSmtpServer().apply {
+            output("421 domain.example Service currently not available")
+            closeConnection()
+        }
+        server.start()
+        val serverSettings = ServerSettings(
+            type = "smtp",
+            host = server.host,
+            port = server.port,
+            connectionSecurity = ConnectionSecurity.NONE,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        val result = serverSettingsValidator.checkServerSettings(serverSettings)
+
+        assertThat(result).isInstanceOf<ServerSettingsValidationResult.ServerError>()
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `certificate error when trying to connect should return CertificateError`() {
+        fakeTrustManager.shouldThrowException = true
+        val server = MockSmtpServer().apply {
+            output("220 localhost Simple Mail Transfer Service Ready")
+            expect("EHLO [127.0.0.1]")
+            output("250-localhost Hello 127.0.0.1")
+            output("250-STARTTLS")
+            output("250 HELP")
+            expect("STARTTLS")
+            output("220 Ready to start TLS")
+            startTls()
+        }
+        server.start()
+        val serverSettings = ServerSettings(
+            type = "smtp",
+            host = server.host,
+            port = server.port,
+            connectionSecurity = ConnectionSecurity.STARTTLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        val result = serverSettingsValidator.checkServerSettings(serverSettings)
+
+        assertThat(result).isInstanceOf<ServerSettingsValidationResult.CertificateError>()
+            .prop(ServerSettingsValidationResult.CertificateError::certificateChain).hasSize(1)
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `non-existent hostname should return NetworkError`() {
+        val serverSettings = ServerSettings(
+            type = "smtp",
+            host = "domain.invalid",
+            port = 587,
+            connectionSecurity = ConnectionSecurity.NONE,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        val result = serverSettingsValidator.checkServerSettings(serverSettings)
+
+        assertThat(result).isInstanceOf<ServerSettingsValidationResult.NetworkError>()
+            .prop(ServerSettingsValidationResult.NetworkError::exception)
+            .isInstanceOf<UnknownHostException>()
+    }
+
+    @Test
+    fun `ServerSettings with wrong type should throw`() {
+        val serverSettings = ServerSettings(
+            type = "wrong",
+            host = "domain.invalid",
+            port = 587,
+            connectionSecurity = ConnectionSecurity.NONE,
+            authenticationType = AuthType.PLAIN,
+            username = USERNAME,
+            password = PASSWORD,
+            clientCertificateAlias = CLIENT_CERTIFICATE_ALIAS,
+        )
+
+        assertFailure {
+            serverSettingsValidator.checkServerSettings(serverSettings)
+        }.isInstanceOf<IllegalArgumentException>()
+    }
+}

--- a/mail/testing/src/main/java/com/fsck/k9/mail/helpers/FakeTrustManager.kt
+++ b/mail/testing/src/main/java/com/fsck/k9/mail/helpers/FakeTrustManager.kt
@@ -1,0 +1,20 @@
+package com.fsck.k9.mail.helpers
+
+import com.fsck.k9.mail.CertificateChainException
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+@Suppress("CustomX509TrustManager")
+class FakeTrustManager : X509TrustManager {
+    var shouldThrowException = false
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        if (shouldThrowException) {
+            throw CertificateChainException("Test", chain, Exception("cause"))
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+}

--- a/mail/testing/src/main/java/com/fsck/k9/mail/helpers/SimpleTrustedSocketFactory.kt
+++ b/mail/testing/src/main/java/com/fsck/k9/mail/helpers/SimpleTrustedSocketFactory.kt
@@ -1,0 +1,26 @@
+package com.fsck.k9.mail.helpers
+
+import com.fsck.k9.mail.ssl.TrustedSocketFactory
+import java.net.Socket
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+class SimpleTrustedSocketFactory(private val trustManager: X509TrustManager) : TrustedSocketFactory {
+    override fun createSocket(socket: Socket?, host: String, port: Int, clientCertificateAlias: String?): Socket {
+        requireNotNull(socket)
+
+        val trustManagers = arrayOf<TrustManager>(trustManager)
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, trustManagers, null)
+        }
+
+        return sslContext.socketFactory.createSocket(
+            socket,
+            socket.inetAddress.hostAddress,
+            socket.port,
+            true,
+        )
+    }
+}


### PR DESCRIPTION
Add the interface `ServerSettingsValidator` and an implementation `SmtpServerSettingsValidator` for validating SMTP server settings.

Implementations for IMAP and POP3 will be added in future pull requests. 

Depends on #7010