### PR TITLE
Disable Gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+Use
 org.gradle.parallel=true
 
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 
 org.gradle.kotlin.dsl.allWarningsAsErrors=true


### PR DESCRIPTION
This disables Gradle configuration cache as Spotless doesn't support it properly.

I fails with the following message and requires user action to remove current cache in case it got stale. This happens a lot if you switch between different branches of the project.

```
Spotless JVM-local cache is stale. Regenerate the cache with
    rm -rf .gradle/configuration-cache
```