### PR TITLE
Use `OutlinedButton` for `SignInWithGoogleButton`

### DIFF
--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
@@ -3,22 +3,20 @@ package app.k9mail.feature.account.oauth.ui.view
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ButtonElevation
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,21 +41,19 @@ fun SignInWithGoogleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isLight: Boolean = MaterialTheme.colors.isLight,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    elevation: ButtonElevation? = ButtonDefaults.elevation(),
 ) {
-    Surface(
-        modifier = Modifier
-            .border(
-                width = 1.dp,
-                color = getBorderColor(isLight),
-                shape = RoundedCornerShape(8.dp),
-            )
-            .clickable { onClick() }
-            .then(modifier),
-        shape = RoundedCornerShape(8.dp),
-        color = getSurfaceColor(isLight),
-        elevation = elevation?.elevation(true, interactionSource)?.value ?: 0.dp,
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = getTextColor(isLight),
+            backgroundColor = getSurfaceColor(isLight),
+        ),
+        border = BorderStroke(
+            width = 1.dp,
+            color = getBorderColor(isLight),
+        ),
+        contentPadding = PaddingValues(all = 0.dp),
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
This way the "Sign in with Google" button looks and behaves more like a regular button.

Before:
<img src="https://github.com/thundernest/k-9/assets/218061/5768b89d-6335-489b-a5a5-cade346053cd" alt="image" width=300> <img src="https://github.com/thundernest/k-9/assets/218061/b6ef4950-90de-4a24-8288-eadaed63d991" alt="image" width=300>

After:
<img src="https://github.com/thundernest/k-9/assets/218061/ba74bc3a-288f-4aea-bef5-1d324ba7ac3b" alt="image" width=300> <img src="https://github.com/thundernest/k-9/assets/218061/af1f1d5c-4cbc-40ef-be33-f5682de101b3" alt="image" width=300>
