### PR TITLE
Fix GitHub Actions Failure with Error Code 143

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,6 @@
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=2
+
+kotlin.incremental=false
+kotlin.compiler.execution.strategy=in-process

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,4 +28,11 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - run: ./gradlew assembleDebug detekt spotlessCheck testsOnCi
+      - name: Build
+        run: ./gradlew assembleDebug
+      - name: Detekt
+        run: ./gradlew detekt
+      - name: Spotless
+        run: ./gradlew spotlessCheck
+      - name: Tests
+        run: ./gradlew testsOnCi

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,18 +21,29 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
+
       - uses: gradle/gradle-build-action@v2
+
+      - name: Quality - Spotless
+        run: ./gradlew spotlessCheck
+
+      - name: Quality - Detekt
+        run: ./gradlew detekt
+
       - name: Build
         run: ./gradlew assembleDebug
-      - name: Detekt
-        run: ./gradlew detekt
-      - name: Spotless
-        run: ./gradlew spotlessCheck
-      - name: Tests
+
+      - name: Test
         run: ./gradlew testsOnCi

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ android.defaults.buildfeatures.shaders=false
 
 # Gradle
 ## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
-org.gradle.jvmargs=-Xmx4G -Xms1G -XX:MaxMetaspaceSize=1536M -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
 
 org.gradle.parallel=true
 


### PR DESCRIPTION
To address the build issues encountered in GitHub Actions, several changes have been made:

1.  The memory settings in gradle.properties have been updated to match those found in [Now in Android's repository](https://github.com/android/nowinandroid/blob/151f877bbe6546c78f8f03f16e56564e285fb508/gradle.properties#L11).
1. A CI-specific gradle.properties file has been added to disable both the Gradle daemon and Kotlin incremental builds.
1. The Kotlin compiler is now configured to execute in-process.

These changes aim to resolve the build failures indicated by Error Code 143.