### PR TITLE
Write empty string to identity header field if name is null

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/IdentityHeaderBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/message/IdentityHeaderBuilder.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.message;
 
 
+import java.util.Objects;
+
 import android.net.Uri;
 import android.net.Uri.Builder;
 
@@ -87,7 +89,7 @@ public class IdentityHeaderBuilder {
         }
 
         if (identityChanged) {
-            appendValue(IdentityField.NAME, identity.getName());
+            appendValue(IdentityField.NAME, Objects.requireNonNullElse(identity.getName(), ""));
             appendValue(IdentityField.EMAIL, identity.getEmail());
         }
 


### PR DESCRIPTION
Minimally invasive change to avoid the problem described in #7111.

This won't fix the problem with existing draft messages, but will avoid the problem with draft messages saved in the future.
