### PR TITLE
Change Gradle memory allowance to 3G

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
 
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true


### PR DESCRIPTION
Seems like updating to Gradle 8.3 and increasing memory allowance to 4G causes out of memory with the GitHub Action runner.

This reduces allowance to 3G which seems to work fine.