### PR TITLE
Add interaction mode to server settings

### DIFF
--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/InteractionMode.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/InteractionMode.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.account.common.domain.entity
+
+/**
+ * Enum representing the mode a user is interacting with an account or setting.
+ */
+enum class InteractionMode {
+    Create,
+    Edit,
+}

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
@@ -5,35 +5,45 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonIcon
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
+import app.k9mail.core.ui.compose.theme.Icons
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import app.k9mail.feature.account.common.R
 
 /**
- * Top app bar for the account screens.
+ * Top app bar for the account screens with a back button.
  */
 @Composable
-fun AccountTopAppBar(
+fun AccountTopAppBarWithBackButton(
     title: String,
     modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
 ) {
     TopAppBar(
         title = title,
         modifier = modifier,
         subtitle = stringResource(id = R.string.account_common_title),
         titleContentPadding = PaddingValues(
-            start = MainTheme.spacings.double,
+            start = MainTheme.spacings.default,
         ),
+        navigationIcon = {
+            ButtonIcon(
+                onClick = onBackClicked,
+                imageVector = Icons.Outlined.arrowBack,
+            )
+        },
     )
 }
 
 @DevicePreviews
 @Composable
-internal fun AccountTopAppBarPreview() {
+internal fun AccountTopAppBarWithBackButtonPreview() {
     PreviewWithThemes {
-        AccountTopAppBar(
+        AccountTopAppBarWithBackButton(
             title = "Title",
+            onBackClicked = {},
         )
     }
 }

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WithInteractionMode.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WithInteractionMode.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.account.common.ui
+
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+
+/**
+ * Interface for screens that can be used in different interaction modes.
+ */
+interface WithInteractionMode {
+    val mode: InteractionMode
+}

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/EditIncomingServerSettingsViewModel.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/EditIncomingServerSettingsViewModel.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.edit.ui
 
 import androidx.lifecycle.viewModelScope
 import app.k9mail.feature.account.common.domain.AccountDomainContract
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.edit.domain.AccountEditDomainContract
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsViewModel
@@ -15,6 +16,7 @@ class EditIncomingServerSettingsViewModel(
     accountStateRepository: AccountDomainContract.AccountStateRepository,
     initialState: IncomingServerSettingsContract.State = IncomingServerSettingsContract.State(),
 ) : IncomingServerSettingsViewModel(
+    mode = InteractionMode.Edit,
     validator = validator,
     accountStateRepository = accountStateRepository,
     initialState = initialState,

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/EditOutgoingServerSettingsViewModel.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/EditOutgoingServerSettingsViewModel.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.edit.ui
 
 import androidx.lifecycle.viewModelScope
 import app.k9mail.feature.account.common.domain.AccountDomainContract
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.edit.domain.AccountEditDomainContract
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsViewModel
@@ -15,6 +16,7 @@ class EditOutgoingServerSettingsViewModel(
     accountStateRepository: AccountDomainContract.AccountStateRepository,
     initialState: OutgoingServerSettingsContract.State = OutgoingServerSettingsContract.State(),
 ) : OutgoingServerSettingsViewModel(
+    mode = InteractionMode.Edit,
     validator = validator,
     accountStateRepository = accountStateRepository,
     initialState = initialState,

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
@@ -58,6 +59,7 @@ class AccountEditModuleKtTest : KoinTest {
                 ServerCertificateErrorContract.State::class,
                 IncomingServerSettingsContract.State::class,
                 OutgoingServerSettingsContract.State::class,
+                InteractionMode::class,
             ),
         )
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ServerSettingsModule.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ServerSettingsModule.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.server.settings
 
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsValidator
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsViewModel
@@ -16,6 +17,7 @@ val featureAccountServerSettingsModule: Module = module {
 
     viewModel {
         IncomingServerSettingsViewModel(
+            mode = InteractionMode.Create,
             validator = get(),
             accountStateRepository = get(),
         )
@@ -23,6 +25,7 @@ val featureAccountServerSettingsModule: Module = module {
 
     viewModel {
         OutgoingServerSettingsViewModel(
+            mode = InteractionMode.Create,
             validator = get(),
             accountStateRepository = get(),
         )

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -2,39 +2,25 @@ package app.k9mail.feature.account.server.settings.ui.incoming
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
-import app.k9mail.core.ui.compose.designsystem.molecule.input.CheckboxInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.NumberInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
-import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
-import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.common.ui.item.defaultItemPadding
-import app.k9mail.feature.account.server.settings.R
-import app.k9mail.feature.account.server.settings.ui.common.ClientCertificateInput
-import app.k9mail.feature.account.server.settings.ui.common.mapper.toResourceString
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
+import app.k9mail.feature.account.server.settings.ui.incoming.content.incomingFormItems
 
-@Suppress("LongMethod")
 @Composable
 internal fun IncomingServerSettingsContent(
     state: State,
@@ -58,139 +44,11 @@ internal fun IncomingServerSettingsContent(
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
-            item {
-                Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
-            }
-
-            item {
-                SelectInput(
-                    options = IncomingProtocolType.all(),
-                    selectedOption = state.protocolType,
-                    onOptionChange = { onEvent(Event.ProtocolTypeChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_protocol_type_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                TextInput(
-                    text = state.server.value,
-                    errorMessage = state.server.error?.toResourceString(resources),
-                    onTextChange = { onEvent(Event.ServerChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_server_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                SelectInput(
-                    options = ConnectionSecurity.all(),
-                    optionToStringTransformation = { it.toResourceString(resources) },
-                    selectedOption = state.security,
-                    onOptionChange = { onEvent(Event.SecurityChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_security_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                NumberInput(
-                    value = state.port.value,
-                    errorMessage = state.port.error?.toResourceString(resources),
-                    onValueChange = { onEvent(Event.PortChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_port_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                SelectInput(
-                    options = state.allowedAuthenticationTypes,
-                    optionToStringTransformation = { it.toResourceString(resources) },
-                    selectedOption = state.authenticationType,
-                    onOptionChange = { onEvent(Event.AuthenticationTypeChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_authentication_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                TextInput(
-                    text = state.username.value,
-                    errorMessage = state.username.error?.toResourceString(resources),
-                    onTextChange = { onEvent(Event.UsernameChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_username_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            if (state.isPasswordFieldVisible) {
-                item {
-                    PasswordInput(
-                        password = state.password.value,
-                        errorMessage = state.password.error?.toResourceString(resources),
-                        onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-            }
-
-            item {
-                ClientCertificateInput(
-                    alias = state.clientCertificateAlias,
-                    onValueChange = { onEvent(Event.ClientCertificateChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_client_certificate_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            if (state.protocolType == IncomingProtocolType.IMAP) {
-                item {
-                    CheckboxInput(
-                        text = stringResource(id = R.string.account_server_settings_incoming_imap_namespace_label),
-                        checked = state.imapAutodetectNamespaceEnabled,
-                        onCheckedChange = { onEvent(Event.ImapAutoDetectNamespaceChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-
-                item {
-                    if (state.imapAutodetectNamespaceEnabled) {
-                        TextInput(
-                            onTextChange = {},
-                            label = stringResource(id = R.string.account_server_settings_incoming_imap_prefix_label),
-                            contentPadding = defaultItemPadding(),
-                            isEnabled = false,
-                        )
-                    } else {
-                        TextInput(
-                            text = state.imapPrefix.value,
-                            errorMessage = state.imapPrefix.error?.toResourceString(resources),
-                            onTextChange = { onEvent(Event.ImapPrefixChanged(it)) },
-                            label = stringResource(id = R.string.account_server_settings_incoming_imap_prefix_label),
-                            contentPadding = defaultItemPadding(),
-                        )
-                    }
-                }
-
-                item {
-                    CheckboxInput(
-                        text = stringResource(id = R.string.account_server_settings_incoming_imap_compression_label),
-                        checked = state.imapUseCompression,
-                        onCheckedChange = { onEvent(Event.ImapUseCompressionChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-
-                item {
-                    CheckboxInput(
-                        text = stringResource(R.string.account_server_settings_incoming_imap_send_client_id_label),
-                        checked = state.imapSendClientId,
-                        onCheckedChange = { onEvent(Event.ImapSendClientIdChanged(it)) },
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-            }
+            incomingFormItems(
+                state = state,
+                onEvent = onEvent,
+                resources = resources,
+            )
         }
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -17,12 +17,14 @@ import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import app.k9mail.feature.account.server.settings.ui.incoming.content.incomingFormItems
 
 @Composable
 internal fun IncomingServerSettingsContent(
+    mode: InteractionMode,
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
@@ -45,6 +47,7 @@ internal fun IncomingServerSettingsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             incomingFormItems(
+                mode = mode,
                 state = state,
                 onEvent = onEvent,
                 resources = resources,
@@ -58,6 +61,7 @@ internal fun IncomingServerSettingsContent(
 internal fun IncomingServerSettingsContentK9Preview() {
     K9Theme {
         IncomingServerSettingsContent(
+            mode = InteractionMode.Create,
             onEvent = { },
             state = State(),
             contentPadding = PaddingValues(),
@@ -70,6 +74,7 @@ internal fun IncomingServerSettingsContentK9Preview() {
 internal fun IncomingServerSettingsContentThunderbirdPreview() {
     ThunderbirdTheme {
         IncomingServerSettingsContent(
+            mode = InteractionMode.Create,
             onEvent = { },
             state = State(),
             contentPadding = PaddingValues(),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContract.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContract.kt
@@ -8,10 +8,11 @@ import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
 import app.k9mail.feature.account.common.domain.entity.toDefaultPort
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.common.ui.WithInteractionMode
 
 interface IncomingServerSettingsContract {
 
-    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>, WithInteractionMode
 
     data class State(
         val protocolType: IncomingProtocolType = IncomingProtocolType.DEFAULT,

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
@@ -10,6 +10,7 @@ import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.AccountTopAppBar
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
 import app.k9mail.feature.account.common.ui.preview.PreviewAccountStateRepository
@@ -70,6 +71,7 @@ internal fun IncomingServerSettingsScreenK9Preview() {
             onNext = {},
             onBack = {},
             viewModel = IncomingServerSettingsViewModel(
+                mode = InteractionMode.Create,
                 validator = IncomingServerSettingsValidator(),
                 accountStateRepository = PreviewAccountStateRepository(),
             ),
@@ -85,6 +87,7 @@ internal fun IncomingServerSettingsScreenThunderbirdPreview() {
             onNext = {},
             onBack = {},
             viewModel = IncomingServerSettingsViewModel(
+                mode = InteractionMode.Create,
                 validator = IncomingServerSettingsValidator(),
                 accountStateRepository = PreviewAccountStateRepository(),
             ),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
@@ -12,6 +12,7 @@ import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.AccountTopAppBar
+import app.k9mail.feature.account.common.ui.AccountTopAppBarWithBackButton
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
 import app.k9mail.feature.account.common.ui.preview.PreviewAccountStateRepository
 import app.k9mail.feature.account.server.settings.R
@@ -43,9 +44,16 @@ fun IncomingServerSettingsScreen(
 
     Scaffold(
         topBar = {
-            AccountTopAppBar(
-                title = stringResource(id = R.string.account_server_settings_incoming_top_bar_title),
-            )
+            if (viewModel.mode == InteractionMode.Edit) {
+                AccountTopAppBarWithBackButton(
+                    title = stringResource(id = R.string.account_server_settings_incoming_top_bar_title),
+                    onBackClicked = { dispatch(Event.OnBackClicked) },
+                )
+            } else {
+                AccountTopAppBar(
+                    title = stringResource(id = R.string.account_server_settings_incoming_top_bar_title),
+                )
+            }
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
@@ -64,6 +64,7 @@ fun IncomingServerSettingsScreen(
         modifier = modifier,
     ) { innerPadding ->
         IncomingServerSettingsContent(
+            mode = viewModel.mode,
             onEvent = { dispatch(it) },
             state = state.value,
             contentPadding = innerPadding,

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
@@ -5,6 +5,7 @@ import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.AccountDomainContract
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.toDefaultPort
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
@@ -13,6 +14,7 @@ import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSett
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.ViewModel
 
 open class IncomingServerSettingsViewModel(
+    override val mode: InteractionMode,
     private val validator: Validator,
     private val accountStateRepository: AccountDomainContract.AccountStateRepository,
     initialState: State = State(),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/ImapFormItems.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/ImapFormItems.kt
@@ -1,0 +1,64 @@
+package app.k9mail.feature.account.server.settings.ui.incoming.content
+
+import android.content.res.Resources
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.molecule.input.CheckboxInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
+import app.k9mail.feature.account.common.ui.item.defaultItemPadding
+import app.k9mail.feature.account.server.settings.R
+import app.k9mail.feature.account.server.settings.ui.common.mapper.toResourceString
+import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
+import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
+
+internal fun LazyListScope.imapFormItems(
+    state: State,
+    onEvent: (Event) -> Unit,
+    resources: Resources,
+) {
+    item {
+        CheckboxInput(
+            text = stringResource(id = R.string.account_server_settings_incoming_imap_namespace_label),
+            checked = state.imapAutodetectNamespaceEnabled,
+            onCheckedChange = { onEvent(Event.ImapAutoDetectNamespaceChanged(it)) },
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        if (state.imapAutodetectNamespaceEnabled) {
+            TextInput(
+                onTextChange = {},
+                label = stringResource(id = R.string.account_server_settings_incoming_imap_prefix_label),
+                contentPadding = defaultItemPadding(),
+                isEnabled = false,
+            )
+        } else {
+            TextInput(
+                text = state.imapPrefix.value,
+                errorMessage = state.imapPrefix.error?.toResourceString(resources),
+                onTextChange = { onEvent(Event.ImapPrefixChanged(it)) },
+                label = stringResource(id = R.string.account_server_settings_incoming_imap_prefix_label),
+                contentPadding = defaultItemPadding(),
+            )
+        }
+    }
+
+    item {
+        CheckboxInput(
+            text = stringResource(id = R.string.account_server_settings_incoming_imap_compression_label),
+            checked = state.imapUseCompression,
+            onCheckedChange = { onEvent(Event.ImapUseCompressionChanged(it)) },
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        CheckboxInput(
+            text = stringResource(R.string.account_server_settings_incoming_imap_send_client_id_label),
+            checked = state.imapSendClientId,
+            onCheckedChange = { onEvent(Event.ImapSendClientIdChanged(it)) },
+            contentPadding = defaultItemPadding(),
+        )
+    }
+}

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/IncomingFormItems.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/IncomingFormItems.kt
@@ -1,0 +1,120 @@
+package app.k9mail.feature.account.server.settings.ui.incoming.content
+
+import android.content.res.Resources
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.molecule.input.NumberInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
+import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
+import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
+import app.k9mail.feature.account.common.ui.item.defaultItemPadding
+import app.k9mail.feature.account.server.settings.R
+import app.k9mail.feature.account.server.settings.ui.common.ClientCertificateInput
+import app.k9mail.feature.account.server.settings.ui.common.mapper.toResourceString
+import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
+import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
+import app.k9mail.feature.account.server.settings.ui.incoming.allowedAuthenticationTypes
+import app.k9mail.feature.account.server.settings.ui.incoming.isPasswordFieldVisible
+
+@Suppress("LongMethod")
+internal fun LazyListScope.incomingFormItems(
+    state: State,
+    onEvent: (Event) -> Unit,
+    resources: Resources,
+) {
+    item {
+        Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
+    }
+
+    item {
+        SelectInput(
+            options = IncomingProtocolType.all(),
+            selectedOption = state.protocolType,
+            onOptionChange = { onEvent(Event.ProtocolTypeChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_protocol_type_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        TextInput(
+            text = state.server.value,
+            errorMessage = state.server.error?.toResourceString(resources),
+            onTextChange = { onEvent(Event.ServerChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_server_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        SelectInput(
+            options = ConnectionSecurity.all(),
+            optionToStringTransformation = { it.toResourceString(resources) },
+            selectedOption = state.security,
+            onOptionChange = { onEvent(Event.SecurityChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_security_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        NumberInput(
+            value = state.port.value,
+            errorMessage = state.port.error?.toResourceString(resources),
+            onValueChange = { onEvent(Event.PortChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_port_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        SelectInput(
+            options = state.allowedAuthenticationTypes,
+            optionToStringTransformation = { it.toResourceString(resources) },
+            selectedOption = state.authenticationType,
+            onOptionChange = { onEvent(Event.AuthenticationTypeChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_authentication_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        TextInput(
+            text = state.username.value,
+            errorMessage = state.username.error?.toResourceString(resources),
+            onTextChange = { onEvent(Event.UsernameChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_username_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    if (state.isPasswordFieldVisible) {
+        item {
+            PasswordInput(
+                password = state.password.value,
+                errorMessage = state.password.error?.toResourceString(resources),
+                onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
+                contentPadding = defaultItemPadding(),
+            )
+        }
+    }
+
+    item {
+        ClientCertificateInput(
+            alias = state.clientCertificateAlias,
+            onValueChange = { onEvent(Event.ClientCertificateChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_client_certificate_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    if (state.protocolType == IncomingProtocolType.IMAP) {
+        imapFormItems(state, onEvent, resources)
+    }
+}

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/IncomingFormItems.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/content/IncomingFormItems.kt
@@ -13,6 +13,7 @@ import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.item.defaultItemPadding
 import app.k9mail.feature.account.server.settings.R
 import app.k9mail.feature.account.server.settings.ui.common.ClientCertificateInput
@@ -24,6 +25,7 @@ import app.k9mail.feature.account.server.settings.ui.incoming.isPasswordFieldVis
 
 @Suppress("LongMethod")
 internal fun LazyListScope.incomingFormItems(
+    mode: InteractionMode,
     state: State,
     onEvent: (Event) -> Unit,
     resources: Resources,
@@ -32,14 +34,16 @@ internal fun LazyListScope.incomingFormItems(
         Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
     }
 
-    item {
-        SelectInput(
-            options = IncomingProtocolType.all(),
-            selectedOption = state.protocolType,
-            onOptionChange = { onEvent(Event.ProtocolTypeChanged(it)) },
-            label = stringResource(id = R.string.account_server_settings_protocol_type_label),
-            contentPadding = defaultItemPadding(),
-        )
+    if (mode == InteractionMode.Create) {
+        item {
+            SelectInput(
+                options = IncomingProtocolType.all(),
+                selectedOption = state.protocolType,
+                onOptionChange = { onEvent(Event.ProtocolTypeChanged(it)) },
+                label = stringResource(id = R.string.account_server_settings_protocol_type_label),
+                contentPadding = defaultItemPadding(),
+            )
+        }
     }
 
     item {

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/fake/FakeIncomingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/fake/FakeIncomingServerSettingsViewModel.kt
@@ -1,12 +1,14 @@
 package app.k9mail.feature.account.server.settings.ui.incoming.fake
 
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.ViewModel
 
 class FakeIncomingServerSettingsViewModel(
+    override val mode: InteractionMode = InteractionMode.Create,
     initialState: State = State(),
 ) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
@@ -2,38 +2,25 @@ package app.k9mail.feature.account.server.settings.ui.outgoing
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.DevicePreviews
-import app.k9mail.core.ui.compose.designsystem.molecule.input.NumberInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
-import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
-import app.k9mail.feature.account.common.domain.entity.AuthenticationType
-import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
-import app.k9mail.feature.account.common.ui.item.defaultItemPadding
-import app.k9mail.feature.account.server.settings.R
-import app.k9mail.feature.account.server.settings.ui.common.ClientCertificateInput
-import app.k9mail.feature.account.server.settings.ui.common.mapper.toResourceString
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
+import app.k9mail.feature.account.server.settings.ui.outgoing.content.outgoingFormItems
 
-@Suppress("LongMethod")
 @Composable
 internal fun OutgoingServerSettingsContent(
     state: State,
@@ -57,87 +44,11 @@ internal fun OutgoingServerSettingsContent(
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
-            item {
-                Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
-            }
-
-            item {
-                TextInput(
-                    text = state.server.value,
-                    errorMessage = state.server.error?.toResourceString(resources),
-                    onTextChange = { onEvent(Event.ServerChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_server_label),
-                    isRequired = true,
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                SelectInput(
-                    options = ConnectionSecurity.all(),
-                    optionToStringTransformation = { it.toResourceString(resources) },
-                    selectedOption = state.security,
-                    onOptionChange = { onEvent(Event.SecurityChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_security_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                NumberInput(
-                    value = state.port.value,
-                    errorMessage = state.port.error?.toResourceString(resources),
-                    onValueChange = { onEvent(Event.PortChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_port_label),
-                    isRequired = true,
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            item {
-                SelectInput(
-                    options = AuthenticationType.outgoing(),
-                    optionToStringTransformation = { it.toResourceString(resources) },
-                    selectedOption = state.authenticationType,
-                    onOptionChange = { onEvent(Event.AuthenticationTypeChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_authentication_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
-
-            if (state.isUsernameFieldVisible) {
-                item {
-                    TextInput(
-                        text = state.username.value,
-                        errorMessage = state.username.error?.toResourceString(resources),
-                        onTextChange = { onEvent(Event.UsernameChanged(it)) },
-                        label = stringResource(id = R.string.account_server_settings_username_label),
-                        isRequired = true,
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-            }
-
-            if (state.isPasswordFieldVisible) {
-                item {
-                    PasswordInput(
-                        password = state.password.value,
-                        errorMessage = state.password.error?.toResourceString(resources),
-                        onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
-                        isRequired = true,
-                        contentPadding = defaultItemPadding(),
-                    )
-                }
-            }
-
-            item {
-                ClientCertificateInput(
-                    alias = state.clientCertificateAlias,
-                    onValueChange = { onEvent(Event.ClientCertificateChanged(it)) },
-                    label = stringResource(id = R.string.account_server_settings_client_certificate_label),
-                    contentPadding = defaultItemPadding(),
-                )
-            }
+            outgoingFormItems(
+                state = state,
+                onEvent = onEvent,
+                resources = resources,
+            )
         }
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContract.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContract.kt
@@ -7,10 +7,11 @@ import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.common.ui.WithInteractionMode
 
 interface OutgoingServerSettingsContract {
 
-    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>, WithInteractionMode
 
     data class State(
         val server: StringInputField = StringInputField(),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
@@ -12,6 +12,7 @@ import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.AccountTopAppBar
+import app.k9mail.feature.account.common.ui.AccountTopAppBarWithBackButton
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
 import app.k9mail.feature.account.common.ui.preview.PreviewAccountStateRepository
 import app.k9mail.feature.account.server.settings.R
@@ -43,9 +44,16 @@ fun OutgoingServerSettingsScreen(
 
     Scaffold(
         topBar = {
-            AccountTopAppBar(
-                title = stringResource(id = R.string.account_server_settings_outgoing_top_bar_title),
-            )
+            if (viewModel.mode == InteractionMode.Edit) {
+                AccountTopAppBarWithBackButton(
+                    title = stringResource(id = R.string.account_server_settings_outgoing_top_bar_title),
+                    onBackClicked = { dispatch(Event.OnBackClicked) },
+                )
+            } else {
+                AccountTopAppBar(
+                    title = stringResource(id = R.string.account_server_settings_outgoing_top_bar_title),
+                )
+            }
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
@@ -10,6 +10,7 @@ import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.AccountTopAppBar
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
 import app.k9mail.feature.account.common.ui.preview.PreviewAccountStateRepository
@@ -70,6 +71,7 @@ internal fun OutgoingServerSettingsScreenK9Preview() {
             onNext = {},
             onBack = {},
             viewModel = OutgoingServerSettingsViewModel(
+                mode = InteractionMode.Create,
                 validator = OutgoingServerSettingsValidator(),
                 accountStateRepository = PreviewAccountStateRepository(),
             ),
@@ -85,6 +87,7 @@ internal fun OutgoingServerSettingsScreenThunderbirdPreview() {
             onNext = {},
             onBack = {},
             viewModel = OutgoingServerSettingsViewModel(
+                mode = InteractionMode.Create,
                 validator = OutgoingServerSettingsValidator(),
                 accountStateRepository = PreviewAccountStateRepository(),
             ),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
@@ -4,6 +4,7 @@ import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.AccountDomainContract
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
@@ -12,6 +13,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.ViewModel
 
 open class OutgoingServerSettingsViewModel(
+    override val mode: InteractionMode,
     private val validator: Validator,
     private val accountStateRepository: AccountDomainContract.AccountStateRepository,
     initialState: State = State(),

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/content/OutgoingFormItems.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/content/OutgoingFormItems.kt
@@ -1,0 +1,112 @@
+package app.k9mail.feature.account.server.settings.ui.outgoing.content
+
+import android.content.res.Resources
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.molecule.input.NumberInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
+import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.feature.account.common.domain.entity.AuthenticationType
+import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
+import app.k9mail.feature.account.common.ui.item.defaultItemPadding
+import app.k9mail.feature.account.server.settings.R
+import app.k9mail.feature.account.server.settings.ui.common.ClientCertificateInput
+import app.k9mail.feature.account.server.settings.ui.common.mapper.toResourceString
+import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
+import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
+import app.k9mail.feature.account.server.settings.ui.outgoing.isPasswordFieldVisible
+import app.k9mail.feature.account.server.settings.ui.outgoing.isUsernameFieldVisible
+
+@Suppress("LongMethod")
+internal fun LazyListScope.outgoingFormItems(
+    state: State,
+    onEvent: (Event) -> Unit,
+    resources: Resources,
+) {
+    item {
+        Spacer(modifier = Modifier.requiredHeight(MainTheme.sizes.smaller))
+    }
+
+    item {
+        TextInput(
+            text = state.server.value,
+            errorMessage = state.server.error?.toResourceString(resources),
+            onTextChange = { onEvent(Event.ServerChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_server_label),
+            isRequired = true,
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        SelectInput(
+            options = ConnectionSecurity.all(),
+            optionToStringTransformation = { it.toResourceString(resources) },
+            selectedOption = state.security,
+            onOptionChange = { onEvent(Event.SecurityChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_security_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        NumberInput(
+            value = state.port.value,
+            errorMessage = state.port.error?.toResourceString(resources),
+            onValueChange = { onEvent(Event.PortChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_port_label),
+            isRequired = true,
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    item {
+        SelectInput(
+            options = AuthenticationType.outgoing(),
+            optionToStringTransformation = { it.toResourceString(resources) },
+            selectedOption = state.authenticationType,
+            onOptionChange = { onEvent(Event.AuthenticationTypeChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_authentication_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+
+    if (state.isUsernameFieldVisible) {
+        item {
+            TextInput(
+                text = state.username.value,
+                errorMessage = state.username.error?.toResourceString(resources),
+                onTextChange = { onEvent(Event.UsernameChanged(it)) },
+                label = stringResource(id = R.string.account_server_settings_username_label),
+                isRequired = true,
+                contentPadding = defaultItemPadding(),
+            )
+        }
+    }
+
+    if (state.isPasswordFieldVisible) {
+        item {
+            PasswordInput(
+                password = state.password.value,
+                errorMessage = state.password.error?.toResourceString(resources),
+                onPasswordChange = { onEvent(Event.PasswordChanged(it)) },
+                isRequired = true,
+                contentPadding = defaultItemPadding(),
+            )
+        }
+    }
+
+    item {
+        ClientCertificateInput(
+            alias = state.clientCertificateAlias,
+            onValueChange = { onEvent(Event.ClientCertificateChanged(it)) },
+            label = stringResource(id = R.string.account_server_settings_client_certificate_label),
+            contentPadding = defaultItemPadding(),
+        )
+    }
+}

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/fake/FakeOutgoingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/fake/FakeOutgoingServerSettingsViewModel.kt
@@ -1,12 +1,14 @@
 package app.k9mail.feature.account.server.settings.ui.outgoing.fake
 
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.ViewModel
 
 class FakeOutgoingServerSettingsViewModel(
+    override val mode: InteractionMode = InteractionMode.Create,
     initialState: State = State(),
 ) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenKtTest.kt
@@ -15,7 +15,7 @@ class IncomingServerSettingsScreenKtTest : ComposeTest() {
     @Test
     fun `should delegate navigation effects`() = runTest {
         val initialState = State()
-        val viewModel = FakeIncomingServerSettingsViewModel(initialState)
+        val viewModel = FakeIncomingServerSettingsViewModel(initialState = initialState)
         var onNextCounter = 0
         var onBackCounter = 0
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
@@ -12,6 +12,7 @@ import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toImapDefaultPort
 import app.k9mail.feature.account.common.domain.entity.toPop3DefaultPort
@@ -350,6 +351,7 @@ class IncomingServerSettingsViewModelTest {
     fun `should change state and not emit NavigateNext effect when OnNextClicked event received and input invalid`() =
         runTest {
             val testSubject = IncomingServerSettingsViewModel(
+                mode = InteractionMode.Create,
                 validator = FakeIncomingServerSettingsValidator(
                     serverAnswer = ValidationResult.Failure(TestError),
                 ),
@@ -398,6 +400,7 @@ class IncomingServerSettingsViewModelTest {
             validator: IncomingServerSettingsContract.Validator = FakeIncomingServerSettingsValidator(),
             repository: AccountDomainContract.AccountStateRepository = InMemoryAccountStateRepository(),
         ) = IncomingServerSettingsViewModel(
+            mode = InteractionMode.Create,
             validator = validator,
             accountStateRepository = repository,
             initialState = initialState,

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreenKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreenKtTest.kt
@@ -15,7 +15,7 @@ class OutgoingServerSettingsScreenKtTest : ComposeTest() {
     @Test
     fun `should delegate navigation effects`() = runTest {
         val initialState = State()
-        val viewModel = FakeOutgoingServerSettingsViewModel(initialState)
+        val viewModel = FakeOutgoingServerSettingsViewModel(initialState = initialState)
         var onNextCounter = 0
         var onBackCounter = 0
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import app.k9mail.feature.account.common.domain.AccountDomainContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
 import app.k9mail.feature.account.common.domain.input.NumberInputField
@@ -305,6 +306,7 @@ class OutgoingServerSettingsViewModelTest {
             validator: OutgoingServerSettingsContract.Validator = FakeOutgoingServerSettingsValidator(),
             repository: AccountDomainContract.AccountStateRepository = InMemoryAccountStateRepository(),
         ) = OutgoingServerSettingsViewModel(
+            mode = InteractionMode.Create,
             validator = validator,
             accountStateRepository = repository,
             initialState = initialState,

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
@@ -77,6 +78,7 @@ class AccountSetupModuleKtTest : KoinTest {
                 Context::class,
                 Boolean::class,
                 Class.forName("net.openid.appauth.AppAuthConfiguration").kotlin,
+                InteractionMode::class,
             ),
         )
 


### PR DESCRIPTION
This adds an `InteractionMode` to change behaviour between `Create` and `Edit` interactions.

This is used to change the top app bar and remove the protocol selection in case it is an edit.