### PR TITLE
Fix gradle properties to avoid out of memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,13 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
 
+# Gradle
 ## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
 org.gradle.jvmargs=-Xmx4G -Xms1G -XX:MaxMetaspaceSize=1536M -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
 
 org.gradle.parallel=true
+
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+
 org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,9 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
 
-org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
+## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
+org.gradle.jvmargs=-Xmx4G -Xms1G -XX:MaxMetaspaceSize=1536M -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,14 @@
-# Disable buildFeatures flags by default
+# Android
+android.useAndroidX=true
+android.enableJetifier=false
+android.nonTransitiveRClass=true
+
+## Disable buildFeatures flags by default
 android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.buildconfig=false
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-
-android.useAndroidX=true
-android.enableJetifier=false
-android.nonTransitiveRClass=true
 
 # Gradle
 ## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750


### PR DESCRIPTION
According to [#19750](https://github.com/gradle/gradle/issues/19750) the Gradle Daemon could disapear or run out of memory when `org.gradle.jvmargs` has been altered in the `gradle.properties`. This causes the deamon to drop all default values leaving `XX:MaxMetaspaceSize` unbound which consumes more and more memory.

This should fix the issues until [#19750](https://github.com/gradle/gradle/issues/19750) is fixed.

Here are the default values used by the Gradle Daemon: [DaemonParameters](https://github.com/gradle/gradle/blob/master/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java). 

For our project the default memory settings have been multiplied by 4.
 