### PR TITLE
Update server settings UI

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContent.kt
@@ -188,15 +188,15 @@ internal fun AccountIncomingConfigContent(
                             contentPadding = defaultItemPadding(),
                         )
                     }
-                }
 
-                item {
-                    CheckboxInput(
-                        text = stringResource(id = R.string.account_setup_incoming_config_compression_label),
-                        checked = state.useCompression,
-                        onCheckedChange = { onEvent(Event.UseCompressionChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
+                    item {
+                        CheckboxInput(
+                            text = stringResource(id = R.string.account_setup_incoming_config_compression_label),
+                            checked = state.useCompression,
+                            onCheckedChange = { onEvent(Event.UseCompressionChanged(it)) },
+                            contentPadding = defaultItemPadding(),
+                        )
+                    }
                 }
             }
         }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContent.kt
@@ -191,9 +191,9 @@ internal fun AccountIncomingConfigContent(
 
                     item {
                         CheckboxInput(
-                            text = stringResource(id = R.string.account_setup_incoming_config_compression_label),
-                            checked = state.useCompression,
-                            onCheckedChange = { onEvent(Event.UseCompressionChanged(it)) },
+                            text = stringResource(id = R.string.account_setup_incoming_config_imap_compression_label),
+                            checked = state.imapUseCompression,
+                            onCheckedChange = { onEvent(Event.ImapUseCompressionChanged(it)) },
                             contentPadding = defaultItemPadding(),
                         )
                     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigContract.kt
@@ -28,7 +28,7 @@ interface AccountIncomingConfigContract {
         val clientCertificate: String = "",
         val imapAutodetectNamespaceEnabled: Boolean = true,
         val imapPrefix: StringInputField = StringInputField(),
-        val useCompression: Boolean = true,
+        val imapUseCompression: Boolean = true,
 
         val isSuccess: Boolean = false,
         val error: Error? = null,
@@ -45,7 +45,7 @@ interface AccountIncomingConfigContract {
         data class ClientCertificateChanged(val clientCertificate: String) : Event()
         data class ImapAutoDetectNamespaceChanged(val enabled: Boolean) : Event()
         data class ImapPrefixChanged(val imapPrefix: String) : Event()
-        data class UseCompressionChanged(val useCompression: Boolean) : Event()
+        data class ImapUseCompressionChanged(val useCompression: Boolean) : Event()
 
         object OnNextClicked : Event()
         object OnBackClicked : Event()

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigViewModel.kt
@@ -49,7 +49,7 @@ internal class AccountIncomingConfigViewModel(
                 it.copy(imapPrefix = it.imapPrefix.updateValue(event.imapPrefix))
             }
 
-            is Event.UseCompressionChanged -> updateState { it.copy(useCompression = event.useCompression) }
+            is Event.ImapUseCompressionChanged -> updateState { it.copy(imapUseCompression = event.useCompression) }
 
             Event.OnNextClicked -> onNext()
             Event.OnBackClicked -> onBack()

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContent.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
-import app.k9mail.core.ui.compose.designsystem.molecule.input.CheckboxInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.NumberInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
@@ -157,24 +156,6 @@ internal fun AccountOutgoingConfigContent(
                         ),
                         onOptionChange = { onEvent(Event.ClientCertificateChanged(it)) },
                         label = stringResource(id = R.string.account_setup_outgoing_config_client_certificate_label),
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-
-                item {
-                    CheckboxInput(
-                        text = stringResource(id = R.string.account_setup_outgoing_config_imap_namespace_label),
-                        checked = state.imapAutodetectNamespaceEnabled,
-                        onCheckedChange = { onEvent(Event.ImapAutoDetectNamespaceChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-
-                item {
-                    CheckboxInput(
-                        text = stringResource(id = R.string.account_setup_outgoing_config_compression_label),
-                        checked = state.useCompression,
-                        onCheckedChange = { onEvent(Event.UseCompressionChanged(it)) },
                         contentPadding = defaultItemPadding(),
                     )
                 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigContract.kt
@@ -22,8 +22,6 @@ interface AccountOutgoingConfigContract {
         val username: StringInputField = StringInputField(),
         val password: StringInputField = StringInputField(),
         val clientCertificate: String = "",
-        val imapAutodetectNamespaceEnabled: Boolean = true,
-        val useCompression: Boolean = true,
 
         val isSuccess: Boolean = false,
         val error: Error? = null,
@@ -37,8 +35,6 @@ interface AccountOutgoingConfigContract {
         data class UsernameChanged(val username: String) : Event()
         data class PasswordChanged(val password: String) : Event()
         data class ClientCertificateChanged(val clientCertificate: String) : Event()
-        data class ImapAutoDetectNamespaceChanged(val enabled: Boolean) : Event()
-        data class UseCompressionChanged(val useCompression: Boolean) : Event()
 
         object OnNextClicked : Event()
         object OnBackClicked : Event()

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigViewModel.kt
@@ -39,11 +39,6 @@ internal class AccountOutgoingConfigViewModel(
             is Event.UsernameChanged -> updateState { it.copy(username = it.username.updateValue(event.username)) }
             is Event.PasswordChanged -> updateState { it.copy(password = it.password.updateValue(event.password)) }
             is Event.ClientCertificateChanged -> updateState { it.copy(clientCertificate = event.clientCertificate) }
-            is Event.ImapAutoDetectNamespaceChanged -> updateState {
-                it.copy(imapAutodetectNamespaceEnabled = event.enabled)
-            }
-
-            is Event.UseCompressionChanged -> updateState { it.copy(useCompression = event.useCompression) }
 
             Event.OnNextClicked -> onNext()
             Event.OnBackClicked -> onBack()

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="account_setup_incoming_config_security_label">Security</string>
     <string name="account_setup_incoming_config_imap_namespace_label">Auto-detect IMAP namespace</string>
     <string name="account_setup_incoming_config_imap_prefix_label">IMAP path prefix</string>
-    <string name="account_setup_incoming_config_compression_label">Use compression</string>
+    <string name="account_setup_incoming_config_imap_compression_label">Use compression</string>
     <string name="account_setup_incoming_config_loading_message">Checking incoming server settings…</string>
     <string name="account_setup_incoming_config_loading_error">Checking incoming server settings failed!</string>
     <string name="account_setup_incoming_config_success">Incoming server settings are valid!</string>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigStateMapperKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigStateMapperKtTest.kt
@@ -26,7 +26,7 @@ class AccountIncomingConfigStateMapperKtTest {
             clientCertificate = "",
             imapAutodetectNamespaceEnabled = true,
             imapPrefix = StringInputField(value = "prefix"),
-            useCompression = true,
+            imapUseCompression = true,
         )
 
         val result = incomingState.toServerSettings()

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigStateTest.kt
@@ -26,7 +26,7 @@ class AccountIncomingConfigStateTest {
                 password = StringInputField(),
                 clientCertificate = "",
                 imapAutodetectNamespaceEnabled = true,
-                useCompression = true,
+                imapUseCompression = true,
             ),
         )
     }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/incoming/AccountIncomingConfigViewModelTest.kt
@@ -152,12 +152,12 @@ class AccountIncomingConfigViewModelTest {
     }
 
     @Test
-    fun `should change state when UseCompressionChanged event is received`() = runTest {
+    fun `should change state when ImapUseCompressionChanged event is received`() = runTest {
         eventStateTest(
             viewModel = testSubject,
-            initialState = State(useCompression = true),
-            event = Event.UseCompressionChanged(false),
-            expectedState = State(useCompression = false),
+            initialState = State(imapUseCompression = true),
+            event = Event.ImapUseCompressionChanged(false),
+            expectedState = State(imapUseCompression = false),
             coroutineScope = backgroundScope,
         )
     }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigStateMapperKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigStateMapperKtTest.kt
@@ -22,8 +22,6 @@ class AccountOutgoingConfigStateMapperKtTest {
             username = StringInputField(value = "user"),
             password = StringInputField(value = "password"),
             clientCertificate = "",
-            imapAutodetectNamespaceEnabled = true,
-            useCompression = true,
         )
 
         val result = outgoingState.toServerSettings()

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigStateTest.kt
@@ -23,8 +23,6 @@ class AccountOutgoingConfigStateTest {
                 username = StringInputField(),
                 password = StringInputField(),
                 clientCertificate = "",
-                imapAutodetectNamespaceEnabled = true,
-                useCompression = true,
             ),
         )
     }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/outgoing/AccountOutgoingConfigViewModelTest.kt
@@ -106,28 +106,6 @@ class AccountOutgoingConfigViewModelTest {
     }
 
     @Test
-    fun `should change state when ImapAutoDetectNamespaceChanged event is received`() = runTest {
-        eventStateTest(
-            viewModel = testSubject,
-            initialState = State(imapAutodetectNamespaceEnabled = true),
-            event = Event.ImapAutoDetectNamespaceChanged(false),
-            expectedState = State(imapAutodetectNamespaceEnabled = false),
-            coroutineScope = backgroundScope,
-        )
-    }
-
-    @Test
-    fun `should change state when UseCompressionChanged event is received`() = runTest {
-        eventStateTest(
-            viewModel = testSubject,
-            initialState = State(useCompression = true),
-            event = Event.UseCompressionChanged(false),
-            expectedState = State(useCompression = false),
-            coroutineScope = backgroundScope,
-        )
-    }
-
-    @Test
     fun `should emit effect NavigateNext when OnNextClicked is received in success state`() = runTest {
         val initialState = State(isSuccess = true)
         testSubject.initState(initialState)


### PR DESCRIPTION
- "Use compression" is only relevant for IMAP accounts
- Removed "Auto-detect IMAP namespace" and "Use compression" from outgoing server settings