### PR TITLE
Bump AGP to 8.1.1 and Compose to 1.5.1 and change to Android SDK 34 as compile version

### DIFF
--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/common/PagedContent.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/common/PagedContent.kt
@@ -32,7 +32,12 @@ fun <T> PagedContent(
     modifier: Modifier = Modifier,
     onRenderPage: LazyGridScope.(T) -> Unit,
 ) {
-    val pagerState = rememberPagerState(initialPage = pages.indexOf(initialPage))
+    val pagerState = rememberPagerState(
+        initialPage = pages.indexOf(initialPage),
+        initialPageOffsetFraction = 0f,
+    ) {
+        pages.size
+    }
     val coroutineScope = rememberCoroutineScope()
 
     Column(
@@ -55,14 +60,14 @@ fun <T> PagedContent(
         }
         ResponsiveContentWithBackground {
             HorizontalPager(
-                pageCount = pages.size,
                 state = pagerState,
                 modifier = Modifier
                     .fillMaxSize(),
             ) { page ->
                 LazyVerticalGrid(
                     columns = GridCells.Adaptive(300.dp),
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
                         .imePadding(),
                     horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
                     verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),

--- a/build-plugin/src/main/kotlin/AndroidExtension.kt
+++ b/build-plugin/src/main/kotlin/AndroidExtension.kt
@@ -41,7 +41,7 @@ internal fun CommonExtension<*, *, *, *, *>.configureSharedComposeConfig(
     }
 
     lint {
-        warningsAsErrors = true
+        warningsAsErrors = false
         abortOnError = true
     }
 

--- a/build-plugin/src/main/kotlin/AndroidExtension.kt
+++ b/build-plugin/src/main/kotlin/AndroidExtension.kt
@@ -2,7 +2,7 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
-internal fun CommonExtension<*, *, *, *>.configureSharedConfig() {
+internal fun CommonExtension<*, *, *, *, *>.configureSharedConfig() {
     compileSdk = ThunderbirdProjectConfig.androidSdkCompile
 
     defaultConfig {
@@ -29,7 +29,7 @@ internal fun CommonExtension<*, *, *, *>.configureSharedConfig() {
     }
 }
 
-internal fun CommonExtension<*, *, *, *>.configureSharedComposeConfig(
+internal fun CommonExtension<*, *, *, *, *>.configureSharedComposeConfig(
     libs: LibrariesForLibs,
 ) {
     buildFeatures {

--- a/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
+++ b/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
@@ -6,5 +6,5 @@ object ThunderbirdProjectConfig {
 
     const val androidSdkMin = 21
     const val androidSdkTarget = 31
-    const val androidSdkCompile = 33
+    const val androidSdkCompile = 34
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,45 +6,45 @@ gradle = "8.3"
 androidGradlePlugin = "8.1.1"
 ktlint = "0.50.0"
 
-kotlin = "1.8.22"
+kotlin = "1.9.10"
 kotlinxCoroutines = "1.7.3"
 jetbrainsAnnotations = "24.0.1"
 androidxAppCompat = "1.6.1"
 androidxActivity = "1.7.2"
 androidxRecyclerView = "1.3.1"
-androidxLifecycle = "2.6.1"
-androidxNavigation = "2.6.0"
+androidxLifecycle = "2.6.2"
+androidxNavigation = "2.7.2"
 androidxConstraintLayout = "2.1.4"
 androidxFragment = "1.6.1"
-androidxCore = "1.10.1"
+androidxCore = "1.12.0"
 androidxCoreSplashscreen = "1.0.1"
 androidxPreference = "1.2.1"
 androidxDrawerLayout = "1.1.1"
 androidxTransition = "1.4.1"
-androidxComposeCompiler = "1.4.8"
+androidxComposeCompiler = "1.5.3"
 # https://developer.android.com/jetpack/compose/bom/bom-mapping
-androidxComposeBom = "2023.06.01"
-androidxComposeMaterial = "1.4.3"
+androidxComposeBom = "2023.09.00"
+androidxComposeMaterial = "1.5.1"
 androidxComposeMaterial3 = "1.1.1"
-accompanist = "0.30.1"
+accompanist = "0.32.0"
 fastAdapter = "5.7.0"
 preferencesFix = "1.1.0"
 timber = "5.0.1"
-koinCore = "3.4.3"
-koinAndroid = "3.4.3"
-koinAndroidCompose = "3.4.6"
-koinTest = "3.4.3"
+koinCore = "3.5.0"
+koinAndroid = "3.5.0"
+koinAndroidCompose = "3.5.0"
+koinTest = "3.5.0"
 mime4j = "0.8.9"
 okhttp = "4.11.0"
 glide = "4.16.0"
 moshi = "1.15.0"
-mockito = "5.4.0"
+mockito = "5.5.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-lint = { id = "com.android.lint", version.ref = "androidGradlePlugin" }
-ksp = "com.google.devtools.ksp:1.8.22-1.0.11"
+ksp = "com.google.devtools.ksp:1.9.10-1.0.13"
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -71,7 +71,7 @@ androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-lived
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
-androidx-annotation = "androidx.annotation:annotation:1.6.0"
+androidx-annotation = "androidx.annotation:annotation:1.7.0"
 androidx-biometric = "androidx.biometric:biometric:1.1.0"
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "androidxNavigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "androidxNavigation" }
@@ -111,7 +111,7 @@ materialdrawer = "com.mikepenz:materialdrawer:8.4.5"
 preferencex = { module = "com.takisoft.preferencex:preferencex", version.ref = "preferencesFix" }
 preferencex-datetimepicker = { module = "com.takisoft.preferencex:preferencex-datetimepicker", version.ref = "preferencesFix" }
 preferencex-colorpicker = { module = "com.takisoft.preferencex:preferencex-colorpicker", version.ref = "preferencesFix" }
-okio = "com.squareup.okio:okio:3.4.0"
+okio = "com.squareup.okio:okio:3.5.0"
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 timber = "com.jakewharton.timber:timber:5.0.1"
@@ -145,7 +145,7 @@ xmlpull = "com.github.cketti:xmlpull-extracted-from-android:1.0"
 kxml2 = "com.github.cketti:kxml2-extracted-from-android:1.0"
 
 junit = "junit:junit:4.13.2"
-robolectric = "org.robolectric:robolectric:4.9.2"
+robolectric = "org.robolectric:robolectric:4.10.3"
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:5.1.0"
 turbine = "app.cash.turbine:turbine:0.13.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 gradle = "8.3"
-androidGradlePlugin = "8.0.2"
+androidGradlePlugin = "8.1.1"
 ktlint = "0.50.0"
 
 kotlin = "1.8.22"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = "com.diffplug.spotless:6.21.0"
 detekt = "io.gitlab.arturbosch.detekt:1.23.0"
-dependency-check = "com.github.ben-manes.versions:0.46.0"
+dependency-check = "com.github.ben-manes.versions:0.48.0"
 
 [libraries]
 desugar = "com.android.tools:desugar_jdk_libs:2.0.3"


### PR DESCRIPTION
This updates dependencies for AGP 8.11 and Compose 1.5.1. 

Bumped:
- Android SDK compile 33 -> 34
- AGP 8.0.2 -> 8.1.1
- Dependency check 0.46.0 -> 0.48.0
- Kotlin 1.8.22 -> 1.9.10
- Compose BOM 2023.06.01 -> 2023.09.00
- Compose compiler 1.4.8 -> 1.5.3
- AndroidX Lifecycle 2.6.1 -> 2.6.2
- AndroidX Navigation 2.6.0 -> 2.7.2
- AndroidX Core 1.10.1 -> 1.12.0
- AndroidX Annotation 1.6.0 -> 1.7.0
- Accompanist 0.30.1 -> 0.32.0
- Koin 3.4.3 -> 3.5.0
- Okio 3.4.0 -> 3.5.0
- Mockito 5.4.0 -> 5.5.0
- Robolectric 4.9.2 -> 4.10.3

This is compatible with latest Intellij IDEA 2023.2.2

Build related issues have been moved to #7178. Once merged this could be rebased.
