### PR TITLE
Change Gradle config to accommodate for latest changes

### DIFF
--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        includeBuild("build-plugin")
         gradlePluginPortal()
         google()
         mavenCentral()
@@ -7,7 +8,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     repositories {
         google()
         mavenCentral()
@@ -18,8 +19,6 @@ dependencyResolutionManagement {
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 rootProject.name = "k-9"
-
-includeBuild("build-plugin")
 
 include(
     ":app-feature-preview",


### PR DESCRIPTION
Minor modification to comply with the latest Gradle version. The key change involves relocating the `build-plugin` to `pluginManagement` within `settings.gradle.kts`. This resolves the issue where the `build-plugin` should exclusively be added to the Gradle plugins and not leak into the whole project.