### PR TITLE
Enable Endless Scroll

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -199,10 +199,6 @@ class MessageListAdapter internal constructor(
         true
     }
 
-    private val footerClickListener = OnClickListener {
-        listItemListener.onFooterClicked()
-    }
-
     private val starClickListener = OnClickListener { view: View ->
         val parentView = view.parent as View
         val messageListItem = getItemFromView(parentView) ?: return@OnClickListener
@@ -339,7 +335,6 @@ class MessageListAdapter internal constructor(
 
     private fun createFooterViewHolder(parent: ViewGroup): MessageListViewHolder {
         val view = layoutInflater.inflate(R.layout.message_list_item_footer, parent, false)
-        view.setOnClickListener(footerClickListener)
         return FooterViewHolder(view)
     }
 
@@ -615,5 +610,4 @@ interface MessageListItemActionListener {
     fun onMessageClicked(messageListItem: MessageListItem)
     fun onToggleMessageSelection(item: MessageListItem)
     fun onToggleMessageFlag(item: MessageListItem)
-    fun onFooterClicked()
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -345,6 +345,19 @@ class MessageListFragment :
         )
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+                val linearLayoutManager = recyclerView.layoutManager as LinearLayoutManager
+                if (currentFolder?.loading == false) {
+                    if (linearLayoutManager.findLastCompletelyVisibleItemPosition() == adapter.itemCount - 1) {
+                        onFooterClicked()
+                        currentFolder?.loading = true
+                    }
+                }
+            }
+        })
+
         recyclerView.adapter = adapter
 
         this.recyclerView = recyclerView

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -498,8 +498,8 @@ class MessageListFragment :
             val folderId = currentFolder.databaseId
             messagingController.loadMoreMessages(account, folderId)
         } else if (isRemoteSearch) {
-            val additionalSearchResults = extraSearchResults ?: return
-            if (additionalSearchResults.isEmpty()) return
+            val additionalSearchResults = extraSearchResults
+            if (additionalSearchResults.isNullOrEmpty()) return
 
             val loadSearchResults: List<String>
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -491,7 +491,7 @@ class MessageListFragment :
         fragmentListener.setMessageListProgressEnabled(progress)
     }
 
-    override fun onFooterClicked() {
+    fun onFooterClicked() {
         val currentFolder = this.currentFolder ?: return
 
         if (currentFolder.moreMessages && !localSearch.isManualSearch) {


### PR DESCRIPTION
Fixes #7059
In the mentioned issue, I proposed an enhancement to implement the Endless Scroll feature in the message list. And I presented the full explanation in that issue.

**In this branch:**
in the first commit, I added a function to detect reaching the end of the list and load the next 25 messages automatically without involving the user.

Also, in another commit, I removed the option of clicking the footer so that only the footer is displayed (because we are loading with EndlessScroll and we don't need a Button). But we still show the footer and show the status to the user at the moment (when reaching the end of the list we show "Load up to 25 more" message, and when loading messages we show "Loading messages..." message)