### PR TITLE
feat: added content desc for flag / unflag on home page

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -206,6 +206,11 @@ class MessageListAdapter internal constructor(
     private val starClickListener = OnClickListener { view: View ->
         val parentView = view.parent as View
         val messageListItem = getItemFromView(parentView) ?: return@OnClickListener
+        view.contentDescription = if (messageListItem.isStarred) {
+            res.getString(R.string.flag_action)
+        } else {
+            res.getString(R.string.unflag_action)
+        }
         listItemListener.onToggleMessageFlag(messageListItem)
     }
 
@@ -387,6 +392,11 @@ class MessageListAdapter internal constructor(
 
             if (appearance.stars) {
                 holder.star.isSelected = isStarred
+                holder.starClickArea.contentDescription = if (holder.star.isSelected) {
+                    res.getString(R.string.unflag_action)
+                } else {
+                    res.getString(R.string.flag_action)
+                }
             }
             holder.uniqueId = uniqueId
             if (appearance.showContactPicture && holder.contactPicture.isVisible) {


### PR DESCRIPTION
Added a content description describing if the star button is currently set to flag or unflag the message for all messages on the home page. 

This does introduce a more minor accessibility fix because now multiple buttons will have the same label. This can be fixed by adding the title of the message to the content description, however, I was wondering if the maintainers want this level of verbosity.