### PR TITLE
Fix `ValidateServerSettings` Koin definition (`clientIdAppName`)

### DIFF
--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModule.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModule.kt
@@ -12,6 +12,7 @@ import com.fsck.k9.mail.store.imap.ImapServerSettingsValidator
 import com.fsck.k9.mail.store.pop3.Pop3ServerSettingsValidator
 import com.fsck.k9.mail.transport.smtp.SmtpServerSettingsValidator
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val featureAccountServerValidationModule = module {
@@ -28,7 +29,7 @@ val featureAccountServerValidationModule = module {
             imapValidator = ImapServerSettingsValidator(
                 trustedSocketFactory = get(),
                 oAuth2TokenProviderFactory = get(),
-                clientIdAppName = "null", // TODO get real value
+                clientIdAppName = get(named("ClientIdAppName")),
             ),
             pop3Validator = Pop3ServerSettingsValidator(
                 trustedSocketFactory = get(),

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.test.KoinTest
@@ -42,6 +43,7 @@ class ServerValidationModuleKtTest : KoinTest {
             }
         }
         single<LocalKeyStore> { Mockito.mock() }
+        single(named("ClientIdAppName")) { "App Name" }
     }
 
     @OptIn(KoinExperimentalAPI::class)


### PR DESCRIPTION
Fetch the app name to use with IMAP's ID command via Koin.