### PR TITLE
Switch to new account setup UI

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/featureflag/InMemoryFeatureFlagFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/featureflag/InMemoryFeatureFlagFactory.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.featureflag.FeatureFlagKey
 class InMemoryFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
-            FeatureFlag(FeatureFlagKey("new_onboarding"), false),
+            FeatureFlag(FeatureFlagKey("new_onboarding"), true),
         )
     }
 }


### PR DESCRIPTION
Use the new UI when adding an account. When editing the server settings of an existing account the old UI is still used.