### PR TITLE
Add Outcome as alternative to Kotlin Result

### DIFF
--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/Outcome.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/Outcome.kt
@@ -32,8 +32,12 @@ data class Success<out V>(val value: V) : Outcome<V, Nothing>
  * Represents a failed [Outcome] with an error of type [E]..
  *
  * @param error The error of the failed [Outcome].
+ * @param cause The cause of the failed [Outcome].
  */
-data class Failure<out E>(val error: E) : Outcome<Nothing, E>
+data class Failure<out E>(
+    val error: E,
+    val cause: Any? = null,
+) : Outcome<Nothing, E>
 
 /**
  * Convert a Result of type [T] to an Outcome of type [T] and [Throwable].

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/Outcome.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/Outcome.kt
@@ -1,0 +1,61 @@
+package app.k9mail.core.common.outcome
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+/**
+ * [Outcome] is a type that represents a value that can either be
+ * - a [Success] (with a value of type [V])
+ * - a [Failure] (with a value of type [E]).
+ *
+ * @param V The type of the value of a successful [Outcome].
+ * @param E The type of the error of a failed [Outcome].
+ */
+sealed interface Outcome<out V, out E> {
+
+    val isSuccess: Boolean
+        get() = this is Success
+
+    val isFailure: Boolean
+        get() = this is Failure
+}
+
+/**
+ * Represents a successful [Outcome] with a value of type [V].
+ *
+ * @param value The value of the successful [Outcome].
+ */
+data class Success<out V>(val value: V) : Outcome<V, Nothing>
+
+/**
+ * Represents a failed [Outcome] with an error of type [E]..
+ *
+ * @param error The error of the failed [Outcome].
+ */
+data class Failure<out E>(val error: E) : Outcome<Nothing, E>
+
+/**
+ * Convert a Result of type [T] to an Outcome of type [T] and [Throwable].
+ *
+ * @param T The type of the value of a successful [Outcome].
+ */
+fun <T> Result<T>.asOutcome(): Outcome<T, Throwable> {
+    return fold(
+        onSuccess = { Success(it) },
+        onFailure = { Failure(it) },
+    )
+}
+
+/**
+ * Convert a Flow of type [T] to a Flow of type [Outcome] of type [T] and [Throwable].
+ *
+ * @param T The type of the value of a successful [Outcome].
+ */
+fun <T> Flow<T>.asOutcome(): Flow<Outcome<T, Throwable>> {
+    return map<T, Outcome<T, Throwable>> {
+        Success(it)
+    }.catch { error ->
+        emit(Failure(error))
+    }
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensions.kt
@@ -12,11 +12,11 @@ import kotlin.contracts.contract
  */
 fun <IN_SUCCESS, IN_FAILURE, OUT_SUCCESS, OUT_FAILURE> Outcome<IN_SUCCESS, IN_FAILURE>.map(
     transformSuccess: (IN_SUCCESS) -> OUT_SUCCESS,
-    transformFailure: (IN_FAILURE) -> OUT_FAILURE,
+    transformFailure: (IN_FAILURE, Any?) -> OUT_FAILURE,
 ): Outcome<OUT_SUCCESS, OUT_FAILURE> {
     return when (this) {
         is Success -> Success(transformSuccess(value))
-        is Failure -> Failure(transformFailure(error))
+        is Failure -> Failure(transformFailure(error, cause))
     }
 }
 
@@ -46,7 +46,7 @@ inline infix fun <V, E, O> Outcome<V, E>.mapValue(
  */
 @OptIn(ExperimentalContracts::class)
 inline infix fun <V, E, O> Outcome<V, E>.mapError(
-    transform: (E) -> O,
+    transform: (E, Any?) -> O,
 ): Outcome<V, O> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
@@ -54,6 +54,6 @@ inline infix fun <V, E, O> Outcome<V, E>.mapError(
 
     return when (this) {
         is Success -> this
-        is Failure -> Failure(transform(error))
+        is Failure -> Failure(transform(error, cause))
     }
 }

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensions.kt
@@ -1,0 +1,59 @@
+package app.k9mail.core.common.outcome
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Map the value and error of an [Outcome] to a new value.
+ *
+ * @param transformSuccess The function to transform the value of a [Success] to a new value.
+ * @param transformFailure The function to transform the value of a [Failure] to a new value.
+ */
+fun <IN_SUCCESS, IN_FAILURE, OUT_SUCCESS, OUT_FAILURE> Outcome<IN_SUCCESS, IN_FAILURE>.map(
+    transformSuccess: (IN_SUCCESS) -> OUT_SUCCESS,
+    transformFailure: (IN_FAILURE) -> OUT_FAILURE,
+): Outcome<OUT_SUCCESS, OUT_FAILURE> {
+    return when (this) {
+        is Success -> Success(transformSuccess(value))
+        is Failure -> Failure(transformFailure(error))
+    }
+}
+
+/**
+ * Map the value of a success [Outcome] to a new value.
+ *
+ * @param transform The function to transform the value of a [Success] to a new value.
+ */
+@OptIn(ExperimentalContracts::class)
+inline infix fun <V, E, O> Outcome<V, E>.mapValue(
+    transform: (V) -> O,
+): Outcome<O, E> {
+    contract {
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Success -> Success(transform(value))
+        is Failure -> this
+    }
+}
+
+/**
+ * Map the value of a failure [Outcome] to a new value.
+ *
+ * @param transform The function to transform the value of a [Failure] to a new value.
+ */
+@OptIn(ExperimentalContracts::class)
+inline infix fun <V, E, O> Outcome<V, E>.mapError(
+    transform: (E) -> O,
+): Outcome<V, O> {
+    contract {
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Success -> this
+        is Failure -> Failure(transform(error))
+    }
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensions.kt
@@ -25,14 +25,14 @@ inline infix fun <V, E> Outcome<V, E>.onSuccess(action: (V) -> Unit): Outcome<V,
  */
 @OptIn(ExperimentalContracts::class)
 inline infix fun <V, E> Outcome<V, E>.onFailure(
-    action: (E) -> Unit,
+    action: (E, Any?) -> Unit,
 ): Outcome<V, E> {
     contract {
         callsInPlace(action, InvocationKind.AT_MOST_ONCE)
     }
 
     if (this is Failure) {
-        action(error)
+        action(error, cause)
     }
 
     return this

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensions.kt
@@ -1,0 +1,39 @@
+package app.k9mail.core.common.outcome
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Invokes an action if the [Outcome] is a [Success].
+ */
+@OptIn(ExperimentalContracts::class)
+inline infix fun <V, E> Outcome<V, E>.onSuccess(action: (V) -> Unit): Outcome<V, E> {
+    contract {
+        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+    }
+
+    if (this is Success) {
+        action(value)
+    }
+
+    return this
+}
+
+/**
+ * Invokes an action if the [Outcome] is a [Failure].
+ */
+@OptIn(ExperimentalContracts::class)
+inline infix fun <V, E> Outcome<V, E>.onFailure(
+    action: (E) -> Unit,
+): Outcome<V, E> {
+    contract {
+        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+    }
+
+    if (this is Failure) {
+        action(error)
+    }
+
+    return this
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensions.kt
@@ -32,3 +32,18 @@ fun <V, E> Outcome<V, E>.unwrapError(): E {
         is Failure -> error
     }
 }
+
+/**
+ * Unwrap the cause of a failed [Outcome].
+ */
+@OptIn(ExperimentalContracts::class)
+fun <V, E> Outcome<V, E>.unwrapCause(): Any? {
+    contract {
+        returns() implies (this@unwrapCause is Failure<E>)
+    }
+
+    return when (this) {
+        is Success -> error("Calling Outcome.unwrapCause on a Success is not possible")
+        is Failure -> cause
+    }
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensions.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensions.kt
@@ -1,0 +1,34 @@
+package app.k9mail.core.common.outcome
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Unwrap the value of a successful [Outcome].
+ */
+@OptIn(ExperimentalContracts::class)
+fun <V, E> Outcome<V, E>.unwrapValue(): V {
+    contract {
+        returns() implies (this@unwrapValue is Success<V>)
+    }
+
+    return when (this) {
+        is Success -> value
+        is Failure -> error("Calling Outcome.unwrapValue on a Failure is not possible")
+    }
+}
+
+/**
+ * Unwrap the error of a failed [Outcome].
+ */
+@OptIn(ExperimentalContracts::class)
+fun <V, E> Outcome<V, E>.unwrapError(): E {
+    contract {
+        returns() implies (this@unwrapError is Failure<E>)
+    }
+
+    return when (this) {
+        is Success -> error("Calling Outcome.unwrapError on a Success is not possible")
+        is Failure -> error
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensionsKtTest.kt
@@ -1,0 +1,59 @@
+package app.k9mail.core.common.outcome
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+class OutcomeMapExtensionsKtTest {
+
+    @Test
+    fun `should map success and failure outcome to new outcome`() {
+        val success = Success("success")
+        val failure = Failure("failure")
+
+        val transformSuccess: (String) -> Int = { 1 }
+        val transformFailure: (String) -> Exception = { Exception("failure exception") }
+
+        val mappedSuccess = success.map(transformSuccess, transformFailure)
+        val mappedFailure = failure.map(transformSuccess, transformFailure)
+
+        assertThat(mappedSuccess).isEqualTo(Success(1))
+        assertThat(mappedFailure.unwrapError().message).isEqualTo("failure exception")
+    }
+
+    @Test
+    fun `mapValue should map value of success outcome to new outcome`() {
+        val success = Success("success")
+
+        val mappedSuccess = success mapValue { 1 }
+
+        assertThat(mappedSuccess).isEqualTo(Success(1))
+    }
+
+    @Test
+    fun `mapValue should keep failure`() {
+        val failure = Failure("failure")
+
+        val mappedFailure = failure mapValue { 1 }
+
+        assertThat(mappedFailure).isEqualTo(failure)
+    }
+
+    @Test
+    fun `mapError should map error of failure outcome to new outcome`() {
+        val failure = Failure("failure")
+
+        val mappedFailure = failure mapError { Exception("failure exception") }
+
+        assertThat(mappedFailure.unwrapError().message).isEqualTo("failure exception")
+    }
+
+    @Test
+    fun `mapError should keep success`() {
+        val success = Success("success")
+
+        val mappedSuccess = success mapError { Exception("failure exception") }
+
+        assertThat(mappedSuccess).isEqualTo(success)
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeMapExtensionsKtTest.kt
@@ -9,16 +9,18 @@ class OutcomeMapExtensionsKtTest {
     @Test
     fun `should map success and failure outcome to new outcome`() {
         val success = Success("success")
-        val failure = Failure("failure")
+        val failure = Failure("failure", "cause")
 
         val transformSuccess: (String) -> Int = { 1 }
-        val transformFailure: (String) -> Exception = { Exception("failure exception") }
+        val transformFailure: (String, Any?) -> Exception = { error, cause ->
+            Exception("error: $error, cause: $cause")
+        }
 
         val mappedSuccess = success.map(transformSuccess, transformFailure)
         val mappedFailure = failure.map(transformSuccess, transformFailure)
 
         assertThat(mappedSuccess).isEqualTo(Success(1))
-        assertThat(mappedFailure.unwrapError().message).isEqualTo("failure exception")
+        assertThat(mappedFailure.unwrapError().message).isEqualTo("error: failure, cause: cause")
     }
 
     @Test
@@ -43,7 +45,7 @@ class OutcomeMapExtensionsKtTest {
     fun `mapError should map error of failure outcome to new outcome`() {
         val failure = Failure("failure")
 
-        val mappedFailure = failure mapError { Exception("failure exception") }
+        val mappedFailure = failure mapError { _, _ -> Exception("failure exception") }
 
         assertThat(mappedFailure.unwrapError().message).isEqualTo("failure exception")
     }
@@ -52,7 +54,7 @@ class OutcomeMapExtensionsKtTest {
     fun `mapError should keep success`() {
         val success = Success("success")
 
-        val mappedSuccess = success mapError { Exception("failure exception") }
+        val mappedSuccess = success mapError { _, _ -> Exception("failure exception") }
 
         assertThat(mappedSuccess).isEqualTo(success)
     }

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensionsKtTest.kt
@@ -1,0 +1,56 @@
+package app.k9mail.core.common.outcome
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+class OutcomeOnExtensionsKtTest {
+
+    @Test
+    fun `should invoke onSuccess action when success`() {
+        val success = Success("success")
+        var invoked = false
+
+        success onSuccess {
+            invoked = true
+        }
+
+        assertThat(invoked).isEqualTo(true)
+    }
+
+    @Test
+    fun `should not invoke onSuccess action when failure`() {
+        val failure = Failure("failure")
+        var invoked = false
+
+        failure onSuccess {
+            invoked = true
+        }
+
+        assertThat(invoked).isEqualTo(false)
+    }
+
+    @Test
+    fun `should invoke onFailure action when failure`() {
+        val failure = Failure("failure")
+        var invoked = false
+
+        failure onFailure {
+            invoked = true
+        }
+
+        assertThat(invoked).isEqualTo(true)
+    }
+
+    @Test
+    fun `should not invoke onFailure action when success`() {
+        val success = Success("success")
+        var invoked = false
+
+        success onFailure {
+            invoked = true
+        }
+
+        assertThat(invoked).isEqualTo(false)
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeOnExtensionsKtTest.kt
@@ -10,12 +10,15 @@ class OutcomeOnExtensionsKtTest {
     fun `should invoke onSuccess action when success`() {
         val success = Success("success")
         var invoked = false
+        var value: String? = null
 
         success onSuccess {
             invoked = true
+            value = it
         }
 
         assertThat(invoked).isEqualTo(true)
+        assertThat(value).isEqualTo("success")
     }
 
     @Test
@@ -32,14 +35,20 @@ class OutcomeOnExtensionsKtTest {
 
     @Test
     fun `should invoke onFailure action when failure`() {
-        val failure = Failure("failure")
+        val failure = Failure("failure", "cause")
         var invoked = false
+        var failureError: String? = null
+        var failureCause: Any? = null
 
-        failure onFailure {
+        failure onFailure { error, cause ->
             invoked = true
+            failureError = error
+            failureCause = cause
         }
 
         assertThat(invoked).isEqualTo(true)
+        assertThat(failureError).isEqualTo("failure")
+        assertThat(failureCause).isEqualTo("cause")
     }
 
     @Test
@@ -47,7 +56,7 @@ class OutcomeOnExtensionsKtTest {
         val success = Success("success")
         var invoked = false
 
-        success onFailure {
+        success onFailure { _, _ ->
             invoked = true
         }
 

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeTest.kt
@@ -1,0 +1,65 @@
+package app.k9mail.core.common.outcome
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class OutcomeTest {
+
+    @Test
+    fun `should check for success`() {
+        val outcome = Success("success")
+
+        assertThat(outcome.isSuccess).isTrue()
+        assertThat(outcome.isFailure).isFalse()
+        assertThat(outcome.value).isEqualTo("success")
+    }
+
+    @Test
+    fun `should check for failure`() {
+        val outcome = Failure("failure")
+
+        assertThat(outcome.isSuccess).isFalse()
+        assertThat(outcome.isFailure).isTrue()
+        assertThat(outcome.error).isEqualTo("failure")
+    }
+
+    @Test
+    fun `should convert result to outcome`() {
+        val result = Result.success("test")
+
+        val outcome = result.asOutcome()
+
+        assertThat(outcome)
+            .isInstanceOf(Success::class)
+            .prop("value") { Success<String>::value.call(it) }
+            .isEqualTo("test")
+    }
+
+    @Test
+    fun `should convert flow to outcome`() = runTest {
+        flow {
+            emit("test")
+            throw IllegalArgumentException("some error")
+        }.asOutcome()
+            .test {
+                assertThat(awaitItem()).isEqualTo(Success("test"))
+
+                assertThat(awaitItem())
+                    .isInstanceOf(Failure::class)
+                    .prop("NAME") { Failure<Exception>::error.call(it) }
+                    .isInstanceOf(IllegalArgumentException::class)
+                    .prop(IllegalArgumentException::message)
+                    .isEqualTo("some error")
+
+                awaitComplete()
+            }
+    }
+}

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensionsKtTest.kt
@@ -37,4 +37,20 @@ class OutcomeUnwrapExtensionsKtTest {
 
         outcome.unwrapError()
     }
+
+    @Test
+    fun `should unwrap cause of a failure outcome`() {
+        val failure = Failure("failure", "cause") as Outcome<String, String>
+
+        val unwrappedCause = failure.unwrapCause()
+
+        assertThat(unwrappedCause).isEqualTo("cause")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw error when unwrapping cause of a success outcome`() {
+        val outcome = Success("success") as Outcome<String, String>
+
+        outcome.unwrapCause()
+    }
 }

--- a/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensionsKtTest.kt
+++ b/core/common/src/test/kotlin/app/k9mail/core/common/outcome/OutcomeUnwrapExtensionsKtTest.kt
@@ -1,0 +1,40 @@
+package app.k9mail.core.common.outcome
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+class OutcomeUnwrapExtensionsKtTest {
+
+    @Test
+    fun `should unwrap value of success outcome`() {
+        val outcome = Success("success") as Outcome<String, String>
+
+        val unwrappedValue = outcome.unwrapValue()
+
+        assertThat(unwrappedValue).isEqualTo("success")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw error when unwrapping value of failure outcome`() {
+        val outcome = Failure("failure") as Outcome<String, String>
+
+        outcome.unwrapValue()
+    }
+
+    @Test
+    fun `should unwrap error of failure outcome`() {
+        val failure = Failure("failure") as Outcome<String, String>
+
+        val unwrappedError = failure.unwrapError()
+
+        assertThat(unwrappedError).isEqualTo("failure")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw error when unwrapping error of success outcome`() {
+        val outcome = Success("success") as Outcome<String, String>
+
+        outcome.unwrapError()
+    }
+}

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupContract.kt
@@ -21,12 +21,11 @@ interface AccountSetupContract {
     )
 
     sealed interface Event {
-        object OnNext : Event
-
         data class OnAutoDiscoveryFinished(
             val isAutomaticConfig: Boolean,
         ) : Event
 
+        object OnNext : Event
         object OnBack : Event
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,6 +161,7 @@ detekt-plugin-compose = "io.nlopez.compose.rules:detekt:0.1.11"
 shared-jvm-main = [
   "koin-core",
   "kotlinx-datetime",
+  "kotlinx-coroutines-core",
 ]
 shared-jvm-android = [
   "androidx-core",
@@ -190,6 +191,7 @@ shared-jvm-androidtest-compose = [
 ]
 shared-jvm-test = [
   "kotlin-test",
+  "kotlinx-coroutines-test",
   "junit",
   "assertk",
   "mockito-core",


### PR DESCRIPTION
This introduces `Outcome` as a substitute for Kotlin's `Result`, removing the constraint of having to use `Throwable` for failure scenarios.

It also adds some Outcome extensions for convenience.