### PR TITLE
Use the theme's regular background color(in Dark Theme)

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/DisplayHtml.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/DisplayHtml.kt
@@ -28,7 +28,7 @@ class DisplayHtml(private val settings: HtmlSettings) : HtmlHeadProvider {
     private fun cssStyleTheme(): String {
         return if (settings.useDarkMode) {
             "<style type=\"text/css\">" +
-                "* { background: black ! important; color: #F3F3F3 !important }" +
+                "* { background: transparent ! important; color: #F3F3F3 !important }" +
                 ":link, :link * { color: #CCFF33 !important }" +
                 ":visited, :visited * { color: #551A8B !important }</style> "
         } else {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -271,7 +271,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         // background color needs to be forced
         //TODO: Change themes to use appropriate background colors that don't need overriding.
         TypedValue outValue = new TypedValue();
-        themeContext.getTheme().resolveAttribute(R.attr.messageViewBackgroundColor, outValue, true);
+        themeContext.getTheme().resolveAttribute(android.R.attr.windowBackground, outValue, true);
 
         contentView.setBackgroundColor(outValue.data);
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.view
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.webkit.WebSettings.LayoutAlgorithm
 import android.webkit.WebSettings.RenderPriority
 import android.webkit.WebView
@@ -34,7 +35,10 @@ class MessageWebView : WebView, KoinComponent {
         isLongClickable = true
 
         if (config.useDarkMode) {
-            setBackgroundColor(0xff000000L.toInt())
+            val typedValue = TypedValue()
+            context.theme.resolveAttribute(android.R.attr.windowBackground, typedValue, true)
+            val backgroundColor = typedValue.data
+            setBackgroundColor(backgroundColor)
         }
 
         with(settings) {

--- a/app/ui/legacy/src/main/res/layout/message.xml
+++ b/app/ui/legacy/src/main/res/layout/message.xml
@@ -8,7 +8,6 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:layout_weight="1"
-    android:background="?attr/messageViewBackgroundColor"
     tools:context=".messageview.MessageViewFragment">
 
     <com.fsck.k9.view.NonLockingScrollView

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -107,7 +107,6 @@
         <attr name="messageListSwipeMoveIcon" format="reference"/>
         <attr name="messageListSwipeMoveBackgroundColor" format="reference|color"/>
         <attr name="messageStarColor" format="color"/>
-        <attr name="messageViewBackgroundColor" format="reference|color"/>
         <attr name="messageDetailsAddContactIcon" format="reference"/>
         <attr name="messageDetailsDividerColor" format="reference|color"/>
         <attr name="attachmentCardBackground" format="reference|color"/>

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -129,7 +129,6 @@
         <item name="messageListSwipeMoveBackgroundColor">@color/material_purple_500</item>
 
         <item name="messageStarColor">#fbbc04</item>
-        <item name="messageViewBackgroundColor">#ffffffff</item>
         <item name="messageDetailsAddContactIcon">@drawable/ic_person_add</item>
         <item name="messageDetailsDividerColor">#ffcccccc</item>
         <item name="attachmentCardBackground">#e8e8e8</item>
@@ -296,7 +295,6 @@
         <item name="messageListSwipeMoveBackgroundColor">@color/material_purple_600</item>
 
         <item name="messageStarColor">#fdd663</item>
-        <item name="messageViewBackgroundColor">#000000</item>
         <item name="messageDetailsAddContactIcon">@drawable/ic_person_add</item>
         <item name="messageDetailsDividerColor">#ff555555</item>
         <item name="attachmentCardBackground">#313131</item>


### PR DESCRIPTION
Fixes #6785 

In the mentioned issue, a problem was reported that the background color was different in the message display and message list pages. By talking more in that issue, we ended up making some changes to achieve the goals you [mentioned in that issue](https://github.com/thundernest/k-9/issues/6785#issuecomment-1598584382):

> The goal is to use the theme's regular background color.
> What needs to be done:
> - Remove the theme attribute messageViewBackgroundColor and all code associated with it.
> - Change DisplayHtml.cssStyleTheme() and MessageWebView.configure() to set the WebView's background color to the theme background color, not black."

In this branch, the changes were applied and we can see the background color difference before and after these changes:

|Before|After|
|-|-|
|![message_view_Before](https://github.com/thundernest/k-9/assets/34542204/c4717b4b-4b4b-4776-80b3-d498e746338e)|![message_view_After](https://github.com/thundernest/k-9/assets/34542204/bdd023e8-aedf-46ed-9d67-4653ab3038c7)|
|![compose_reply(html type)_Before](https://github.com/thundernest/k-9/assets/34542204/47730cb5-f0f2-4c48-9982-529aa0437892)|![compose_reply(html type)_After](https://github.com/thundernest/k-9/assets/34542204/6d5a5387-8488-42d0-a7a9-e02681538fa5)|





