### PR TITLE
Fix : Screen reader won't say unread for unread message #accessibility 

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -414,7 +414,10 @@ class MessageListAdapter internal constructor(
             } else {
                 holder.subject.text = subject
             }
-
+            if (!isRead) {
+                holder.subject.contentDescription =
+                    "${res.getString(R.string.unread_mail)} ${holder.subject.text}"
+            }
             holder.date.typeface = Typeface.create(holder.date.typeface, maybeBoldTypeface)
             holder.date.setTextColor(textColor)
             holder.date.text = displayDate

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -409,15 +409,16 @@ class MessageListAdapter internal constructor(
 
             holder.subject.typeface = Typeface.create(holder.subject.typeface, maybeBoldTypeface)
             holder.subject.setTextColor(textColor)
-            if (appearance.senderAboveSubject) {
-                holder.subject.text = displayName
+
+            val firstLineText = if (appearance.senderAboveSubject) displayName else subject
+            holder.subject.text = firstLineText
+
+            holder.subject.contentDescription = if (isRead) {
+                null
             } else {
-                holder.subject.text = subject
+                res.getString(R.string.message_list_content_description_unread_prefix, firstLineText)
             }
-            if (!isRead) {
-                holder.subject.contentDescription =
-                    "${res.getString(R.string.unread_mail)} ${holder.subject.text}"
-            }
+
             holder.date.typeface = Typeface.create(holder.date.typeface, maybeBoldTypeface)
             holder.date.setTextColor(textColor)
             holder.date.text = displayDate

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1341,4 +1341,6 @@ You can keep this message and use it as a backup for your secret key. If you wan
 
     <!-- Might be displayed in a notification when deleting an account (in the background) -->
     <string name="background_work_notification_remove_account">Removing account…</string>
+
+    <string name="unread_mail">Unread mail</string>
 </resources>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1342,5 +1342,6 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <!-- Might be displayed in a notification when deleting an account (in the background) -->
     <string name="background_work_notification_remove_account">Removing account…</string>
 
-    <string name="unread_mail">Unread mail</string>
+    <!-- For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers. -->
+    <string name="message_list_content_description_unread_prefix">unread, %s</string>
 </resources>


### PR DESCRIPTION
Fixes [#6348](https://github.com/thundernest/k-9/issues/6348)

### PR Description
This PR adds `Unread mail` text on unread email subjects for screen reader to read, thereby making it more accessible/easier to distinguish between read & unread emails.

### Issue

https://github.com/GitStartHQ/client-k9-android-app/assets/13991373/74b4aabc-97c5-4846-b10d-0aa97742778a




### Fix

https://github.com/GitStartHQ/client-k9-android-app/assets/13991373/3265d991-d86f-4dfb-971d-3309e32a8a79



---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
