### PR TITLE
Add 'CheckServerSettings' use case

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup
 import app.k9mail.autodiscovery.api.AutoDiscoveryService
 import app.k9mail.autodiscovery.service.RealAutoDiscoveryService
 import app.k9mail.feature.account.setup.domain.DomainContract
+import app.k9mail.feature.account.setup.domain.usecase.CheckServerSettings
 import app.k9mail.feature.account.setup.domain.usecase.GetAutoDiscovery
 import app.k9mail.feature.account.setup.ui.AccountSetupViewModel
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract
@@ -31,6 +32,12 @@ val featureAccountSetupModule: Module = module {
     single<DomainContract.UseCase.GetAutoDiscovery> {
         GetAutoDiscovery(
             service = get(),
+        )
+    }
+
+    single<DomainContract.UseCase.CheckServerSettings> {
+        CheckServerSettings(
+            serverSettingsValidators = get<ServerSettingsValidatorProvider>().getValidators(),
         )
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ServerSettingsValidatorProvider.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ServerSettingsValidatorProvider.kt
@@ -1,0 +1,13 @@
+package app.k9mail.feature.account.setup
+
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.server.ServerSettingsValidator
+
+/**
+ * Provides a mapping from the protocol value used in [ServerSettings.type] to a [ServerSettingsValidator].
+ *
+ * Note: Apps using this feature module need to provide an instance of this interface via Koin.
+ */
+fun interface ServerSettingsValidatorProvider {
+    fun getValidators(): Map<String, ServerSettingsValidator>
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/DomainContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/DomainContract.kt
@@ -2,12 +2,18 @@ package app.k9mail.feature.account.setup.domain
 
 import app.k9mail.autodiscovery.api.AutoDiscoveryResult
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.server.ServerSettingsValidationResult
 
 internal interface DomainContract {
 
     interface UseCase {
         fun interface GetAutoDiscovery {
             suspend fun execute(emailAddress: String): AutoDiscoveryResult
+        }
+
+        fun interface CheckServerSettings {
+            suspend fun execute(serverSettings: ServerSettings): ServerSettingsValidationResult
         }
 
         fun interface ValidateEmailAddress {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/CheckServerSettings.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/CheckServerSettings.kt
@@ -1,0 +1,23 @@
+package app.k9mail.feature.account.setup.domain.usecase
+
+import app.k9mail.feature.account.setup.domain.DomainContract
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.server.ServerSettingsValidationResult
+import com.fsck.k9.mail.server.ServerSettingsValidator
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class CheckServerSettings(
+    private val serverSettingsValidators: Map<String, ServerSettingsValidator>,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : DomainContract.UseCase.CheckServerSettings {
+    override suspend fun execute(serverSettings: ServerSettings): ServerSettingsValidationResult {
+        val serverSettingsValidator = serverSettingsValidators[serverSettings.type]
+            ?: error("Unsupported ServerSettings.type value: ${serverSettings.type}")
+
+        return withContext(coroutineDispatcher) {
+            serverSettingsValidator.checkServerSettings(serverSettings)
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -26,6 +26,12 @@ class AccountSetupModuleKtTest : KoinTest {
         single<OkHttpClient> { OkHttpClient() }
     }
 
+    private val appModule = module {
+        single<ServerSettingsValidatorProvider> {
+            ServerSettingsValidatorProvider { emptyMap() }
+        }
+    }
+
     @Test
     fun `should have a valid di module`() {
         featureAccountSetupModule.verify(
@@ -39,7 +45,7 @@ class AccountSetupModuleKtTest : KoinTest {
         )
 
         koinApplication {
-            modules(networkModule, featureAccountSetupModule)
+            modules(appModule, networkModule, featureAccountSetupModule)
             androidContext(RuntimeEnvironment.getApplication())
             checkModules()
         }


### PR DESCRIPTION
Add a use case to test if a `ServerSettings` instance can be used to successfully connect and log in to a mail server.

This functionality is not used yet.