### PR TITLE
Fix F-Droid build

### DIFF
--- a/app/k9mail/build.gradle.kts
+++ b/app/k9mail/build.gradle.kts
@@ -84,7 +84,9 @@ android {
     buildTypes {
         release {
             signingConfigs.findByName("release")?.let { releaseSigningConfig ->
-                signingConfig = releaseSigningConfig
+                // The comment in the line below is necessary to prevent F-Droid's build tools from breaking our Gradle
+                // config when stripping the signing config.
+                signingConfig = releaseSigningConfig // F-Droid hack
             }
 
             isMinifyEnabled = true


### PR DESCRIPTION
fdroidserver contains [code to strip signing config blocks](https://gitlab.com/fdroid/fdroidserver/-/blob/047819d34fbf17a1c57d42d35afd98725edb744a/fdroidserver/common.py#L2890) from `build.gradle[.kts]` files. That code also removed the assignment inside the `let` lambda. This in turn lead to Gradle failing the compilation of the Kotlin script because the argument `releaseSigningConfig` was unused 😞

Adding the "F-Droid hack" comment in this line prevents [fdroidserver's regular expression](https://gitlab.com/fdroid/fdroidserver/-/blob/047819d34fbf17a1c57d42d35afd98725edb744a/fdroidserver/common.py#L2884) from matching and removing this line.