### PR TITLE
Change exception handling in POP3 code

### DIFF
--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -91,6 +91,7 @@ class Pop3Connection {
             throw new MessagingException(
                     "Unable to open connection to POP server due to security error.", gse);
         } catch (IOException ioe) {
+            close();
             throw new MessagingException("Unable to open connection to POP server.", ioe);
         }
     }
@@ -165,7 +166,7 @@ class Pop3Connection {
     }
 
     private void performAuthentication(AuthType authType, String serverGreeting)
-            throws MessagingException {
+            throws MessagingException, IOException {
         switch (authType) {
             case PLAIN:
                 if (capabilities.authPlain) {
@@ -250,7 +251,7 @@ class Pop3Connection {
         return capabilities;
     }
 
-    private void login() throws MessagingException {
+    private void login() throws MessagingException, IOException {
         executeSimpleCommand(USER_COMMAND + " " + settings.getUsername());
         try {
             executeSimpleCommand(PASS_COMMAND + " " + settings.getPassword(), true);
@@ -260,7 +261,7 @@ class Pop3Connection {
         }
     }
 
-    private void authPlain() throws MessagingException {
+    private void authPlain() throws MessagingException, IOException {
         executeSimpleCommand("AUTH PLAIN");
         try {
             byte[] encodedBytes = Base64.encodeBase64(("\000" + settings.getUsername()
@@ -273,7 +274,7 @@ class Pop3Connection {
         }
     }
 
-    private void authAPOP(String serverGreeting) throws MessagingException {
+    private void authAPOP(String serverGreeting) throws MessagingException, IOException {
         // regex based on RFC 2449 (3.) "Greeting"
         String timestamp = serverGreeting.replaceFirst(
                 "^\\+OK *(?:\\[[^\\]]+\\])?[^<]*(<[^>]*>)?[^<]*$", "$1");
@@ -298,7 +299,7 @@ class Pop3Connection {
         }
     }
 
-    private void authCramMD5() throws MessagingException {
+    private void authCramMD5() throws MessagingException, IOException {
         String b64Nonce = executeSimpleCommand("AUTH CRAM-MD5").replace("+ ", "");
 
         String b64CRAM = Authentication.computeCramMd5(settings.getUsername(), settings.getPassword(), b64Nonce);
@@ -311,7 +312,7 @@ class Pop3Connection {
         }
     }
 
-    private void authExternal() throws MessagingException {
+    private void authExternal() throws MessagingException, IOException {
         try {
             executeSimpleCommand(
                     String.format("AUTH EXTERNAL %s",
@@ -336,36 +337,29 @@ class Pop3Connection {
         out.flush();
     }
 
-    String executeSimpleCommand(String command) throws MessagingException {
+    String executeSimpleCommand(String command) throws IOException, Pop3ErrorResponse {
         return executeSimpleCommand(command, false);
     }
 
-    private String executeSimpleCommand(String command, boolean sensitive) throws MessagingException {
-        try {
-            if (command != null) {
-                if (K9MailLib.isDebug() && DEBUG_PROTOCOL_POP3) {
-                    if (sensitive && !K9MailLib.isDebugSensitive()) {
-                        Timber.d(">>> [Command Hidden, Enable Sensitive Debug Logging To Show]");
-                    } else {
-                        Timber.d(">>> %s", command);
-                    }
+    private String executeSimpleCommand(String command, boolean sensitive) throws IOException, Pop3ErrorResponse {
+        if (command != null) {
+            if (K9MailLib.isDebug() && DEBUG_PROTOCOL_POP3) {
+                if (sensitive && !K9MailLib.isDebugSensitive()) {
+                    Timber.d(">>> [Command Hidden, Enable Sensitive Debug Logging To Show]");
+                } else {
+                    Timber.d(">>> %s", command);
                 }
-
-                writeLine(command);
             }
 
-            String response = readLine();
-            if (response.length() == 0 || response.charAt(0) != '+') {
-                throw new Pop3ErrorResponse(response);
-            }
-
-            return response;
-        } catch (MessagingException me) {
-            throw me;
-        } catch (Exception e) {
-            close();
-            throw new MessagingException("Unable to execute POP3 command", e);
+            writeLine(command);
         }
+
+        String response = readLine();
+        if (response.length() == 0 || response.charAt(0) != '+') {
+            throw new Pop3ErrorResponse(response);
+        }
+
+        return response;
     }
 
     String readLine() throws IOException {

--- a/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.kt
+++ b/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.kt
@@ -89,7 +89,7 @@ class Pop3FolderTest {
     @Test(expected = MessagingException::class)
     fun `open() with STAT command failing should throw`() {
         stubbing(connection) {
-            on { executeSimpleCommand(STAT_COMMAND) } doThrow MessagingException("Test")
+            on { executeSimpleCommand(STAT_COMMAND) } doThrow Pop3ErrorResponse("Test")
         }
 
         folder.open()
@@ -136,7 +136,7 @@ class Pop3FolderTest {
     @Test
     fun `close() with exception when sending QUIT command should not throw`() {
         stubbing(connection) {
-            on { executeSimpleCommand(Pop3Commands.QUIT_COMMAND) } doThrow MessagingException("Test")
+            on { executeSimpleCommand(Pop3Commands.QUIT_COMMAND) } doThrow Pop3ErrorResponse("Test")
         }
         folder.open()
 


### PR DESCRIPTION
Defer wrapping an `IOException` in a `MessagingException` for as long as possible.
