### PR TITLE
Fix signingConfig hack

### DIFF
--- a/app/k9mail/build.gradle.kts
+++ b/app/k9mail/build.gradle.kts
@@ -83,11 +83,7 @@ android {
 
     buildTypes {
         release {
-            signingConfigs.findByName("release")?.let { releaseSigningConfig ->
-                // The comment in the line below is necessary to prevent F-Droid's build tools from breaking our Gradle
-                // config when stripping the signing config.
-                signingConfig = releaseSigningConfig // F-Droid hack
-            }
+            signingConfig = signingConfigs.findByName("release")
 
             isMinifyEnabled = true
             proguardFiles(


### PR DESCRIPTION
This removes the hack for F-Droid and replaces it by a simplyfied assignment. This should work as the receiving `signingConfig` is nullable and `signingConfigs.findByName("release")` is either null or returns the release config.
Having a one liner allows F-Droid to strip the `signingConfig` line without tripping detekt or spotless afterwards.

From what I discovered: The troublesome code tried to fix another issue that arrised due to the use of `signingConfigs.getByName("release")`, which throws an `UnknownDomainObjectException`. But with `findByName("release")` no issue.
