### PR TITLE
Fix OAuth code in new account setup

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.backends
 
 import android.content.Context
+import com.fsck.k9.BuildConfig
 import com.fsck.k9.mail.AuthenticationFailedException
 import com.fsck.k9.mail.oauth.AuthStateStorage
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
@@ -12,6 +13,7 @@ import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors
 import net.openid.appauth.AuthorizationException.GeneralErrors
 import net.openid.appauth.AuthorizationService
+import timber.log.Timber
 
 class RealOAuth2TokenProvider(
     context: Context,
@@ -20,6 +22,7 @@ class RealOAuth2TokenProvider(
     private val authService = AuthorizationService(context)
     private var requestFreshToken = false
 
+    @Suppress("TooGenericExceptionCaught")
     override fun getToken(timeoutMillis: Long): String {
         val latch = CountDownLatch(1)
         var token: String? = null
@@ -34,14 +37,30 @@ class RealOAuth2TokenProvider(
 
         val oldAccessToken = authState.accessToken
 
-        authState.performActionWithFreshTokens(authService) { accessToken: String?, _, authException: AuthorizationException? ->
-            token = accessToken
-            exception = authException
+        try {
+            authState.performActionWithFreshTokens(authService) { accessToken: String?, _, authException: AuthorizationException? ->
+                token = accessToken
+                exception = authException
 
-            latch.countDown()
+                latch.countDown()
+            }
+
+            latch.await(timeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (e: Exception) {
+            // OAuth errors are communicated via the callback. If we end up here, it's probably a programming error.
+            if (BuildConfig.DEBUG) {
+                throw AssertionError("Wrong usage of AuthState.performActionWithFreshTokens()?", e)
+            }
+
+            Timber.w(e, "Failed to fetch an access token. Clearing authorization state.")
+
+            authStateStorage.updateAuthorizationState(authorizationState = null)
+
+            throw AuthenticationFailedException(
+                message = "Failed to fetch an access token",
+                throwable = e,
+            )
         }
-
-        latch.await(timeoutMillis, TimeUnit.MILLISECONDS)
 
         val authException = exception
         if (authException == GeneralErrors.NETWORK_ERROR ||

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/DomainContract.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/DomainContract.kt
@@ -20,7 +20,7 @@ interface DomainContract {
         }
 
         fun interface FinishOAuthSignIn {
-            suspend fun execute(authorizationState: AuthorizationState, intent: Intent): AuthorizationResult
+            suspend fun execute(intent: Intent): AuthorizationResult
         }
 
         fun interface CheckIsGoogleSignIn {

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/DomainContract.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/DomainContract.kt
@@ -37,10 +37,7 @@ interface DomainContract {
         suspend fun getAuthorizationResponse(intent: Intent): AuthorizationResponse?
         suspend fun getAuthorizationException(intent: Intent): AuthorizationException?
 
-        suspend fun getExchangeToken(
-            authorizationState: AuthorizationState,
-            response: AuthorizationResponse,
-        ): AuthorizationResult
+        suspend fun getExchangeToken(response: AuthorizationResponse): AuthorizationResult
     }
 
     fun interface AuthorizationStateRepository {

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignIn.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignIn.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import app.k9mail.feature.account.oauth.domain.DomainContract
 import app.k9mail.feature.account.oauth.domain.DomainContract.UseCase
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationResult
-import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 
 class FinishOAuthSignIn(
     private val repository: DomainContract.AuthorizationRepository,
@@ -14,7 +13,7 @@ class FinishOAuthSignIn(
         val exception = repository.getAuthorizationException(intent)
 
         return if (response != null) {
-            repository.getExchangeToken(AuthorizationState(), response)
+            repository.getExchangeToken(response)
         } else if (exception != null) {
             AuthorizationResult.Failure(exception)
         } else {

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignIn.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignIn.kt
@@ -9,12 +9,12 @@ import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 class FinishOAuthSignIn(
     private val repository: DomainContract.AuthorizationRepository,
 ) : UseCase.FinishOAuthSignIn {
-    override suspend fun execute(authorizationState: AuthorizationState, intent: Intent): AuthorizationResult {
+    override suspend fun execute(intent: Intent): AuthorizationResult {
         val response = repository.getAuthorizationResponse(intent)
         val exception = repository.getAuthorizationException(intent)
 
         return if (response != null) {
-            repository.getExchangeToken(authorizationState, response)
+            repository.getExchangeToken(AuthorizationState(), response)
         } else if (exception != null) {
             AuthorizationResult.Failure(exception)
         } else {

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContract.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContract.kt
@@ -14,7 +14,6 @@ interface AccountOAuthContract {
     data class State(
         val hostname: String = "",
         val emailAddress: String = "",
-        val authorizationState: AuthorizationState = AuthorizationState(),
         val wizardNavigationBarState: WizardNavigationBarState = WizardNavigationBarState(
             isNextEnabled = false,
         ),

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthViewModel.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthViewModel.kt
@@ -7,6 +7,7 @@ import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.oauth.domain.DomainContract.UseCase
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationIntentResult
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationResult
+import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.Effect
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.Error
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.Event
@@ -90,18 +91,15 @@ class AccountOAuthViewModel(
             )
         }
         viewModelScope.launch {
-            when (val result = finishOAuthSignIn.execute(state.value.authorizationState, data)) {
+            when (val result = finishOAuthSignIn.execute(data)) {
                 AuthorizationResult.BrowserNotAvailable -> updateErrorState(Error.BrowserNotAvailable)
                 AuthorizationResult.Canceled -> updateErrorState(Error.Canceled)
                 is AuthorizationResult.Failure -> updateErrorState(Error.Unknown(result.error))
                 is AuthorizationResult.Success -> {
                     updateState { state ->
-                        state.copy(
-                            authorizationState = result.state,
-                            isLoading = false,
-                        )
+                        state.copy(isLoading = false)
                     }
-                    navigateNext()
+                    navigateNext(authorizationState = result.state)
                 }
             }
         }
@@ -116,5 +114,7 @@ class AccountOAuthViewModel(
 
     private fun navigateBack() = emitEffect(Effect.NavigateBack)
 
-    private fun navigateNext() = emitEffect(Effect.NavigateNext(state.value.authorizationState))
+    private fun navigateNext(authorizationState: AuthorizationState) {
+        emitEffect(Effect.NavigateNext(authorizationState))
+    }
 }

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepositoryTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepositoryTest.kt
@@ -6,7 +6,6 @@ import androidx.core.net.toUri
 import app.k9mail.core.common.oauth.OAuthConfiguration
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationIntentResult
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationResult
-import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -14,6 +13,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import kotlinx.coroutines.test.runTest
+import net.openid.appauth.AuthState
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
@@ -179,13 +179,11 @@ class AuthorizationRepositoryTest {
                 callback.onTokenRequestCompleted(tokenResponse, null)
             }
         }
-        val authorizationState = AuthorizationState()
 
-        val result = testSubject.getExchangeToken(authorizationState, authorizationResponse)
+        val result = testSubject.getExchangeToken(authorizationResponse)
 
-        val authState = authorizationState.toAuthState()
-        authState.update(tokenResponse, null)
-        val successAuthorizationState = authState.toAuthorizationState()
+        val expectedAuthState = AuthState(authorizationResponse, tokenResponse, null)
+        val successAuthorizationState = expectedAuthState.toAuthorizationState()
 
         assertThat(result).isEqualTo(AuthorizationResult.Success(successAuthorizationState))
     }
@@ -208,9 +206,8 @@ class AuthorizationRepositoryTest {
                 callback.onTokenRequestCompleted(null, authorizationException)
             }
         }
-        val authorizationState = AuthorizationState()
 
-        val result = testSubject.getExchangeToken(authorizationState, authorizationResponse)
+        val result = testSubject.getExchangeToken(authorizationResponse)
 
         assertThat(result).isEqualTo(AuthorizationResult.Failure(authorizationException))
     }
@@ -226,9 +223,8 @@ class AuthorizationRepositoryTest {
                 callback.onTokenRequestCompleted(null, null)
             }
         }
-        val authorizationState = AuthorizationState()
 
-        val result = testSubject.getExchangeToken(authorizationState, authorizationResponse)
+        val result = testSubject.getExchangeToken(authorizationResponse)
 
         assertThat(result).isEqualTo(AuthorizationResult.Failure(exception))
     }

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/FakeAuthorizationRepository.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/FakeAuthorizationRepository.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import app.k9mail.core.common.oauth.OAuthConfiguration
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationIntentResult
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationResult
-import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 
@@ -40,14 +39,11 @@ class FakeAuthorizationRepository(
         return answerGetAuthorizationException
     }
 
-    var recordedGetExchangeTokenAuthorizationState: AuthorizationState? = null
     var recordedGetExchangeTokenResponse: AuthorizationResponse? = null
 
     override suspend fun getExchangeToken(
-        authorizationState: AuthorizationState,
         response: AuthorizationResponse,
     ): AuthorizationResult {
-        recordedGetExchangeTokenAuthorizationState = authorizationState
         recordedGetExchangeTokenResponse = response
         return answerGetExchangeToken
     }

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignInTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignInTest.kt
@@ -19,7 +19,6 @@ class FinishOAuthSignInTest {
 
     @Test
     fun `should return failure when intent has encoded exception`() = runTest {
-        val authorizationState = AuthorizationState()
         val intent = Intent()
         val exception = AuthorizationException(
             AuthorizationException.TYPE_GENERAL_ERROR,
@@ -36,10 +35,7 @@ class FinishOAuthSignInTest {
             repository = repository,
         )
 
-        val result = testSubject.execute(
-            authorizationState = authorizationState,
-            intent = intent,
-        )
+        val result = testSubject.execute(intent)
 
         assertThat(result).isEqualTo(AuthorizationResult.Failure(exception))
         assertThat(repository.recordedGetAuthorizationExceptionIntent).isEqualTo(intent)
@@ -47,16 +43,7 @@ class FinishOAuthSignInTest {
 
     @Test
     fun `should return canceled when intent has no response and no exception`() = runTest {
-        val authorizationState = AuthorizationState()
         val intent = Intent()
-        val exception = AuthorizationException(
-            AuthorizationException.TYPE_GENERAL_ERROR,
-            1,
-            "error",
-            "error_description",
-            null,
-            null,
-        )
         val repository = FakeAuthorizationRepository(
             answerGetAuthorizationResponse = null,
             answerGetAuthorizationException = null,
@@ -65,10 +52,7 @@ class FinishOAuthSignInTest {
             repository = repository,
         )
 
-        val result = testSubject.execute(
-            authorizationState = authorizationState,
-            intent = intent,
-        )
+        val result = testSubject.execute(intent)
 
         assertThat(result).isEqualTo(AuthorizationResult.Canceled)
         assertThat(repository.recordedGetAuthorizationResponseIntent).isEqualTo(intent)
@@ -89,10 +73,7 @@ class FinishOAuthSignInTest {
             repository = repository,
         )
 
-        val result = testSubject.execute(
-            authorizationState = authorizationState,
-            intent = intent,
-        )
+        val result = testSubject.execute(intent)
 
         assertThat(result).isEqualTo(AuthorizationResult.Success(authorizationState))
         assertThat(repository.recordedGetAuthorizationResponseIntent).isEqualTo(intent)

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignInTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/domain/usecase/FinishOAuthSignInTest.kt
@@ -78,7 +78,6 @@ class FinishOAuthSignInTest {
         assertThat(result).isEqualTo(AuthorizationResult.Success(authorizationState))
         assertThat(repository.recordedGetAuthorizationResponseIntent).isEqualTo(intent)
         assertThat(repository.recordedGetAuthorizationExceptionIntent).isEqualTo(intent)
-        assertThat(repository.recordedGetExchangeTokenAuthorizationState).isEqualTo(authorizationState)
         assertThat(repository.recordedGetExchangeTokenResponse).isEqualTo(response)
     }
 }

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthStateTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthStateTest.kt
@@ -1,7 +1,6 @@
 package app.k9mail.feature.account.oauth.ui
 
 import app.k9mail.feature.account.common.ui.WizardNavigationBarState
-import app.k9mail.feature.account.oauth.domain.entity.AuthorizationState
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.State
 import assertk.all
 import assertk.assertThat
@@ -18,7 +17,6 @@ class AccountOAuthStateTest {
         assertThat(state).all {
             prop(State::hostname).isEqualTo("")
             prop(State::emailAddress).isEqualTo("")
-            prop(State::authorizationState).isEqualTo(AuthorizationState())
             prop(State::wizardNavigationBarState).isEqualTo(
                 WizardNavigationBarState(
                     isNextEnabled = false,

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthViewModelTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthViewModelTest.kt
@@ -198,7 +198,6 @@ class AccountOAuthViewModelTest {
 
         val successState = loadingState.copy(
             isLoading = false,
-            authorizationState = authorizationState,
         )
 
         assertThat(stateTurbine.awaitItem()).isEqualTo(successState)
@@ -371,7 +370,7 @@ class AccountOAuthViewModelTest {
             getOAuthRequestIntent = { _, _ ->
                 authorizationIntentResult
             },
-            finishOAuthSignIn = { _, _ ->
+            finishOAuthSignIn = { _ ->
                 delay(50)
                 authorizationResult
             },


### PR DESCRIPTION
The `AuthState` created by K-9 Mail 6.709 can't be used to fetch a new access token. This PR fixes the problem for new accounts and handles the exception when trying to use the refresh token to retrieve a new access token.