### PR TITLE
Fix OAuth 2.0 for Yahoo and AOL

### DIFF
--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepository.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepository.kt
@@ -14,6 +14,7 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.CodeVerifierUtil
 import net.openid.appauth.ResponseTypeValues
 import timber.log.Timber
 
@@ -80,9 +81,11 @@ class AuthorizationRepository(
             configuration.redirectUri.toUri(),
         )
 
+        val codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier()
+
         val authRequest = authRequestBuilder
             .setScope(configuration.scopes.joinToString(" "))
-            .setCodeVerifier(null)
+            .setCodeVerifier(codeVerifier)
             .setLoginHint(emailAddress)
             .build()
 

--- a/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepositoryTest.kt
+++ b/feature/account/oauth/src/test/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepositoryTest.kt
@@ -9,6 +9,7 @@ import app.k9mail.feature.account.oauth.domain.entity.AuthorizationResult
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
@@ -72,8 +73,10 @@ class AuthorizationRepositoryTest {
                 prop(AuthorizationRequest::responseType).isEqualTo(ResponseTypeValues.CODE)
                 prop(AuthorizationRequest::redirectUri).isEqualTo(oAuthConfiguration.redirectUri.toUri())
                 prop(AuthorizationRequest::scope).isEqualTo("scope scope2")
-                prop(AuthorizationRequest::codeVerifier).isNull()
                 prop(AuthorizationRequest::loginHint).isEqualTo(emailAddress)
+                prop(AuthorizationRequest::codeVerifier).isNotNull()
+                prop(AuthorizationRequest::codeVerifierChallengeMethod).isEqualTo("S256")
+                prop(AuthorizationRequest::codeVerifierChallenge).isNotNull().isNotEmpty()
             }
         }
 


### PR DESCRIPTION
Yahoo and AOL OAuth 2.0 was broken, because they removed support for plain Authentication Codes and authentication requests without any code challenge mechanism. Now they only support Authorization Codes with PKCE. As this is Mandatory To Implement (MTI) for OAuth servers according to [RFC7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2), we will enable it for all supported OAuth 2.0 providers.

Fixes: #7159 and #7132
