### PR TITLE
Add GitHub workflow to mark and close stale pull-requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          close-pr-message: 'This pull request has been automatically closed due to inactivity.'
+          close-issue-message: 'This issue has been automatically closed due to inactivity.'
+          days-before-pr-stale: 45
+          days-before-issue-stale: -1 # never stale
+          days-before-close: 14


### PR DESCRIPTION
This aims to automate handling of old pull-request by marking and closing them when there is no activity. See: https://github.com/actions/stale

Pull-requests are marked as stale after 45 days without activity and closed 14 days after marked as stale.

Issues have been excluded from this check.