### PR TITLE
Fix changelog layout

### DIFF
--- a/app/ui/legacy/src/main/res/layout/fragment_changelog.xml
+++ b/app/ui/legacy/src/main/res/layout/fragment_changelog.xml
@@ -11,11 +11,10 @@
         android:id="@+id/changelog_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginBottom="8dp"
         android:overScrollMode="ifContentScrolls"
         android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintBottom_toTopOf="@+id/show_recent_changes_checkbox"
+        app:layout_constraintBottom_toTopOf="@+id/bottomBar"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible"
         tools:listitem="@layout/changelog_list_release_item"/>
@@ -28,7 +27,7 @@
         android:layout_gravity="center"
         android:indeterminate="true"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -41,34 +40,30 @@
         android:layout_gravity="center"
         android:text="@string/changelog_loading_error"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="gone" />
 
-    <View
+    <FrameLayout
         android:id="@+id/bottomBar"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:background="?attr/bottomBarBackground"
         android:elevation="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/changelog_list" />
+        app:layout_constraintStart_toStartOf="parent">
 
-    <CheckBox
-        android:id="@+id/show_recent_changes_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="8dp"
-        android:elevation="8dp"
-        android:text="@string/changelog_show_recent_changes"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        <CheckBox
+            android:id="@+id/show_recent_changes_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginVertical="8dp"
+            android:text="@string/changelog_show_recent_changes" />
+
+    </FrameLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The loading state wasn't displayed properly.

|Before|After|
|-|-|
|![image](https://github.com/thundernest/k-9/assets/218061/7db235d1-b006-4944-9565-618a57217179)|![image](https://github.com/thundernest/k-9/assets/218061/3af17018-9eb3-4e84-9d64-7780862ece92)|

