### PR TITLE
Change `message_view_recipient_prefix` string to not require a trailing space

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientLayoutCreator.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientLayoutCreator.kt
@@ -1,7 +1,5 @@
 package com.fsck.k9.ui.messageview
 
-import android.text.SpannableStringBuilder
-
 private const val LIST_SEPARATOR = ", "
 
 /**
@@ -19,7 +17,7 @@ private const val LIST_SEPARATOR = ", "
 internal class RecipientLayoutCreator(
     private val textMeasure: TextMeasure,
     private val maxNumberOfRecipientNames: Int,
-    private val recipientsPrefix: String,
+    private val recipientsFormat: String,
     private val additionalRecipientSpacing: Int,
     private val additionalRecipientsPrefix: String,
 ) {
@@ -30,14 +28,9 @@ internal class RecipientLayoutCreator(
     ): RecipientLayoutData {
         require(recipientNames.isNotEmpty())
 
-        val displayRecipientsBuilder = SpannableStringBuilder()
-
         if (recipientNames.size == 1) {
-            displayRecipientsBuilder.append(recipientsPrefix)
-            displayRecipientsBuilder.append(recipientNames.first())
-
             return RecipientLayoutData(
-                recipientNames = displayRecipientsBuilder,
+                recipientNames = recipientsFormat.format(recipientNames.first()),
                 additionalRecipients = null,
             )
         }
@@ -46,12 +39,11 @@ internal class RecipientLayoutCreator(
 
         val maxRecipientNames = recipientNames.size.coerceAtMost(maxNumberOfRecipientNames)
         for (numberOfDisplayRecipients in maxRecipientNames downTo 2) {
-            displayRecipientsBuilder.clear()
-            displayRecipientsBuilder.append(recipientsPrefix)
-
-            recipientNames.asSequence()
+            val recipientNamesString = recipientNames.asSequence()
                 .take(numberOfDisplayRecipients)
-                .joinTo(displayRecipientsBuilder, separator = LIST_SEPARATOR)
+                .joinToString(separator = LIST_SEPARATOR)
+
+            val displayRecipients = recipientsFormat.format(recipientNamesString)
 
             additionalRecipientsBuilder.setLength(0)
             val numberOfAdditionalRecipients = totalNumberOfRecipients - numberOfDisplayRecipients
@@ -60,20 +52,16 @@ internal class RecipientLayoutCreator(
                 additionalRecipientsBuilder.append(numberOfAdditionalRecipients)
             }
 
-            if (doesTextFitAvailableWidth(displayRecipientsBuilder, additionalRecipientsBuilder, availableWidth)) {
+            if (doesTextFitAvailableWidth(displayRecipients, additionalRecipientsBuilder, availableWidth)) {
                 return RecipientLayoutData(
-                    recipientNames = displayRecipientsBuilder,
+                    recipientNames = displayRecipients,
                     additionalRecipients = additionalRecipientsBuilder.toStringOrNull(),
                 )
             }
         }
 
-        displayRecipientsBuilder.clear()
-        displayRecipientsBuilder.append(recipientsPrefix)
-        displayRecipientsBuilder.append(recipientNames.first())
-
         return RecipientLayoutData(
-            recipientNames = displayRecipientsBuilder,
+            recipientNames = recipientsFormat.format(recipientNames.first()),
             additionalRecipients = "$additionalRecipientsPrefix${totalNumberOfRecipients - 1}",
         )
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
@@ -68,7 +68,7 @@ class RecipientNamesView(context: Context, attrs: AttributeSet?) : ViewGroup(con
         recipientLayoutCreator = RecipientLayoutCreator(
             textMeasure = textMeasure,
             maxNumberOfRecipientNames = MAX_NUMBER_OF_RECIPIENT_NAMES,
-            recipientsPrefix = context.getString(R.string.message_view_recipient_prefix),
+            recipientsFormat = context.getString(R.string.message_view_recipients_format),
             additionalRecipientSpacing = additionRecipientSpacing,
             additionalRecipientsPrefix = context.getString(R.string.message_view_additional_recipient_prefix),
         )

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -199,8 +199,8 @@
   <string name="message_view_cc_label">نسخة كربونية :</string>
   <string name="message_view_bcc_label">نسخة مخفية:</string>
   <string name="message_view_status_attachment_not_saved">غير قادر على حفظ المُرفَق.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">إلي</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">إلي <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -195,8 +195,8 @@
   <string name="message_view_cc_label">Копія:</string>
   <string name="message_view_bcc_label">Схаваная копія:</string>
   <string name="message_view_status_attachment_not_saved">Немагчыма захаваць далучаныя файлы.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"да "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">да <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -180,7 +180,7 @@
   <string name="message_view_cc_label">Копие:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Не може да запази прикачения файл.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -161,7 +161,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">N\'haller ket enrollañ ar stagadenn.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">A/c:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">No s\'ha pogut desar l\'adjunt.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"a "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">a <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -195,8 +195,8 @@
   <string name="message_view_cc_label">Kopie:</string>
   <string name="message_view_bcc_label">Skrytá kopie (Bcc):</string>
   <string name="message_view_status_attachment_not_saved">Přílohu se nedaří uložit.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"komu "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">komu <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -194,7 +194,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Methu â chadw\'r atodiad.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -189,8 +189,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Kunne ikke gemme vedhæftning.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"til "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">til <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">CC:</string>
   <string name="message_view_bcc_label">BCC:</string>
   <string name="message_view_status_attachment_not_saved">Anhang konnte nicht gespeichert werden.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"an "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">an <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">Κοιν:</string>
   <string name="message_view_bcc_label">Κρυφή κοιν:</string>
   <string name="message_view_status_attachment_not_saved">Αδυναμία αποθήκευσης συνημμένου.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">σε</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">σε <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -16,7 +16,7 @@
   <!--Shown in place of the subject when a message has no subject. Showing this in parentheses is customary.-->
   <!--Title of an error notification that is displayed when creating a notification for a new message has failed-->
   <!--Body of an error notification that is displayed when creating a notification for a new message has failed-->
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -179,7 +179,7 @@
   <string name="message_view_cc_label">Kopio:</string>
   <string name="message_view_bcc_label">Kaŝkopio:</string>
   <string name="message_view_status_attachment_not_saved">Ne povis konservi kunsendaĵon.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -192,8 +192,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Cco:</string>
   <string name="message_view_status_attachment_not_saved">No se puede guardar el adjunto.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"para "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">para <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">Koopia:</string>
   <string name="message_view_bcc_label">Pimekoopia:</string>
   <string name="message_view_status_attachment_not_saved">Manuse salvestamine ebaõnnestus</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"saajaks "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">saajaks <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Ezin izan da eranskina gorde.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"honi: "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">honi: <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">رونوشت به:</string>
   <string name="message_view_bcc_label">مخفیانه به:</string>
   <string name="message_view_status_attachment_not_saved">نمی‌توان پیوست را ذخیره کرد.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">به </string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">به <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">Kopio:</string>
   <string name="message_view_bcc_label">Piilokopio:</string>
   <string name="message_view_status_attachment_not_saved">Liitteen tallentaminen epäonnistui.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"vastaanottaja "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">vastaanottaja <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -194,8 +194,8 @@
   <string name="message_view_cc_label">Cc :</string>
   <string name="message_view_bcc_label">Cci :</string>
   <string name="message_view_status_attachment_not_saved">Impossible d’enregistrer le fichier joint.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"à "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">à <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fy/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Kin bylage net bewarje.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"oan "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">oan <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -174,7 +174,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Cha b’ urrainn dhuinn an ceanglachan a shàbhaladh.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -183,7 +183,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Incapaz de gardar o anexo.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -163,7 +163,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Nije moguće spremiti privitak.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">Másolat:</string>
   <string name="message_view_bcc_label">Titkos másolat:</string>
   <string name="message_view_status_attachment_not_saved">Nem lehet elmenteni a mellékletet.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">-&gt;</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">-&gt; <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -172,7 +172,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Tidak dapat menyimpan lampiran.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">Afrit:</string>
   <string name="message_view_bcc_label">Falið afrit:</string>
   <string name="message_view_status_attachment_not_saved">Tókst ekki að vista viðhengi</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"til "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">til <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -193,8 +193,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Ccn:</string>
   <string name="message_view_status_attachment_not_saved">Impossibile salvare l\'allegato.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"a "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">a <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/app/ui/legacy/src/main/res/values-iw/strings.xml
@@ -177,7 +177,7 @@
   <string name="remove_attachment_action">מחק קובץ מצורף</string>
   <string name="message_to_label">ל:</string>
   <string name="message_view_cc_label">עותק:</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -188,7 +188,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">添付ファイルを保存できません。</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ko/strings.xml
@@ -174,7 +174,7 @@
   <string name="message_view_cc_label">참조:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">첨부파일을 저장할 수 없음</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -194,8 +194,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Nepavyko išsaugoti priedo.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"kam "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">kam <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -193,8 +193,8 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Neredzamais:</string>
   <string name="message_view_status_attachment_not_saved">Nevar saglabāt pielikumu.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"kam "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">kam <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -184,7 +184,7 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">അറ്റാച്ചുമെന്റ് സേവ് ചെയ്യാനായില്ല.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -169,7 +169,7 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   <string name="message_view_cc_label">Kopi:</string>
   <string name="message_view_bcc_label">Blindkopi:</string>
   <string name="message_view_status_attachment_not_saved">Klarte ikke lagre vedlegg</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -190,8 +190,8 @@
   <string name="message_view_cc_label">CC:</string>
   <string name="message_view_bcc_label">BCC:</string>
   <string name="message_view_status_attachment_not_saved">Kan bijlage niet opslaan.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"aan "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">aan <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -195,8 +195,8 @@ Wysłane z urządzenia Android za pomocą K-9 Mail. Proszę wybaczyć moją zwi�
   <string name="message_view_cc_label">DW:</string>
   <string name="message_view_bcc_label">UDW:</string>
   <string name="message_view_status_attachment_not_saved">Nie można zapisać załącznika.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"do "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">do <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -192,8 +192,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Cco:</string>
   <string name="message_view_status_attachment_not_saved">Não foi possível salvar o anexo.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"para "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">para <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -193,8 +193,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Não foi possível guardar o anexo</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"para "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">para <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -193,8 +193,8 @@ cel mult încă <xliff:g id="messages_to_load">%d</xliff:g></string>
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">Nu se poate salva atașamentul.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"la "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">la <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -194,8 +194,8 @@
   <string name="message_view_cc_label">Копия:</string>
   <string name="message_view_bcc_label">Скрытая копия:</string>
   <string name="message_view_status_attachment_not_saved">Не получается сохранить вложение.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"для "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">для <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -174,7 +174,7 @@
   <string name="message_view_cc_label">Kópia:</string>
   <string name="message_view_bcc_label">Skrytá kópia (Bcc):</string>
   <string name="message_view_status_attachment_not_saved">Prílohu sa nepodarilo uložiť.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -194,8 +194,8 @@ dodatnih <xliff:g id="messages_to_load">%d</xliff:g> sporočil</string>
   <string name="message_view_cc_label">Kp:</string>
   <string name="message_view_bcc_label">Skp:</string>
   <string name="message_view_status_attachment_not_saved">Priloge ni mogoče shraniti.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"za "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">za <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">Cc:</string>
   <string name="message_view_bcc_label">Bcc:</string>
   <string name="message_view_status_attachment_not_saved">S\’arrihet të ruhet bashkëngjitje</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"për "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">për <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -173,7 +173,7 @@
   <string name="message_view_cc_label">Коп:</string>
   <string name="message_view_bcc_label">СКоп:</string>
   <string name="message_view_status_attachment_not_saved">Не могу да сачувам прилог.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -191,8 +191,8 @@
   <string name="message_view_cc_label">Kopia:</string>
   <string name="message_view_bcc_label">Blindkopia:</string>
   <string name="message_view_status_attachment_not_saved">Det går inte att spara bilaga.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"till "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">till <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -188,7 +188,7 @@
   <string name="message_view_cc_label">Bilgi:</string>
   <string name="message_view_bcc_label">Gizli Kopya:</string>
   <string name="message_view_status_attachment_not_saved">Eklenti kaydedilemedi</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
+  <!--Used to display the recipient list in the message view screen.-->
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
   <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -195,8 +195,8 @@
   <string name="message_view_cc_label">Копія:</string>
   <string name="message_view_bcc_label">Прихована копія:</string>
   <string name="message_view_status_attachment_not_saved">Не вдалося зберегти вкладення.</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">"для "</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">для <xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -188,8 +188,8 @@
   <string name="message_view_cc_label">抄送：</string>
   <string name="message_view_bcc_label">密送:</string>
   <string name="message_view_status_attachment_not_saved">无法保存附件。</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">到</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">到<xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -188,8 +188,8 @@
   <string name="message_view_cc_label">副本：</string>
   <string name="message_view_bcc_label">密件副本：</string>
   <string name="message_view_status_attachment_not_saved">無法存檔附件。</string>
-  <!--Displayed in the message view screen in front of the recipient list. For most languages this should end with a space.-->
-  <string name="message_view_recipient_prefix">至</string>
+  <!--Used to display the recipient list in the message view screen.-->
+  <string name="message_view_recipients_format">至<xliff:g id="recipients">%s</xliff:g></string>
   <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
   <string name="message_view_additional_recipient_prefix">+</string>
   <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -229,8 +229,8 @@
     <string name="message_view_bcc_label">Bcc:</string>
     <string name="message_view_status_attachment_not_saved">Unable to save attachment.</string>
 
-    <!-- Displayed in the message view screen in front of the recipient list. For most languages this should end with a space. -->
-    <string name="message_view_recipient_prefix">"to "</string>
+    <!-- Used to display the recipient list in the message view screen. -->
+    <string name="message_view_recipients_format">to <xliff:g id="recipients">%s</xliff:g></string>
     <!-- Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed). -->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!-- Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me". -->

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
@@ -24,7 +24,7 @@ class RecipientLayoutCreatorTest : RobolectricTest() {
     private val recipientLayoutCreator = RecipientLayoutCreator(
         textMeasure = textMeasure,
         maxNumberOfRecipientNames = 5,
-        recipientsPrefix = "to ",
+        recipientsFormat = "to %s",
         additionalRecipientSpacing = 1,
         additionalRecipientsPrefix = "+",
     )


### PR DESCRIPTION
Use a format string instead of a string that needs to end in a space for most languages. A trailing space is something that is easy to miss in most translation UIs.

Depends on #7204