### PR TITLE
Change `PasswordTextfield` and `PasswordInput` to check for password reveal permission

### DIFF
--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/ColorItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/ColorItems.kt
@@ -14,6 +14,7 @@ import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.ui.catalog.ui.common.list.itemDefaultPadding
 import app.k9mail.ui.catalog.ui.common.list.sectionHeaderItem
 
+@Suppress("LongMethod")
 fun LazyGridScope.colorItems() {
     sectionHeaderItem(text = "Material theme colors")
     item {
@@ -54,8 +55,26 @@ fun LazyGridScope.colorItems() {
     }
     item {
         ColorContent(
+            name = "Success",
+            color = MainTheme.colors.success,
+        )
+    }
+    item {
+        ColorContent(
             name = "Error",
             color = MainTheme.colors.error,
+        )
+    }
+    item {
+        ColorContent(
+            name = "Warning",
+            color = MainTheme.colors.warning,
+        )
+    }
+    item {
+        ColorContent(
+            name = "Info",
+            color = MainTheme.colors.info,
         )
     }
 }

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/TextFieldItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/items/TextFieldItems.kt
@@ -54,6 +54,7 @@ data class TextFieldState<T>(
     val isRequired: Boolean = false,
     val hasError: Boolean = false,
     val isSingleLine: Boolean = false,
+    val hasRevealPasswordPermission: Boolean = false,
 )
 
 @Suppress("LongMethod")
@@ -63,6 +64,7 @@ fun <T> TextFieldDemo(
     modifier: Modifier = Modifier,
     hasTrailingIcon: Boolean = false,
     hasSingleLine: Boolean = false,
+    hasRevealPasswordPermission: Boolean = false,
     content: @Composable (state: MutableState<TextFieldState<T>>) -> Unit,
 ) {
     WithRememberedState(input = initialState) { state ->
@@ -140,6 +142,15 @@ fun <T> TextFieldDemo(
                         contentPadding = defaultPadding,
                     )
                 }
+
+                if (hasRevealPasswordPermission) {
+                    CheckboxInput(
+                        text = "Has reveal password permission",
+                        checked = state.value.hasRevealPasswordPermission,
+                        onCheckedChange = { state.value = state.value.copy(hasRevealPasswordPermission = it) },
+                        contentPadding = defaultPadding,
+                    )
+                }
             }
         }
     }
@@ -181,6 +192,7 @@ private fun LazyGridScope.passwordTextFieldOutlinedItems() {
                 input = "",
                 label = "Password",
             ),
+            hasRevealPasswordPermission = true,
         ) { state ->
             TextFieldOutlinedPassword(
                 value = state.value.input,
@@ -190,6 +202,9 @@ private fun LazyGridScope.passwordTextFieldOutlinedItems() {
                 isReadOnly = state.value.isReadOnly,
                 isRequired = state.value.isRequired,
                 hasError = state.value.hasError,
+                checkRevealPasswordPermission = {
+                    state.value.hasRevealPasswordPermission
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/molecule/items/InputItems.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/molecule/items/InputItems.kt
@@ -115,6 +115,18 @@ fun LazyGridScope.inputItems() {
             }
         }
     }
+    sectionSubtitleItem(text = "With password reveal permission")
+    item {
+        ItemOutlined {
+            WithRememberedState(input = "my password") { state ->
+                PasswordInput(
+                    password = state.value,
+                    onPasswordChange = { state.value = it },
+                    checkRevealPasswordPermission = { true },
+                )
+            }
+        }
+    }
 
     sectionHeaderItem(text = "SelectInput")
     item {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPassword.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPassword.kt
@@ -29,6 +29,7 @@ fun TextFieldOutlinedPassword(
     isEnabled: Boolean = true,
     isReadOnly: Boolean = false,
     isRequired: Boolean = false,
+    checkRevealPasswordPermission: () -> Boolean = { false },
     hasError: Boolean = false,
 ) {
     var passwordVisibilityState by rememberSaveable { mutableStateOf(false) }
@@ -42,7 +43,11 @@ fun TextFieldOutlinedPassword(
         trailingIcon = selectTrailingIcon(
             isEnabled = isEnabled,
             isPasswordVisible = passwordVisibilityState,
-            onClick = { passwordVisibilityState = !passwordVisibilityState },
+            onClick = {
+                if (checkRevealPasswordPermission()) {
+                    passwordVisibilityState = !passwordVisibilityState
+                }
+            },
         ),
         readOnly = isReadOnly,
         isError = hasError,

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/InputLayout.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/InputLayout.kt
@@ -15,6 +15,7 @@ internal fun InputLayout(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = inputContentPadding(),
     errorMessage: String? = null,
+    warningMessage: String? = null,
     content: @Composable () -> Unit,
 ) {
     Column(
@@ -30,6 +31,14 @@ internal fun InputLayout(
                 text = errorMessage ?: "",
                 modifier = Modifier.padding(start = MainTheme.spacings.double, top = MainTheme.spacings.half),
                 color = MainTheme.colors.error,
+            )
+        }
+
+        AnimatedVisibility(visible = warningMessage != null) {
+            TextCaption(
+                text = warningMessage ?: "",
+                modifier = Modifier.padding(start = MainTheme.spacings.double, top = MainTheme.spacings.half),
+                color = MainTheme.colors.warning,
             )
         }
     }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/PasswordInput.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/PasswordInput.kt
@@ -3,6 +3,10 @@ package app.k9mail.core.ui.compose.designsystem.molecule.input
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,20 +19,36 @@ fun PasswordInput(
     onPasswordChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     password: String = "",
+    checkRevealPasswordPermission: () -> Boolean = { false },
     isRequired: Boolean = false,
     errorMessage: String? = null,
     contentPadding: PaddingValues = inputContentPadding(),
 ) {
+    var showPermissionInfo by remember { mutableStateOf(false) }
+
     InputLayout(
         modifier = modifier,
         contentPadding = contentPadding,
         errorMessage = errorMessage,
+        warningMessage = if (showPermissionInfo) {
+            stringResource(id = R.string.designsystem_molecule_password_input_permission_warning)
+        } else {
+            null
+        },
     ) {
         TextFieldOutlinedPassword(
             value = password,
-            onValueChange = onPasswordChange,
+            onValueChange = {
+                onPasswordChange(it)
+                showPermissionInfo = false
+            },
             label = stringResource(id = R.string.designsystem_molecule_password_input_label),
             isRequired = isRequired,
+            checkRevealPasswordPermission = {
+                checkRevealPasswordPermission().also {
+                    showPermissionInfo = !it
+                }
+            },
             hasError = errorMessage != null,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -52,6 +72,17 @@ internal fun PasswordInputWithErrorPreview() {
         PasswordInput(
             onPasswordChange = {},
             errorMessage = "Password error",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun PasswordInputWithNoPermissionPreview() {
+    PreviewWithThemes {
+        PasswordInput(
+            onPasswordChange = {},
+            checkRevealPasswordPermission = { false },
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/res/values/strings.xml
+++ b/core/ui/compose/designsystem/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="designsystem_atom_password_textfield_show_password">Show password</string>
     <string name="designsystem_molecule_email_address_input_label">Email address</string>
     <string name="designsystem_molecule_password_input_label">Password</string>
+    <string name="designsystem_molecule_password_input_permission_warning">You don\'t have permission to reveal the password</string>
     <string name="designsystem_molecule_error_view_button_retry">Retry</string>
 </resources>

--- a/core/ui/compose/designsystem/src/test/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPasswordKtTest.kt
+++ b/core/ui/compose/designsystem/src/test/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedPasswordKtTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import app.k9mail.core.ui.compose.designsystem.R
 import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.onNodeWithText
+import app.k9mail.core.ui.compose.testing.setContent
 import org.junit.Test
 
 private const val PASSWORD = "Password input"
@@ -27,11 +29,41 @@ class TextFieldOutlinedPasswordKtTest : ComposeTest() {
     }
 
     @Test
-    fun `should display password when show password is clicked`() = runComposeTest {
+    fun `should not reveal password by default`() = runComposeTest {
         setContent {
             TextFieldOutlinedPassword(
                 value = PASSWORD,
                 onValueChange = {},
+            )
+        }
+
+        onShowPasswordNode().performClick()
+
+        onNodeWithText(PASSWORD).assertDoesNotExist()
+    }
+
+    @Test
+    fun `should not reveal password if permission is not granted`() = runComposeTest {
+        setContent {
+            TextFieldOutlinedPassword(
+                value = PASSWORD,
+                onValueChange = {},
+                checkRevealPasswordPermission = { false },
+            )
+        }
+
+        onShowPasswordNode().performClick()
+
+        onNodeWithText(PASSWORD).assertDoesNotExist()
+    }
+
+    @Test
+    fun `should show password when show password is clicked`() = runComposeTest {
+        setContent {
+            TextFieldOutlinedPassword(
+                value = PASSWORD,
+                onValueChange = {},
+                checkRevealPasswordPermission = { true },
             )
         }
 
@@ -46,6 +78,7 @@ class TextFieldOutlinedPasswordKtTest : ComposeTest() {
             TextFieldOutlinedPassword(
                 value = PASSWORD,
                 onValueChange = {},
+                checkRevealPasswordPermission = { true },
             )
         }
         onShowPasswordNode().performClick()
@@ -61,6 +94,7 @@ class TextFieldOutlinedPasswordKtTest : ComposeTest() {
             TextFieldOutlinedPassword(
                 value = PASSWORD,
                 onValueChange = {},
+                checkRevealPasswordPermission = { true },
             )
         }
 
@@ -75,6 +109,7 @@ class TextFieldOutlinedPasswordKtTest : ComposeTest() {
             TextFieldOutlinedPassword(
                 value = PASSWORD,
                 onValueChange = {},
+                checkRevealPasswordPermission = { true },
             )
         }
         onShowPasswordNode().performClick()

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -130,6 +130,7 @@ internal fun IncomingServerSettingsContent(
                         password = state.password.value,
                         errorMessage = state.password.error?.toResourceString(resources),
                         onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
+                        checkRevealPasswordPermission = { true },
                         contentPadding = defaultItemPadding(),
                     )
                 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
@@ -124,6 +124,7 @@ internal fun OutgoingServerSettingsContent(
                         password = state.password.value,
                         errorMessage = state.password.error?.toResourceString(resources),
                         onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
+                        checkRevealPasswordPermission = { true },
                         isRequired = true,
                         contentPadding = defaultItemPadding(),
                     )

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/item/PasswordItem.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/item/PasswordItem.kt
@@ -26,6 +26,7 @@ internal fun LazyItemScope.PasswordItem(
             password = password,
             errorMessage = error?.toResourceString(resources),
             onPasswordChange = onPasswordChange,
+            checkRevealPasswordPermission = { true },
             contentPadding = PaddingValues(),
         )
     }


### PR DESCRIPTION
This adds a permission check to reveal the password to the `PasswordInput` and `PasswordOutlinedTextField`. It's default is no allowance, so consumers needed to adapt.

Also added missing colors to the catalog app.

This will conflict with #7195 and either this or the other needs to be patched after merge.
