### PR TITLE
Set GroupAlertBehavior for Single (and Summary) Notifications

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationCreator.kt
@@ -25,6 +25,7 @@ internal class SingleMessageNotificationCreator(
             .setCategory(NotificationCompat.CATEGORY_EMAIL)
             .setGroup(baseNotificationData.groupKey)
             .setGroupSummary(isGroupSummary)
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
             .setSmallIcon(resourceProvider.iconNewMail)
             .setColor(baseNotificationData.color)
             .setWhen(singleNotificationData.timestamp)

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -54,6 +54,7 @@ internal class SummaryNotificationCreator(
             .setCategory(NotificationCompat.CATEGORY_EMAIL)
             .setGroup(baseNotificationData.groupKey)
             .setGroupSummary(true)
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
             .setSmallIcon(resourceProvider.iconNewMail)
             .setColor(baseNotificationData.color)
             .setWhen(notificationData.timestamp)


### PR DESCRIPTION
To fix notifications on WearOS being handled silently an explicit `GroupAlertBehaviour` had to be set.

Fixes #7271